### PR TITLE
JENKINS-49965 "Slow performance of warnings table if there are 1000 elements"

### DIFF
--- a/src/main/webapp/js/issues-detail.js
+++ b/src/main/webapp/js/issues-detail.js
@@ -203,6 +203,7 @@
                 language: {
                     emptyTable: "Loading - please wait ..."
                 },
+                deferRender: true,
                 pagingType: 'numbers',  // Page number button only
                 order: [[1, 'asc']],
                 columnDefs: [{


### PR DESCRIPTION
This is not exactly the ajax pagination but a simple hotfix to allow users use warnings ng plug-in even though they have much more than 1000+ elements in their warnings table.

Resource:
https://datatables.net/examples/ajax/defer_render.html

I am not sure how can I test this in action. It would be great having a way for getting *.hpi file and see it in our current Jenkins implementations with the builds more than 2k+ warnings.