### PR TITLE
Portlet: issues per type and job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for [ErrorProne](http://errorprone.info) in maven builds. 
 Parser now reports description with link to external documentation.
+- [JENKINS-55500](https://issues.jenkins-ci.org/browse/JENKINS-55500): Added a portlet that renders a two-dimensional 
+table of issues per type and job
 
 ### Fixed
 - [JENKINS-55514](https://issues.jenkins-ci.org/browse/JENKINS-55514): Fixed handling of severity mappings with FindBugs (rank vs. priority) 
-- [JENKINS-55513](https://issues.jenkins-ci.org/browse/JENKINS-55513) Fixed rendering of issues table: check if order column in browsers local storage is valid before applying it (report on Gitter).
+- [JENKINS-55513](https://issues.jenkins-ci.org/browse/JENKINS-55513): Fixed rendering of issues table: check if order column in browsers local storage is valid before applying it.
 - [JENKINS-55337](https://issues.jenkins-ci.org/browse/JENKINS-55337): Navigate to maven warnings in console log view
 - Maven Parser: Disabled post processing on agent since there are no source files involved.
 - Do not show empty paragraph if issues have no message.

--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -688,11 +688,6 @@ Examples:
 
 ## Not Yet Supported Features
 
-Some of the existing features of the Warnings plugin are not yet ported to the API. These will be added one by one after the
-first 5.x release of the Warnings plugin: 
-
-- Portlets for Jenkins' dashboard view
-- View column that shows the number of issues in a job
-- Quality gate based on the total number of issues
-
+Some of the existing features of the Warnings plugin are not yet ported to the API. These will be added one by one. Feel
+free to create an issue or vote for an issue in our [issue tracker](https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20in%20(analysis-model%2C%20analysis-model-api-plugin%2C%20warnings-ng-plugin\)). 
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <jenkins-test-harness.version>2.42</jenkins-test-harness.version>
 
     <!-- Project Dependencies Configuration -->
-    <analysis-model-api.version>2.0.0-20190102.151138-2</analysis-model-api.version>
-    <analysis-model.version>2.0.0-20190102.151024-3</analysis-model.version>
+    <analysis-model-api.version>2.0.0-20190106.112120-3</analysis-model-api.version>
+    <analysis-model.version>2.0.0-20190106.111959-4</analysis-model.version>
 
     <commons.lang.version>3.8.1</commons.lang.version>
     <commons.io.version>2.6</commons.io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <workflow-job.version>2.16</workflow-job.version>
     <structs.version>1.10</structs.version>
     <antisamy-markup-formatter.version>1.5</antisamy-markup-formatter.version>
+    <dashboard-view.version>2.9.4</dashboard-view.version>
 
     <!-- Maven plug-in versions -->
     <maven-pmd-plugin.version>3.11.0</maven-pmd-plugin.version>
@@ -259,6 +260,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <version>${git-plugin.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>dashboard-view</artifactId>
+      <version>${dashboard-view.version}</version>
       <optional>true</optional>
     </dependency>
 

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
@@ -42,12 +42,21 @@ public class JobAction implements Action {
         this.labelProvider = labelProvider;
     }
 
+    /**
+     * Returns the ID of this action and the ID of the associated results.
+     *
+     * @return the ID
+     */
+    public String getId() {
+        return labelProvider.getId();
+    }
+
     @Override
     public String getDisplayName() {
         return labelProvider.getLinkName();
     }
 
-    /**Dry
+    /**
      * Returns the title of the trend graph.
      *
      * @return the title of the trend graph.
@@ -104,12 +113,22 @@ public class JobAction implements Action {
      * @throws IOException
      *         in case of an error
      */
+    @SuppressWarnings("unused") // Called by jelly view
     public void doIndex(final StaplerRequest request, final StaplerResponse response) throws IOException {
-        Optional<ResultAction> action = createBuildHistory().getBaselineAction();
+        Optional<ResultAction> action = getLatestAction();
         if (action.isPresent()) {
             response.sendRedirect2(String.format("../%d/%s", action.get().getOwner().getNumber(), 
                     labelProvider.getId()));
         }
+    }
+
+    /**
+     * Returns the latest static analysis results for this job.
+     *
+     * @return the latest results (if available)
+     */
+    public Optional<ResultAction> getLatestAction() {
+        return createBuildHistory().getBaselineAction();
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
@@ -79,6 +79,15 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
     }
 
     /**
+     * Returns the name of the static analysis tool.
+     *
+     * @return the ID
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
      * Returns the associated build/run that created the static analysis result.
      *
      * @return the run
@@ -213,7 +222,12 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
         return String.format("%s for %s", getClass().getName(), getLabelProvider().getName());
     }
 
-    private StaticAnalysisLabelProvider getLabelProvider() {
+    /**
+     * Returns the {@link StaticAnalysisLabelProvider} for this action.
+     *
+     * @return the label provider for this tool
+     */
+    public StaticAnalysisLabelProvider getLabelProvider() {
         return new LabelProviderFactory().create(id, name);
     }
 

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.kohsuke.stapler.StaplerProxy;
@@ -57,6 +58,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
      * @param charset
      *         the charset to use to display source files
      */
+    // FIXME: is ID the same as label providers ID?
     public ResultAction(final Run<?, ?> owner, final AnalysisResult result, final HealthDescriptor healthDescriptor,
             final String id, final String name, final Charset charset) {
         this.owner = owner;
@@ -96,7 +98,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
         onAttached(r);
     }
 
-    @Override
+    @Override @NonNull
     public String getDisplayName() {
         return getLabelProvider().getLinkName();
     }
@@ -151,6 +153,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
      *
      * @return {@code true} if a large image is defined, {@code false} otherwise
      */
+    @SuppressWarnings("unused") // Called by jelly view
     public boolean hasLargeImage() {
         return StringUtils.isNotBlank(getLargeImageName());
     }
@@ -160,6 +163,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
      *
      * @return the URL of the image
      */
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Called by jelly view
     public String getLargeImageName() {
         return getLabelProvider().getLargeIconUrl();
     }
@@ -169,6 +173,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
      *
      * @return the URL of the image
      */
+    @SuppressWarnings("unused") // Called by jelly view
     public String getSmallImageName() {
         return getSmallImage();
     }
@@ -178,6 +183,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
      *
      * @return the URL of the image
      */
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Called by jelly view
     public String getSmallImage() {
         return getLabelProvider().getSmallIconUrl();
     }

--- a/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet.java
@@ -1,0 +1,136 @@
+package io.jenkins.plugins.analysis.core.portlets;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Job;
+import hudson.plugins.view.dashboard.DashboardPortlet;
+
+import io.jenkins.plugins.analysis.core.model.JobAction;
+import io.jenkins.plugins.analysis.core.model.ResultAction;
+
+/**
+ * A dashboard view portlet that renders a two-dimensional table of issues per type and job.
+ *
+ * @author Ullrich Hafner
+ */
+public class IssuesTablePortlet extends DashboardPortlet {
+    private boolean hideNoIssues;
+
+    /**
+     * A mapping of tools IDs to tool names. Note that this map will be initialized by #{@link
+     * #getToolNames(Collection)}: it cannot be used before this method has been called.
+     */
+    private TreeMap<String, String> toolNamesById;
+
+    /**
+     * Creates a new instance of {@link IssuesTablePortlet}.
+     *
+     * @param name
+     *         the name of the portlet
+     */
+    @DataBoundConstructor
+    public IssuesTablePortlet(final String name) {
+        super(name);
+    }
+
+    /**
+     * Returns all visible jobs. If activated in the configuration, jobs with no issues will be hidden.
+     *
+     * @param jobs
+     *         the jobs shown in the view
+     *
+     * @return the filtered jobs
+     */
+    public Collection<Job<?, ?>> getVisibleJobs(final Collection<Job<?, ?>> jobs) {
+        return hideNoIssues ? removeZeroIssuesJobs(jobs) : jobs;
+    }
+
+    private Collection<Job<?, ?>> removeZeroIssuesJobs(final Collection<Job<?, ?>> jobs) {
+        return jobs.stream().filter(this::isVisible).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the names of the static analysis tools that should be shown in the table.
+     *
+     * @param visibleJobs
+     *         the jobs shown in the view
+     *
+     * @return the names of the static analysis tools (ordered by ID)
+     */
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Called by jelly view
+    public Collection<String> getToolNames(final Collection<Job<?, ?>> visibleJobs) {
+        createToolMapping(visibleJobs);
+
+        return toolNamesById.values();
+    }
+
+    /**
+     * Searches for all available {@link ResultAction actions} of the visible jobs and stores the IDs and names.
+     *
+     * @param jobs
+     *         the visible jobs
+     */
+    private void createToolMapping(final Collection<Job<?, ?>> jobs) {
+        toolNamesById = jobs.stream()
+                .flatMap(job -> job.getActions(JobAction.class).stream())
+                .map(JobAction::getLatestAction)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(ResultAction::getId, ResultAction::getDisplayName, (r1, r2) -> r1,
+                        TreeMap::new));
+    }
+
+    /**
+     * Returns the number of issues in the specified job grouped by static analysis tool.
+     *
+     * @param job
+     *         the job to get the issues for
+     *
+     * @return the number of issues grouped by static analysis tool and ordered by ID
+     */
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Called by jelly view
+    public Collection<String> getTotals(final Job<?, ?> job) {
+        if (toolNamesById == null) {
+            throw new IllegalStateException("Method createToolMapping has not been called yet.");
+        }
+
+        return toolNamesById.keySet().stream().map(id -> countIssues(job, id)).collect(Collectors.toList());
+    }
+
+    private String countIssues(final Job<?, ?> job, final String id) {
+        return job.getActions(JobAction.class)
+                .stream()
+                .filter(jobAction -> jobAction.getId().equals(id))
+                .findFirst()
+                .map(JobAction::getLatestAction)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(resultAction -> String.valueOf(resultAction.getResult().getTotalSize()))
+                .orElse("-");
+    }
+
+    private boolean isVisible(final Job<?, ?> job) {
+        return true; // TODO: implement visibility
+    }
+
+    /**
+     * Extension point registration.
+     *
+     * @author Ulli Hafner
+     */
+    @Extension(optional = true)
+    public static class IssuesTablePortletDescriptor extends Descriptor<DashboardPortlet> {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return Messages.IssuesTablePortlet_Name();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/JenkinsFacade.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/JenkinsFacade.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.google.errorprone.annotations.MustBeClosed;
 
+import org.kohsuke.stapler.Stapler;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.AbstractItem;
@@ -165,6 +166,18 @@ public class JenkinsFacade implements Serializable {
      */
     public String getImagePath(final BallColor color) {
         return color.getImageOf("16x16");
+    }
+
+    /**
+     * Returns the absolute URL for the specified icon.
+     *
+     * @param icon
+     *         the icon URL
+     *
+     * @return the absolute URL
+     */
+    public String getImagePath(final String icon) {
+        return Stapler.getCurrentRequest().getContextPath() + Jenkins.RESOURCE_PATH + icon;
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.jelly
@@ -7,5 +7,8 @@
   <f:entry title="${%hide.title}" description="${%hide.description}" field="hideCleanJobs">
     <f:checkbox />
   </f:entry>
+  <f:entry title="${%icons.title}" description="${%icons.description}" field="showIcons">
+    <f:checkbox />
+  </f:entry>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+  <f:entry title="${%Name}" field="name">
+    <f:textbox default="${descriptor.getDisplayName()}"/>
+  </f:entry>
+  <f:entry title="${%hide.title}" description="${%hide.description}" field="hideCleanJobs">
+    <f:checkbox />
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.properties
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.properties
@@ -1,0 +1,2 @@
+hide.title=Hide clean jobs
+hide.description=Hide all jobs that have no issues from the selected static analysis tools.

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.properties
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/config.properties
@@ -1,2 +1,5 @@
 hide.title=Hide clean jobs
 hide.description=Hide all jobs that have no issues from the selected static analysis tools.
+
+icons.title=Show icons
+icons.description=Show icons of static analysis tools in table header rather than the human readable names.

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/portlet.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/portlet.jelly
@@ -1,33 +1,50 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:dp="/hudson/plugins/view/dashboard">
+<j:jelly xmlns:j="jelly:core" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:issues="/issues">
+
+  <issues:bootstrap-css/>
+  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/custom-style.css"/>
+  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/font-awesome/css/solid.min.css"/>
+  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/font-awesome/css/fontawesome.min.css"/>
+
+  <script src="${resURL}/plugin/warnings-ng/js/libs/jquery.min.js"/>
+  <script src="${resURL}/plugin/warnings-ng/js/libs/popper.min.js"/>
+  <script src="${resURL}/plugin/warnings-ng/js/libs/bootstrap.min.js"/>
 
   <dp:decorate portlet="${it}" width="1">
     <tr>
       <td>
 
         <j:set var="visibleJobs" value="${it.getVisibleJobs(jobs)}"/>
-        <table class="table table-hover table-striped" id="${it.id}">
-          <thead>
-            <tr>
-              <th>${%Job}</th>
-              <j:forEach var="toolName" items="${it.getToolNames(visibleJobs)}">
-                <th>${toolName}</th>
-              </j:forEach>
-            </tr>
-          </thead>
-          <tbody>
-            <j:forEach var="job" items="${visibleJobs}">
-              <tr>
-                <td class="pane">
-                  <dp:jobLink job="${job}"/>
-                </td>
-                <j:forEach var="total" items="${it.getTotals(job)}">
-                  <th>${total}</th>
+        <j:choose>
+          <j:when test="${!visibleJobs.isEmpty()}">
+            <table class="table table-hover table-striped" id="${it.id}">
+              <thead>
+                <tr>
+                  <th>${%Job}</th>
+                  <j:forEach var="toolName" items="${it.getToolNames(visibleJobs)}">
+                    <th>${toolName}</th>
+                  </j:forEach>
+                </tr>
+              </thead>
+              <tbody>
+                <j:forEach var="job" items="${visibleJobs}">
+                  <tr>
+                    <td class="pane">
+                      <dp:jobLink job="${job}"/>
+                    </td>
+                    <j:forEach var="total" items="${it.getTotals(job)}">
+                      <td>${total}</td>
+                    </j:forEach>
+                  </tr>
                 </j:forEach>
-              </tr>
-            </j:forEach>
-          </tbody>
-        </table>
+              </tbody>
+            </table>
+          </j:when>
+          <j:otherwise>
+            <issues:zero-issues/>
+          </j:otherwise>
+        </j:choose>
+
 
       </td>
     </tr>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/portlet.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/portlet.jelly
@@ -1,15 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:issues="/issues">
 
-  <issues:bootstrap-css/>
-  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/custom-style.css"/>
-  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/font-awesome/css/solid.min.css"/>
-  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/font-awesome/css/fontawesome.min.css"/>
-
-  <script src="${resURL}/plugin/warnings-ng/js/libs/jquery.min.js"/>
-  <script src="${resURL}/plugin/warnings-ng/js/libs/popper.min.js"/>
-  <script src="${resURL}/plugin/warnings-ng/js/libs/bootstrap.min.js"/>
-
   <dp:decorate portlet="${it}" width="1">
     <tr>
       <td>
@@ -17,12 +8,20 @@
         <j:set var="visibleJobs" value="${it.getVisibleJobs(jobs)}"/>
         <j:choose>
           <j:when test="${!visibleJobs.isEmpty()}">
-            <table class="table table-hover table-striped" id="${it.id}">
+            <j:if test="${!it.getShowIcons()}">
+              <j:set var="sortable" value="sortable" />
+            </j:if>
+            <!-- TODO: replace the old-school table with datatables.js as well -->
+            <table class="pane bigtable ${sortable}" id="${it.id}">
               <thead>
                 <tr>
-                  <th>${%Job}</th>
+                  <th class="pane-header" align="left" initialSortDir="down" >
+                    ${%Job}
+                  </th>
                   <j:forEach var="toolName" items="${it.getToolNames(visibleJobs)}">
-                    <th>${toolName}</th>
+                    <th class="pane-header" align="right">
+                      <j:out value="${toolName}"/>
+                    </th>
                   </j:forEach>
                 </tr>
               </thead>
@@ -33,7 +32,7 @@
                       <dp:jobLink job="${job}"/>
                     </td>
                     <j:forEach var="total" items="${it.getTotals(job)}">
-                      <td>${total}</td>
+                      <td class="pane" align="right">${total}</td>
                     </j:forEach>
                   </tr>
                 </j:forEach>
@@ -41,6 +40,15 @@
             </table>
           </j:when>
           <j:otherwise>
+            <issues:bootstrap-css/>
+            <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/custom-style.css"/>
+            <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/font-awesome/css/solid.min.css"/>
+            <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/font-awesome/css/fontawesome.min.css"/>
+
+            <script src="${resURL}/plugin/warnings-ng/js/libs/jquery.min.js"/>
+            <script src="${resURL}/plugin/warnings-ng/js/libs/popper.min.js"/>
+            <script src="${resURL}/plugin/warnings-ng/js/libs/bootstrap.min.js"/>
+
             <issues:zero-issues/>
           </j:otherwise>
         </j:choose>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/portlet.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortlet/portlet.jelly
@@ -1,0 +1,35 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:dp="/hudson/plugins/view/dashboard">
+
+  <dp:decorate portlet="${it}" width="1">
+    <tr>
+      <td>
+
+        <j:set var="visibleJobs" value="${it.getVisibleJobs(jobs)}"/>
+        <table class="table table-hover table-striped" id="${it.id}">
+          <thead>
+            <tr>
+              <th>${%Job}</th>
+              <j:forEach var="toolName" items="${it.getToolNames(visibleJobs)}">
+                <th>${toolName}</th>
+              </j:forEach>
+            </tr>
+          </thead>
+          <tbody>
+            <j:forEach var="job" items="${visibleJobs}">
+              <tr>
+                <td class="pane">
+                  <dp:jobLink job="${job}"/>
+                </td>
+                <j:forEach var="total" items="${it.getTotals(job)}">
+                  <th>${total}</th>
+                </j:forEach>
+              </tr>
+            </j:forEach>
+          </tbody>
+        </table>
+
+      </td>
+    </tr>
+  </dp:decorate>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/Messages.properties
@@ -1,0 +1,1 @@
+IssuesTablePortlet.Name=Static analysis Issues per Origin and Project

--- a/src/main/resources/io/jenkins/plugins/analysis/core/portlets/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/portlets/Messages.properties
@@ -1,1 +1,1 @@
-IssuesTablePortlet.Name=Static analysis Issues per Origin and Project
+IssuesTablePortlet.Name=Static analysis issues per tool and job

--- a/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryTest.java
@@ -11,15 +11,16 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
 import org.junit.jupiter.api.Test;
 
+import hudson.model.BallColor;
+import hudson.model.Run;
+
+import io.jenkins.plugins.analysis.core.model.Summary.LabelProviderFactoryFacade;
 import io.jenkins.plugins.analysis.core.util.AnalysisBuild;
 import io.jenkins.plugins.analysis.core.util.JenkinsFacade;
-import io.jenkins.plugins.analysis.core.model.Summary.LabelProviderFactoryFacade;
 import io.jenkins.plugins.analysis.core.util.QualityGateStatus;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
-import hudson.model.Run;
 
 /**
  * Tests the class {@link Summary}.
@@ -299,7 +300,7 @@ class SummaryTest {
 
     private StaticAnalysisLabelProvider createLabelProvider(final String checkstyle, final String checkStyle) {
         JenkinsFacade jenkins = mock(JenkinsFacade.class);
-        when(jenkins.getImagePath(any())).thenReturn("color");
+        when(jenkins.getImagePath(any(BallColor.class))).thenReturn("color");
         when(jenkins.getAbsoluteUrl(any())).thenReturn("absoluteUrl");
         return new StaticAnalysisLabelProvider(checkstyle, checkStyle, jenkins);
     }

--- a/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
@@ -12,7 +12,10 @@ import hudson.model.Job;
 
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;
 import io.jenkins.plugins.analysis.core.model.JobAction;
+import io.jenkins.plugins.analysis.core.model.LabelProviderFactory;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
+import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider;
+import io.jenkins.plugins.analysis.core.util.JenkinsFacade;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -24,55 +27,74 @@ import static org.mockito.Mockito.*;
  */
 class IssuesTablePortletTest {
     private static final String SPOT_BUGS_ID = "spotbugs";
-    private static final String SPOT_BUGS_NAME = "SpotBugs Warnings";
+    private static final String SPOT_BUGS_NAME = "SpotBugs";
     private static final String CHECK_STYLE_ID = "checkstyle";
-    private static final String CHECK_STYLE_NAME = "CheckStyle Warnings";
+    private static final String CHECK_STYLE_NAME = "CheckStyle";
 
     @Test
     void shouldThrowExceptionIfToolNamesAreNotSet() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        IssuesTablePortlet portlet = createPortlet();
 
         assertThatIllegalStateException()
                 .as("Mapping is generated in getToolNames and must be called first")
-                .isThrownBy(() -> issues.getTotals(mock(Job.class)));
+                .isThrownBy(() -> portlet.getTotals(mock(Job.class)));
     }
 
     @Test
     void shouldShowTableWithOneJob() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        IssuesTablePortlet portlet = createPortlet();
 
         List<Job<?, ?>> jobs = createJobs(createJob(1, SPOT_BUGS_ID, SPOT_BUGS_NAME));
 
-        assertThat(issues.getToolNames(jobs)).containsExactly(SPOT_BUGS_NAME);
-        assertThat(issues.getTotals(jobs.get(0))).containsExactly("1");
+        assertThat(portlet.getToolNames(jobs)).containsExactly(SPOT_BUGS_NAME);
+        assertThat(portlet.getTotals(jobs.get(0))).containsExactly("1");
     }
 
     @Test
     void shouldShowTableWithTwoJobs() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        IssuesTablePortlet portlet = createPortlet();
 
         List<Job<?, ?>> jobs = createJobs(createJob(1, SPOT_BUGS_ID, SPOT_BUGS_NAME),
                 createJob(2, SPOT_BUGS_ID, SPOT_BUGS_NAME));
 
-        assertThat(issues.getToolNames(jobs)).containsExactly(SPOT_BUGS_NAME);
-        assertThat(issues.getTotals(jobs.get(0))).containsExactly("1");
-        assertThat(issues.getTotals(jobs.get(1))).containsExactly("2");
+        assertThat(portlet.getToolNames(jobs)).containsExactly(SPOT_BUGS_NAME);
+        assertThat(portlet.getTotals(jobs.get(0))).containsExactly("1");
+        assertThat(portlet.getTotals(jobs.get(1))).containsExactly("2");
     }
 
     @Test
     void shouldShowTableWithTwoTools() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        IssuesTablePortlet portlet = createPortlet();
 
         List<Job<?, ?>> jobs = createJobs(createJobWithActions(createAction(1, SPOT_BUGS_ID, SPOT_BUGS_NAME),
                 createAction(2, CHECK_STYLE_ID, CHECK_STYLE_NAME)));
 
-        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
-        assertThat(issues.getTotals(jobs.get(0))).containsExactly("2", "1");
+        assertThat(portlet.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(portlet.getTotals(jobs.get(0))).containsExactly("2", "1");
+    }
+
+    @Test
+    void shouldShowIconsOfTools() {
+        IssuesTablePortlet portlet = createPortlet();
+        portlet.setShowIcons(true);
+
+        JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
+        when(jenkinsFacade.getImagePath("checkstyle.png")).thenReturn("/path/to/checkstyle.png");
+        when(jenkinsFacade.getImagePath("spotbugs.png")).thenReturn("/path/to/spotbugs.png");
+        portlet.setJenkinsFacade(jenkinsFacade);
+
+        List<Job<?, ?>> jobs = createJobs(createJobWithActions(createAction(1, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createAction(2, CHECK_STYLE_ID, CHECK_STYLE_NAME)));
+
+        assertThat(portlet.getToolNames(jobs)).containsExactly(
+                "<img alt=\"CheckStyle\" title=\"CheckStyle\" src=\"/path/to/checkstyle.png\">",
+                "<img alt=\"SpotBugs\" title=\"SpotBugs\" src=\"/path/to/spotbugs.png\">");
+        assertThat(portlet.getTotals(jobs.get(0))).containsExactly("2", "1");
     }
 
     @Test
     void shouldShowTableWithTwoToolsAndTwoJobs() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        IssuesTablePortlet portlet = createPortlet();
 
         List<Job<?, ?>> jobs = new ArrayList<>();
         Job first = createJobWithActions(createAction(1, SPOT_BUGS_ID, SPOT_BUGS_NAME),
@@ -82,16 +104,16 @@ class IssuesTablePortletTest {
                 createAction(4, CHECK_STYLE_ID, CHECK_STYLE_NAME));
         jobs.add(second);
 
-        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
-        assertThat(issues.getVisibleJobs(jobs)).containsExactly(first, second);
-        assertThat(issues.getTotals(first)).containsExactly("2", "1");
-        assertThat(issues.getTotals(second)).containsExactly("4", "3");
+        assertThat(portlet.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(portlet.getVisibleJobs(jobs)).containsExactly(first, second);
+        assertThat(portlet.getTotals(first)).containsExactly("2", "1");
+        assertThat(portlet.getTotals(second)).containsExactly("4", "3");
     }
 
     @Test
     void shouldFilterZeroIssuesJobs() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
-        issues.setHideCleanJobs(true);
+        IssuesTablePortlet portlet = createPortlet();
+        portlet.setHideCleanJobs(true);
 
         List<Job<?, ?>> jobs = new ArrayList<>();
         Job first = createJobWithActions(createAction(0, SPOT_BUGS_ID, SPOT_BUGS_NAME),
@@ -101,14 +123,14 @@ class IssuesTablePortletTest {
                 createAction(4, CHECK_STYLE_ID, CHECK_STYLE_NAME));
         jobs.add(second);
 
-        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
-        assertThat(issues.getVisibleJobs(jobs)).containsExactly(second);
+        assertThat(portlet.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(portlet.getVisibleJobs(jobs)).containsExactly(second);
     }
 
     @Test
     void shouldFilterNonActionJobs() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
-        issues.setHideCleanJobs(true);
+        IssuesTablePortlet portlet = createPortlet();
+        portlet.setHideCleanJobs(true);
 
         List<Job<?, ?>> jobs = new ArrayList<>();
         Job first = createJobWithActions();
@@ -117,13 +139,13 @@ class IssuesTablePortletTest {
                 createAction(4, CHECK_STYLE_ID, CHECK_STYLE_NAME));
         jobs.add(second);
 
-        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
-        assertThat(issues.getVisibleJobs(jobs)).containsExactly(second);
+        assertThat(portlet.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(portlet.getVisibleJobs(jobs)).containsExactly(second);
     }
 
     @Test
     void shouldShowTableWithTwoJobsWithDifferentTools() {
-        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        IssuesTablePortlet portlet = createPortlet();
 
         List<Job<?, ?>> jobs = new ArrayList<>();
 
@@ -133,9 +155,29 @@ class IssuesTablePortletTest {
         Job second = createJobWithActions(createAction(2, CHECK_STYLE_ID, CHECK_STYLE_NAME));
         jobs.add(second);
 
-        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
-        assertThat(issues.getTotals(first)).containsExactly("-", "1");
-        assertThat(issues.getTotals(second)).containsExactly("2", "-");
+        assertThat(portlet.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(portlet.getTotals(first)).containsExactly("-", "1");
+        assertThat(portlet.getTotals(second)).containsExactly("2", "-");
+    }
+
+    private IssuesTablePortlet createPortlet() {
+        IssuesTablePortlet portlet = new IssuesTablePortlet("portlet");
+
+        LabelProviderFactory factory = mock(LabelProviderFactory.class);
+        registerTool(factory, CHECK_STYLE_ID, CHECK_STYLE_NAME);
+        registerTool(factory, SPOT_BUGS_ID, SPOT_BUGS_NAME);
+        portlet.setLabelProviderFactory(factory);
+
+        return portlet;
+    }
+
+    private void registerTool(final LabelProviderFactory factory, final String id, final String name) {
+        StaticAnalysisLabelProvider tool = mock(StaticAnalysisLabelProvider.class);
+        when(factory.create(id, name)).thenReturn(tool);
+        when(factory.create(id)).thenReturn(tool);
+        when(tool.getSmallIconUrl()).thenReturn(id + ".png");
+        when(tool.getName()).thenReturn(name);
+        when(tool.getLinkName()).thenReturn(name);
     }
 
     private List<Job<?, ?>> createJobs(final Job<?, ?>... analysisJobs) {
@@ -173,7 +215,7 @@ class IssuesTablePortletTest {
 
         when(resultAction.getResult()).thenReturn(result);
         when(resultAction.getId()).thenReturn(id);
-        when(resultAction.getDisplayName()).thenReturn(name);
+        when(resultAction.getName()).thenReturn(name);
         return jobAction;
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
@@ -1,8 +1,18 @@
 package io.jenkins.plugins.analysis.core.portlets;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.collections.impl.factory.Lists;
 import org.junit.jupiter.api.Test;
 
 import hudson.model.Job;
+
+import io.jenkins.plugins.analysis.core.model.AnalysisResult;
+import io.jenkins.plugins.analysis.core.model.JobAction;
+import io.jenkins.plugins.analysis.core.model.ResultAction;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -13,12 +23,123 @@ import static org.mockito.Mockito.*;
  * @author Ullrich Hafner
  */
 class IssuesTablePortletTest {
+    private static final String SPOT_BUGS_ID = "spotbugs";
+    private static final String SPOT_BUGS_NAME = "SpotBugs Warnings";
+    private static final String CHECK_STYLE_ID = "checkstyle";
+    private static final String CHECK_STYLE_NAME = "CheckStyle Warnings";
+
     @Test
-    void shouldName() {
+    void shouldThrowExceptionIfToolNamesAreNotSet() {
         IssuesTablePortlet issues = new IssuesTablePortlet("issues");
 
         assertThatIllegalStateException()
                 .as("Mapping is generated in getToolNames and must be called first")
                 .isThrownBy(() -> issues.getTotals(mock(Job.class)));
+    }
+
+    @Test
+    void shouldShowTableWithOneJob() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+
+        List<Job<?, ?>> jobs = createJobs(createJob (1, SPOT_BUGS_ID, SPOT_BUGS_NAME));
+
+        assertThat(issues.getToolNames(jobs)).containsExactly(SPOT_BUGS_NAME);
+        assertThat(issues.getTotals(jobs.get(0))).containsExactly("1");
+    }
+
+    @Test
+    void shouldShowTableWithTwoJobs() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+
+        List<Job<?, ?>> jobs = createJobs(createJob(1, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createJob(2, SPOT_BUGS_ID, SPOT_BUGS_NAME));
+
+        assertThat(issues.getToolNames(jobs)).containsExactly(SPOT_BUGS_NAME);
+        assertThat(issues.getTotals(jobs.get(0))).containsExactly("1");
+        assertThat(issues.getTotals(jobs.get(1))).containsExactly("2");
+    }
+
+    @Test
+    void shouldShowTableWithTwoTools() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+
+        List<Job<?, ?>> jobs = createJobs(createJobWithActions(createAction(1, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createAction(2, CHECK_STYLE_ID, CHECK_STYLE_NAME)));
+
+        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(issues.getTotals(jobs.get(0))).containsExactly("2", "1");
+    }
+
+    @Test
+    void shouldShowTableWithTwoToolsAndTwoJobs() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+
+        List<Job<?, ?>> jobs = new ArrayList<>();
+        Job first = createJobWithActions(createAction(1, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createAction(2, CHECK_STYLE_ID, CHECK_STYLE_NAME));
+        jobs.add(first);
+        Job second = createJobWithActions(createAction(3, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createAction(4, CHECK_STYLE_ID, CHECK_STYLE_NAME));
+        jobs.add(second);
+
+        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(issues.getTotals(first)).containsExactly("2", "1");
+        assertThat(issues.getTotals(second)).containsExactly("4", "3");
+    }
+
+    @Test
+    void shouldShowTableWithTwoJobsWithDifferentTools() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+
+        List<Job<?, ?>> jobs = new ArrayList<>();
+
+        Job first = createJobWithActions(createAction(1, SPOT_BUGS_ID, SPOT_BUGS_NAME));
+        jobs.add(first);
+
+        Job second = createJobWithActions(createAction(2, CHECK_STYLE_ID, CHECK_STYLE_NAME));
+        jobs.add(second);
+
+        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(issues.getTotals(first)).containsExactly("-", "1");
+        assertThat(issues.getTotals(second)).containsExactly("2", "-");
+    }
+
+    private List<Job<?, ?>> createJobs(final Job<?, ?>... analysisJobs) {
+        List<Job<?, ?>> jobs = new ArrayList<>();
+        Collections.addAll(jobs, analysisJobs);
+        return jobs;
+    }
+
+    private Job createJobWithActions(final JobAction... actions) {
+        Job job = mock(Job.class);
+
+        when(job.getActions(JobAction.class)).thenReturn(Lists.fixedSize.of(actions));
+
+        return job;
+    }
+
+    private Job<?, ?> createJob(final int size, final String id, final String name) {
+        Job job = mock(Job.class);
+        JobAction jobAction = createAction(size, id, name);
+
+        when(job.getActions(JobAction.class)).thenReturn(Collections.singletonList(jobAction));
+
+        return job;
+    }
+
+    private JobAction createAction(final int size, final String id, final String name) {
+        JobAction jobAction = mock(JobAction.class);
+
+        ResultAction resultAction = mock(ResultAction.class);
+        when(jobAction.getLatestAction()).thenReturn(Optional.of(resultAction));
+        when(jobAction.getId()).thenReturn(id);
+
+        AnalysisResult result = mock(AnalysisResult.class);
+        when(result.getTotalSize()).thenReturn(size);
+
+        when(resultAction.getResult()).thenReturn(result);
+        when(resultAction.getId()).thenReturn(id);
+        when(resultAction.getDisplayName()).thenReturn(name);
+        return jobAction;
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
@@ -41,7 +41,7 @@ class IssuesTablePortletTest {
     void shouldShowTableWithOneJob() {
         IssuesTablePortlet issues = new IssuesTablePortlet("issues");
 
-        List<Job<?, ?>> jobs = createJobs(createJob (1, SPOT_BUGS_ID, SPOT_BUGS_NAME));
+        List<Job<?, ?>> jobs = createJobs(createJob(1, SPOT_BUGS_ID, SPOT_BUGS_NAME));
 
         assertThat(issues.getToolNames(jobs)).containsExactly(SPOT_BUGS_NAME);
         assertThat(issues.getTotals(jobs.get(0))).containsExactly("1");
@@ -83,8 +83,42 @@ class IssuesTablePortletTest {
         jobs.add(second);
 
         assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(issues.getVisibleJobs(jobs)).containsExactly(first, second);
         assertThat(issues.getTotals(first)).containsExactly("2", "1");
         assertThat(issues.getTotals(second)).containsExactly("4", "3");
+    }
+
+    @Test
+    void shouldFilterZeroIssuesJobs() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        issues.setHideCleanJobs(true);
+
+        List<Job<?, ?>> jobs = new ArrayList<>();
+        Job first = createJobWithActions(createAction(0, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createAction(0, CHECK_STYLE_ID, CHECK_STYLE_NAME));
+        jobs.add(first);
+        Job second = createJobWithActions(createAction(3, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createAction(4, CHECK_STYLE_ID, CHECK_STYLE_NAME));
+        jobs.add(second);
+
+        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(issues.getVisibleJobs(jobs)).containsExactly(second);
+    }
+
+    @Test
+    void shouldFilterNonActionJobs() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+        issues.setHideCleanJobs(true);
+
+        List<Job<?, ?>> jobs = new ArrayList<>();
+        Job first = createJobWithActions();
+        jobs.add(first);
+        Job second = createJobWithActions(createAction(3, SPOT_BUGS_ID, SPOT_BUGS_NAME),
+                createAction(4, CHECK_STYLE_ID, CHECK_STYLE_NAME));
+        jobs.add(second);
+
+        assertThat(issues.getToolNames(jobs)).containsExactly(CHECK_STYLE_NAME, SPOT_BUGS_NAME);
+        assertThat(issues.getVisibleJobs(jobs)).containsExactly(second);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/portlets/IssuesTablePortletTest.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.analysis.core.portlets;
+
+import org.junit.jupiter.api.Test;
+
+import hudson.model.Job;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link IssuesTablePortlet}.
+ *
+ * @author Ullrich Hafner
+ */
+class IssuesTablePortletTest {
+    @Test
+    void shouldName() {
+        IssuesTablePortlet issues = new IssuesTablePortlet("issues");
+
+        assertThatIllegalStateException()
+                .as("Mapping is generated in getToolNames and must be called first")
+                .isThrownBy(() -> issues.getTotals(mock(Job.class)));
+    }
+}

--- a/src/test/resources/design.puml
+++ b/src/test/resources/design.puml
@@ -13,6 +13,7 @@ skinparam component {
 
 [Charts] <<..core.charts>>
 [Filter] <<..core.filter>>
+[Portlets] <<..core.portlets>>
 [Rest API] <<..core.restapi>>
 [SCM] <<..core.scm>>
 [Tokens] <<..core.tokens>>
@@ -27,6 +28,7 @@ skinparam component {
 [Steps] ---> [Filter]
 
 [Tokens] --> [Model]
+[Portlets] --> [Model]
 
 [Model] --> [Utilities]
 [Model] --> [Charts]

--- a/src/test/resources/design.puml
+++ b/src/test/resources/design.puml
@@ -29,6 +29,7 @@ skinparam component {
 
 [Tokens] --> [Model]
 [Portlets] --> [Model]
+[Portlets] --> [Utilities]
 
 [Model] --> [Utilities]
 [Model] --> [Charts]


### PR DESCRIPTION
A dashboard view portlet that renders a two-dimensional table of issues per type and job.

See [JENKINS-55500](https://issues.jenkins-ci.org/browse/JENKINS-55500)