### PR TITLE
Add required formatting option to docs

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/warnings/Flake8.java
+++ b/src/main/java/io/jenkins/plugins/analysis/warnings/Flake8.java
@@ -44,5 +44,10 @@ public class Flake8 extends ReportScanningTool {
         public String getDisplayName() {
             return Messages.Violations_Flake8();
         }
+
+        @Override
+        public String getHelp() {
+            return "<p>Run flake8 as <code>flake8 --format=pylint</code></p>";
+        }
     }
 }


### PR DESCRIPTION
The flake8 parser requires that flake8 output in pylint format, not its default format.
This format can be achieved with `--format=pylint` or in a file `--config=path` ->
```
[flake8]
format=pylint
```

Link shows parser requiring pylint formatting of output.
https://github.com/tomasbjerre/violations-lib/blob/c3f597a65528544a99cb1c6dfa016299189065bc/src/main/java/se/bjurr/violations/lib/parsers/Flake8Parser.java#L20