### PR TITLE
Pylint: add proper support for packages and modules

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/model/TabLabelProvider.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/TabLabelProvider.java
@@ -105,7 +105,7 @@ public class TabLabelProvider {
             if (fileTypes.contains("cs")) {
                 return nameSpaceText;
             }
-            else if (fileTypes.contains("java")) {
+            else if (fileTypes.contains("java") || fileTypes.contains("py")) {
                 return packageText;
             }
         }

--- a/src/main/java/io/jenkins/plugins/analysis/warnings/PyLint.java
+++ b/src/main/java/io/jenkins/plugins/analysis/warnings/PyLint.java
@@ -85,7 +85,7 @@ public class PyLint extends ReportScanningTool {
         @Override
         public String getHelp() {
             return "<p>Create a ./pylintrc that contains:" 
-                    + "<p><code>msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}</code></p>"
+                    + "<p><code>msg-template={path}:{module}:{line}: [{msg_id}({symbol}), {obj}] {msg}</code></p>"
                     + "</p>" 
                     + "<p>Start pylint using the command:" 
                     + "<p><code>pylint --rcfile=./pylintrc CODE > pylint.log</code></p>" 


### PR DESCRIPTION
Continuation of my work in https://github.com/jenkinsci/analysis-model/pull/100.

I did two changes
* Adjust the help message for pylint in the snippet generator.
* Activate the `Package` tab in the details view when python files are found for the issues (instead of having a Folder tab).