### PR TITLE
Default FileFinder to not follow symlinks.

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/util/FileFinder.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/FileFinder.java
@@ -44,7 +44,7 @@ public class FileFinder extends MasterToSlaveFileCallable<String[]> {
      *         the ant file excludes pattern to scan for
      */
     public FileFinder(final String includesPattern, final String excludesPattern) {
-        this(includesPattern, excludesPattern, true);
+        this(includesPattern, excludesPattern, false);
     }
 
     /**


### PR DESCRIPTION
There are a couple of code paths that scan work spaces with the follow symlinks defaulted to true (specifically around resolving a project's modules).  This prevents those scans from following symlinks, which can cause problems with repositories with recursive links.

There is no clear way to make this configurable (e.g. the module paths are static fields on the class).  Given that Jenkins has a fair amount of control over pulling the files into it's workspace (e.g. fetch from source control), I think moving the default to false will be reasonably safe.