### PR TITLE
[JENKINS-39203] Mark publishIssues steps with QualityGateStatus.WARNING with WarningAction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
-    <relativePath />
+    <version>3.43</version>
+    <relativePath/>
   </parent>
 
   <groupId>io.jenkins.plugins</groupId>
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Override properties defined in parent POM -->
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
 
@@ -59,6 +59,7 @@
     <matrix-project.version>1.13</matrix-project.version>
     <junit-plugin.version>1.24</junit-plugin.version>
     <git-plugin.version>3.9.1</git-plugin.version>
+    <workflow-api.version>2.34</workflow-api.version>
     <workflow-step.version>2.19</workflow-step.version>
     <workflow-job.version>2.32</workflow-job.version>
     <structs.version>1.17</structs.version>
@@ -245,6 +246,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
       <version>${script-security.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <version>${workflow-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -481,12 +487,6 @@
     </dependency>
 
     <!-- Declarative Pipeline -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-api</artifactId>
-      <version>2.33</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
@@ -738,59 +738,22 @@
           </dependency>
         </dependencies>
         <configuration>
+          <!-- Including provided-scope dependencies like Jenkins core results in too many false positives -->
+          <checkDependencies>false</checkDependencies>
           <analysisConfiguration>
             <revapi.semver.ignore>
               <enabled>true</enabled>
             </revapi.semver.ignore>
             <revapi.ignore>
               <item>
-                <code>java.method.returnTypeChanged</code>
-                <newType>edu.hm.hafner.analysis.IssueParser</newType>
-                <justification>The parser should not be visible.</justification>
-              </item>
-            </revapi.ignore>
-            <revapi.ignore>
-              <item>
                 <regex>true</regex>
                 <code>java.missing.*</code>
-                <classQualifiedName>hudson.matrix.*</classQualifiedName>
-                <justification>Optional dependency</justification>
+                <justification>Dependencies are not being checked, so they are reported as missing</justification>
               </item>
               <item>
-                <code>java.class.nonPublicPartOfAPI</code>
-                <classQualifiedName>org.jvnet.hudson.reactor.Reactor.Node</classQualifiedName>
-                <justification>Not relevant</justification>
-              </item>
-              <item>
-                <code>java.class.nonPublicPartOfAPI</code>
-                <classQualifiedName>hudson.remoting.Command</classQualifiedName>
-                <justification>Not relevant</justification>
-              </item>
-              <item>
-                <code>java.class.nonPublicPartOfAPI</code>
-                <classQualifiedName>hudson.remoting.CommandTransport.CommandReceiver</classQualifiedName>
-                <justification>Not relevant</justification>
-              </item>
-              <item>
-                <code>java.class.nonPublicPartOfAPI</code>
-                <classQualifiedName>hudson.model.FingerprintMap.FingerprintParams</classQualifiedName>
-                <justification>Not relevant</justification>
-              </item>
-              <item>
-                <code>java.class.nonPublicPartOfAPI</code>
-                <classQualifiedName>org.kohsuke.stapler.AncestorImpl</classQualifiedName>
-                <justification>Not relevant</justification>
-              </item>
-              <item>
-                <code>java.class.nonPublicPartOfAPI</code>
-                <classQualifiedName>net.sf.json.AbstractJSON.WritingVisitor</classQualifiedName>
-                <justification>Not relevant</justification>
-              </item>
-              <item>
-                <code>java.class.nonPublicPartOfAPI</code>
-                <regex>true</regex>
-                <classQualifiedName>com.fasterxml.jackson.databind.*</classQualifiedName>
-                <justification>Not relevant</justification>
+                <code>java.annotation.removed</code>
+                <classQualifiedName>io.jenkins.plugins.analysis.core.steps.IssuesRecorder.Descriptor</classQualifiedName>
+                <justification>Symbol-based usage migrated transparently to RecordIssuesStep</justification>
               </item>
             </revapi.ignore>
           </analysisConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -760,6 +760,11 @@
                 <classQualifiedName>io.jenkins.plugins.analysis.core.steps.IssuesRecorder.Descriptor</classQualifiedName>
                 <justification>Symbol-based usage migrated transparently to RecordIssuesStep</justification>
               </item>
+              <item>
+                <code>java.method.removed</code>
+                <classQualifiedName>io.jenkins.plugins.analysis.core.util.QualityGateStatus</classQualifiedName>
+                <justification>Not part of the plugin's public API</justification>
+              </item>
             </revapi.ignore>
           </analysisConfiguration>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -746,6 +746,11 @@
             </revapi.semver.ignore>
             <revapi.ignore>
               <item>
+                <code>java.method.returnTypeChanged</code>
+                <newType>edu.hm.hafner.analysis.IssueParser</newType>
+                <justification>The parser should not be visible.</justification>
+              </item>
+              <item>
                 <regex>true</regex>
                 <code>java.missing.*</code>
                 <justification>Dependencies are not being checked, so they are reported as missing</justification>

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesAggregator.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesAggregator.java
@@ -17,6 +17,7 @@ import hudson.model.BuildListener;
 
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
+import io.jenkins.plugins.analysis.core.util.QualityGateStatusHandler;
 
 /**
  * Aggregates the {@link AnalysisResult}s of all {@link ResultAction}s of several {@link MatrixRun}s into {@link
@@ -91,7 +92,8 @@ public class IssuesAggregator extends MatrixAggregator {
     public boolean endBuild() {
         for (Entry<String, List<AnnotatedReport>> reportsPerId : results.entrySet()) {
             AnnotatedReport aggregatedReport = new AnnotatedReport(reportsPerId.getKey(), reportsPerId.getValue());
-            recorder.publishResult(build, listener, Messages.Tool_Default_Name(), aggregatedReport, StringUtils.EMPTY);
+            recorder.publishResult(build, listener, Messages.Tool_Default_Name(), aggregatedReport, StringUtils.EMPTY,
+                    new QualityGateStatusHandler.SetBuildResultStatusHandler(build));
         }
         return true;
     }

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesPublisher.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesPublisher.java
@@ -27,6 +27,7 @@ import io.jenkins.plugins.analysis.core.util.JenkinsFacade;
 import io.jenkins.plugins.analysis.core.util.LogHandler;
 import io.jenkins.plugins.analysis.core.util.QualityGateEvaluator;
 import io.jenkins.plugins.analysis.core.util.QualityGateStatus;
+import io.jenkins.plugins.analysis.core.util.QualityGateStatusHandler;
 
 import static io.jenkins.plugins.analysis.core.model.AnalysisHistory.JobResultEvaluationMode.*;
 import static io.jenkins.plugins.analysis.core.model.AnalysisHistory.QualityGateEvaluationMode.*;
@@ -48,12 +49,14 @@ class IssuesPublisher {
     private final QualityGateEvaluationMode qualityGateEvaluationMode;
     private final JobResultEvaluationMode jobResultEvaluationMode;
     private final LogHandler logger;
+    private final QualityGateStatusHandler qualityGateStatusHandler;
 
     @SuppressWarnings("ParameterNumber")
     IssuesPublisher(final Run<?, ?> run, final AnnotatedReport report,
             final HealthDescriptor healthDescriptor, final QualityGateEvaluator qualityGate,
             final String name, final String referenceJobName, final boolean ignoreQualityGate,
-            final boolean ignoreFailedBuilds, final Charset sourceCodeEncoding, final LogHandler logger) {
+            final boolean ignoreFailedBuilds, final Charset sourceCodeEncoding, final LogHandler logger,
+            final QualityGateStatusHandler qualityGateStatusHandler) {
         this.report = report;
         this.run = run;
         this.healthDescriptor = healthDescriptor;
@@ -64,6 +67,7 @@ class IssuesPublisher {
         qualityGateEvaluationMode = ignoreQualityGate ? IGNORE_QUALITY_GATE : SUCCESSFUL_QUALITY_GATE;
         jobResultEvaluationMode = ignoreFailedBuilds ? NO_JOB_FAILURE : IGNORE_JOB_RESULT;
         this.logger = logger;
+        this.qualityGateStatusHandler = qualityGateStatusHandler;
     }
 
     private String getId() {
@@ -142,7 +146,7 @@ class IssuesPublisher {
             else {
                 filtered.logInfo("-> Some quality gates have been missed: overall result is %s", qualityGateStatus);
             }
-            qualityGateStatus.setResult(run);
+            qualityGateStatusHandler.handleStatus(qualityGateStatus);
         }
         else {
             filtered.logInfo("No quality gates have been set - skipping");

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -616,7 +616,7 @@ public class IssuesRecorder extends Recorder implements SimpleBuildStep {
      */
     @SuppressWarnings("deprecation")
     void publishResult(final Run<?, ?> run, final TaskListener listener, final String loggerName,
-            final AnnotatedReport report, final String reportName, QualityGateStatusHandler statusHandler) {
+            final AnnotatedReport report, final String reportName, final QualityGateStatusHandler statusHandler) {
         QualityGateEvaluator qualityGate = new QualityGateEvaluator();
         if (qualityGates.isEmpty()) {
             qualityGates.addAll(QualityGate.map(thresholds));

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -576,8 +576,7 @@ public class PublishIssuesStep extends Step {
             IssuesPublisher publisher = new IssuesPublisher(getRun(), report, healthDescriptor, qualityGate,
                     name, referenceJobName, ignoreQualityGate, ignoreFailedBuilds,
                     getCharset(sourceCodeEncoding), getLogger(report), statusHandler);
-            ResultAction resultAction = publisher.attachAction();
-            return resultAction;
+            return publisher.attachAction();
         }
 
         private LogHandler getLogger(final AnnotatedReport report) throws InterruptedException {

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
@@ -59,6 +59,7 @@ import org.kohsuke.stapler.QueryParameter;
  * </li>
  * </ul>
  */
+@SuppressWarnings({"PMD.ExcessivePublicCount", "PMD.ExcessiveImports"})
 public class RecordIssuesStep extends Step implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -82,7 +83,9 @@ public class RecordIssuesStep extends Step implements Serializable {
      * Creates a new instance of {@link RecordIssuesStep}.
      */
     @DataBoundConstructor
-    public RecordIssuesStep() { }
+    public RecordIssuesStep() {
+        super();
+    }
 
     /**
      * Defines the optional list of quality gates.
@@ -435,7 +438,7 @@ public class RecordIssuesStep extends Step implements Serializable {
     }
 
     @Override
-    public StepExecution start(StepContext context) throws Exception {
+    public StepExecution start(final StepContext context) throws Exception {
         return new Execution(context, this);
     }
 

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
@@ -1,0 +1,599 @@
+package io.jenkins.plugins.analysis.core.steps;
+
+import edu.hm.hafner.analysis.Severity;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ComboBoxModel;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+
+import io.jenkins.plugins.analysis.core.filter.RegexpFilter;
+import io.jenkins.plugins.analysis.core.model.AnalysisResult;
+import io.jenkins.plugins.analysis.core.model.HealthReportBuilder;
+import io.jenkins.plugins.analysis.core.model.ResultAction;
+import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider;
+import io.jenkins.plugins.analysis.core.model.Tool;
+import io.jenkins.plugins.analysis.core.util.ModelValidation;
+import io.jenkins.plugins.analysis.core.util.QualityGate;
+import io.jenkins.plugins.analysis.core.util.QualityGateEvaluator;
+import io.jenkins.plugins.analysis.core.util.QualityGateStatusHandler;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.collections.impl.factory.Sets;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * Pipeline step that scans report files or the console log for issues. Stores the created
+ * issues in an {@link AnalysisResult}. The result is attached to the {@link Run} by registering a {@link
+ * ResultAction}.
+ * <p>
+ * Additional features:
+ * <ul>
+ * <li>It provides a {@link QualityGateEvaluator} that is checked after each run. If the quality gate is not passed,
+ * then the
+ * build will be set to {@link Result#UNSTABLE} or {@link Result#FAILURE}, depending on the configuration
+ * properties.</li>
+ * <li>It provides thresholds for the build health that could be adjusted in the configuration screen.
+ * These values are used by the {@link HealthReportBuilder} to compute the health and the health trend graph.
+ * </li>
+ * </ul>
+ */
+public class RecordIssuesStep extends Step implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private List<Tool> analysisTools = new ArrayList<>();
+    private String sourceCodeEncoding = StringUtils.EMPTY;
+    private boolean ignoreQualityGate = false; // by default, a successful quality gate is mandatory;
+    private boolean ignoreFailedBuilds = true; // by default, failed builds are ignored;
+    private String referenceJobName;
+    private int healthy;
+    private int unhealthy;
+    private Severity minimumSeverity = Severity.WARNING_LOW;
+    private List<RegexpFilter> filters = new ArrayList<>();
+    private boolean isEnabledForFailure;
+    private boolean isAggregatingResults;
+    private boolean isBlameDisabled;
+    private String id;
+    private String name;
+    private List<QualityGate> qualityGates = new ArrayList<>();
+
+    /**
+     * Creates a new instance of {@link RecordIssuesStep}.
+     */
+    @DataBoundConstructor
+    public RecordIssuesStep() { }
+
+    /**
+     * Defines the optional list of quality gates.
+     *
+     * @param qualityGates
+     *         the quality gates
+     */
+    @SuppressWarnings("unused") // used by Stapler view data binding
+    @DataBoundSetter
+    public void setQualityGates(final List<QualityGate> qualityGates) {
+        this.qualityGates = qualityGates;
+    }
+
+    /**
+     * Appends the specified quality gates to the end of the list of quality gates.
+     *
+     * @param size
+     *         the minimum number of issues that fails the quality gate
+     * @param type
+     *         the type of the quality gate
+     * @param result
+     *         determines whether the quality gate is a warning or failure
+     */
+    public void addQualityGate(final int size, final QualityGate.QualityGateType type, final QualityGate.QualityGateResult result) {
+        qualityGates.add(new QualityGate(size, type, result));
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"}) // used by Stapler view data binding
+    public List<QualityGate> getQualityGates() {
+        return qualityGates;
+    }
+
+    /**
+     * Defines the ID of the results. The ID is used as URL of the results and as name in UI elements. If no ID is
+     * given, then the ID of the associated result object is used.
+     * <p>
+     * Note: this property is not used if {@link #isAggregatingResults} is {@code false}. It is also not visible in the
+     * UI in order to simplify the user interface.
+     * </p>
+     *
+     * @param id
+     *         the ID of the results
+     */
+    @DataBoundSetter
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Defines the name of the results. The name is used for all labels in the UI. If no name is given, then the name of
+     * the associated {@link StaticAnalysisLabelProvider} is used.
+     * <p>
+     * Note: this property is not used if {@link #isAggregatingResults} is {@code false}. It is also not visible in the
+     * UI in order to simplify the user interface.
+     * </p>
+     *
+     * @param name
+     *         the name of the results
+     */
+    @DataBoundSetter
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the static analysis tools that will scan files and create issues.
+     *
+     * @return the static analysis tools (wrapped as {@link ToolProxy})
+     * @see #getTools
+     * @deprecated this method is only intended to be called by the UI
+     */
+    @Nullable
+    @Deprecated
+    public List<ToolProxy> getToolProxies() {
+        return analysisTools.stream().map(ToolProxy::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Sets the static analysis tools that will scan files and create issues.
+     *
+     * @param toolProxies
+     *         the static analysis tools (wrapped as {@link ToolProxy})
+     *
+     * @see #setTools(List)
+     * @see #setTool(Tool)
+     * @deprecated this method is only intended to be called by the UI
+     */
+    @DataBoundSetter
+    @Deprecated
+    public void setToolProxies(final List<ToolProxy> toolProxies) {
+        analysisTools = toolProxies.stream().map(ToolProxy::getTool).collect(Collectors.toList());
+    }
+
+    /**
+     * Sets the static analysis tools that will scan files and create issues.
+     *
+     * @param tools
+     *         the static analysis tools
+     *
+     * @see #setTool(Tool)
+     */
+    @DataBoundSetter
+    public void setTools(final List<Tool> tools) {
+        analysisTools = new ArrayList<>(tools);
+    }
+
+    /**
+     * Sets the static analysis tools that will scan files and create issues.
+     *
+     * @param tool
+     *         the static analysis tool
+     * @param additionalTools
+     *         additional static analysis tools (might be empty)
+     *
+     * @see #setTool(Tool)
+     * @see #setTools(List)
+     */
+    public void setTools(final Tool tool, final Tool... additionalTools) {
+        IssuesRecorder.ensureThatToolIsValid(tool);
+        for (Tool additionalTool : additionalTools) {
+            IssuesRecorder.ensureThatToolIsValid(additionalTool);
+        }
+        analysisTools = new ArrayList<>();
+        analysisTools.add(tool);
+        Collections.addAll(analysisTools, additionalTools);
+    }
+
+    /**
+     * Returns the static analysis tools that will scan files and create issues.
+     *
+     * @return the static analysis tools
+     */
+    public List<Tool> getTools() {
+        return new ArrayList<>(analysisTools);
+    }
+
+    /**
+     * Sets the static analysis tool that will scan files and create issues.
+     *
+     * @param tool
+     *         the static analysis tool
+     */
+    @DataBoundSetter
+    public void setTool(final Tool tool) {
+        IssuesRecorder.ensureThatToolIsValid(tool);
+
+        analysisTools = Collections.singletonList(tool);
+    }
+
+    /**
+     * Always returns {@code null}. Note: this method is required for Jenkins data binding.
+     *
+     * @return {@code null}
+     */
+    @Nullable
+    public Tool getTool() {
+        return null;
+    }
+
+    @Nullable
+    public String getSourceCodeEncoding() {
+        return sourceCodeEncoding;
+    }
+
+    /**
+     * Sets the encoding to use to read source files.
+     *
+     * @param sourceCodeEncoding
+     *         the encoding, e.g. "ISO-8859-1"
+     */
+    @DataBoundSetter
+    public void setSourceCodeEncoding(final String sourceCodeEncoding) {
+        this.sourceCodeEncoding = sourceCodeEncoding;
+    }
+
+    /**
+     * Returns whether the results for each configured static analysis result should be aggregated into a single result
+     * or if every tool should get an individual result.
+     *
+     * @return {@code true}  if the results of each static analysis tool should be aggregated into a single result,
+     *         {@code false} if every tool should get an individual result.
+     */
+    @SuppressWarnings("PMD.BooleanGetMethodName")
+    public boolean getAggregatingResults() {
+        return isAggregatingResults;
+    }
+
+    @DataBoundSetter
+    public void setAggregatingResults(final boolean aggregatingResults) {
+        isAggregatingResults = aggregatingResults;
+    }
+
+    /**
+     * Returns whether SCM blaming should be disabled.
+     *
+     * @return {@code true} if SCM blaming should be disabled
+     */
+    @SuppressWarnings("PMD.BooleanGetMethodName")
+    public boolean getBlameDisabled() {
+        return isBlameDisabled;
+    }
+
+    @DataBoundSetter
+    public void setBlameDisabled(final boolean blameDisabled) {
+        isBlameDisabled = blameDisabled;
+    }
+
+    /**
+     * Returns whether recording should be enabled for failed builds as well.
+     *
+     * @return {@code true}  if recording should be enabled for failed builds as well, {@code false} if recording is
+     *         enabled for successful or unstable builds only
+     */
+    @SuppressWarnings("PMD.BooleanGetMethodName")
+    public boolean getEnabledForFailure() {
+        return isEnabledForFailure;
+    }
+
+    @DataBoundSetter
+    public void setEnabledForFailure(final boolean enabledForFailure) {
+        isEnabledForFailure = enabledForFailure;
+    }
+
+    /**
+     * If {@code true}, then the result of the quality gate is ignored when selecting a reference build. This option is
+     * disabled by default so a failing quality gate will be passed from build to build until the original reason for
+     * the failure has been resolved.
+     *
+     * @param ignoreQualityGate
+     *         if {@code true} then the result of the quality gate is ignored, otherwise only build with a successful
+     *         quality gate are selected
+     */
+    @DataBoundSetter
+    public void setIgnoreQualityGate(final boolean ignoreQualityGate) {
+        this.ignoreQualityGate = ignoreQualityGate;
+    }
+
+    @SuppressWarnings("PMD.BooleanGetMethodName")
+    public boolean getIgnoreQualityGate() {
+        return ignoreQualityGate;
+    }
+
+    /**
+     * If {@code true}, then only successful or unstable reference builds will be considered. This option is enabled by
+     * default, since analysis results might be inaccurate if the build failed. If {@code false}, every build that
+     * contains a static analysis result is considered, even if the build failed.
+     *
+     * @param ignoreFailedBuilds
+     *         if {@code true} then a stable build is used as reference
+     */
+    @DataBoundSetter
+    public void setIgnoreFailedBuilds(final boolean ignoreFailedBuilds) {
+        this.ignoreFailedBuilds = ignoreFailedBuilds;
+    }
+
+    @SuppressWarnings("PMD.BooleanGetMethodName")
+    public boolean getIgnoreFailedBuilds() {
+        return ignoreFailedBuilds;
+    }
+
+    /**
+     * Sets the reference job to get the results for the issue difference computation.
+     *
+     * @param referenceJobName
+     *         the name of reference job
+     */
+    @DataBoundSetter
+    public void setReferenceJobName(final String referenceJobName) {
+        if (IssuesRecorder.NO_REFERENCE_JOB.equals(referenceJobName)) {
+            this.referenceJobName = StringUtils.EMPTY;
+        }
+        this.referenceJobName = referenceJobName;
+    }
+
+    /**
+     * Returns the reference job to get the results for the issue difference computation. If the job is not defined,
+     * then {@link IssuesRecorder#NO_REFERENCE_JOB} is returned.
+     *
+     * @return the name of reference job, or {@link IssuesRecorder#NO_REFERENCE_JOB} if undefined
+     */
+    public String getReferenceJobName() {
+        if (StringUtils.isBlank(referenceJobName)) {
+            return IssuesRecorder.NO_REFERENCE_JOB;
+        }
+        return referenceJobName;
+    }
+
+    public int getHealthy() {
+        return healthy;
+    }
+
+    /**
+     * Sets the healthy threshold, i.e. the number of issues when health is reported as 100%.
+     *
+     * @param healthy
+     *         the number of issues when health is reported as 100%
+     */
+    @DataBoundSetter
+    public void setHealthy(final int healthy) {
+        this.healthy = healthy;
+    }
+
+    public int getUnhealthy() {
+        return unhealthy;
+    }
+
+    /**
+     * Sets the healthy threshold, i.e. the number of issues when health is reported as 0%.
+     *
+     * @param unhealthy
+     *         the number of issues when health is reported as 0%
+     */
+    @DataBoundSetter
+    public void setUnhealthy(final int unhealthy) {
+        this.unhealthy = unhealthy;
+    }
+
+    @Nullable
+    public String getMinimumSeverity() {
+        return minimumSeverity.getName();
+    }
+
+    /**
+     * Sets the minimum severity to consider when computing the health report. Issues with a severity less than this
+     * value will be ignored.
+     *
+     * @param minimumSeverity
+     *         the severity to consider
+     */
+    @DataBoundSetter
+    public void setMinimumSeverity(final String minimumSeverity) {
+        this.minimumSeverity = Severity.valueOf(minimumSeverity, Severity.WARNING_LOW);
+    }
+
+    public List<RegexpFilter> getFilters() {
+        return new ArrayList<>(filters);
+    }
+
+    @DataBoundSetter
+    public void setFilters(final List<RegexpFilter> filters) {
+        this.filters = new ArrayList<>(filters);
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(context, this);
+    }
+
+    /**
+     * Actually performs the execution of the associated step.
+     */
+    static class Execution extends AnalysisExecution<Void> {
+        private static final long serialVersionUID = 1L;
+        private final RecordIssuesStep step;
+
+        Execution(@NonNull final StepContext context, final RecordIssuesStep step) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws IOException, InterruptedException {
+            IssuesRecorder recorder = new IssuesRecorder();
+            recorder.setTools(step.getTools());
+            recorder.setSourceCodeEncoding(step.getSourceCodeEncoding());
+            recorder.setIgnoreQualityGate(step.getIgnoreQualityGate());
+            recorder.setIgnoreFailedBuilds(step.getIgnoreFailedBuilds());
+            recorder.setReferenceJobName(step.getReferenceJobName());
+            recorder.setHealthy(step.getHealthy());
+            recorder.setUnhealthy(step.getUnhealthy());
+            recorder.setMinimumSeverity(step.getMinimumSeverity());
+            recorder.setFilters(step.getFilters());
+            recorder.setEnabledForFailure(step.getEnabledForFailure());
+            recorder.setAggregatingResults(step.getAggregatingResults());
+            recorder.setBlameDisabled(step.getBlameDisabled());
+            recorder.setId(step.getId());
+            recorder.setName(step.getName());
+            recorder.setQualityGates(step.getQualityGates());
+
+            QualityGateStatusHandler statusHandler = new QualityGateStatusHandler.PipelineStatusHandler(getRun(),
+                    getContext().get(FlowNode.class));
+
+            FilePath workspace = getWorkspace();
+            workspace.mkdirs();
+            recorder.perform(getRun(), workspace, getTaskListener(), statusHandler);
+            return null;
+        }
+
+    }
+
+    /**
+     * Descriptor for this step: defines the context and the UI labels.
+     */
+    @Extension
+    @SuppressWarnings("unused") // most methods are used by the corresponding jelly view
+    public static class Descriptor extends StepDescriptor {
+        private final ModelValidation model = new ModelValidation();
+
+        @Override
+        public String getFunctionName() {
+            return "recordIssues";
+        }
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.ScanAndPublishIssues_DisplayName();
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Sets.immutable.of(FilePath.class, FlowNode.class, Run.class, TaskListener.class).castToSet();
+        }
+
+        /**
+         * Returns a model with all available charsets.
+         *
+         * @return a model with all available charsets
+         */
+        public ComboBoxModel doFillSourceCodeEncodingItems() {
+            return model.getAllCharsets();
+        }
+
+        /**
+         * Returns a model with all available severity filters.
+         *
+         * @return a model with all available severity filters
+         */
+        public ListBoxModel doFillMinimumSeverityItems() {
+            return model.getAllSeverityFilters();
+        }
+
+        /**
+         * Returns the model with the possible reference jobs.
+         *
+         * @return the model with the possible reference jobs
+         */
+        public ComboBoxModel doFillReferenceJobNameItems() {
+            return model.getAllJobs();
+        }
+
+        /**
+         * Performs on-the-fly validation of the reference job.
+         *
+         * @param referenceJobName
+         *         the reference job
+         *
+         * @return the validation result
+         */
+        public FormValidation doCheckReferenceJobName(@QueryParameter final String referenceJobName) {
+            return model.validateJob(referenceJobName);
+        }
+
+        /**
+         * Performs on-the-fly validation of the character encoding.
+         *
+         * @param reportEncoding
+         *         the character encoding
+         *
+         * @return the validation result
+         */
+        public FormValidation doCheckReportEncoding(@QueryParameter final String reportEncoding) {
+            return model.validateCharset(reportEncoding);
+        }
+
+        /**
+         * Performs on-the-fly validation on the character encoding.
+         *
+         * @param sourceCodeEncoding
+         *         the character encoding
+         *
+         * @return the validation result
+         */
+        public FormValidation doCheckSourceCodeEncoding(@QueryParameter final String sourceCodeEncoding) {
+            return model.validateCharset(sourceCodeEncoding);
+        }
+
+        /**
+         * Performs on-the-fly validation of the health report thresholds.
+         *
+         * @param healthy
+         *         the healthy threshold
+         * @param unhealthy
+         *         the unhealthy threshold
+         *
+         * @return the validation result
+         */
+        public FormValidation doCheckHealthy(@QueryParameter final int healthy, @QueryParameter final int unhealthy) {
+            return model.validateHealthy(healthy, unhealthy);
+        }
+
+        /**
+         * Performs on-the-fly validation of the health report thresholds.
+         *
+         * @param healthy
+         *         the healthy threshold
+         * @param unhealthy
+         *         the unhealthy threshold
+         *
+         * @return the validation result
+         */
+        public FormValidation doCheckUnhealthy(@QueryParameter final int healthy, @QueryParameter final int unhealthy) {
+            return model.validateUnhealthy(healthy, unhealthy);
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
@@ -49,15 +49,22 @@ public enum QualityGateStatus {
     }
 
     /**
+     * Returns the associated {@link Result}.
+     *
+     * @return the associated {@link Result}
+     */
+    public Result getResult() {
+        return result;
+    }
+
+    /**
      * Sets the result of the specified run to the associated value of this quality gate status.
      *
      * @param run
      *         the run to set the result for
      */
     public void setResult(final Run<?, ?> run) {
-        if (!isSuccessful()) {
-            run.setResult(result);
-        }
+        new QualityGateStatusHandler.SetBuildResultStatusHandler(run).handleStatus(this);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
@@ -58,16 +58,6 @@ public enum QualityGateStatus {
     }
 
     /**
-     * Sets the result of the specified run to the associated value of this quality gate status.
-     *
-     * @param run
-     *         the run to set the result for
-     */
-    public void setResult(final Run<?, ?> run) {
-        new QualityGateStatusHandler.SetBuildResultStatusHandler(run).handleStatus(this);
-    }
-
-    /**
      * Returns whether this status is worse than the specified status.
      *
      * @param other

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusHandler.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusHandler.java
@@ -1,0 +1,80 @@
+package io.jenkins.plugins.analysis.core.util;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+
+/**
+ * Interface used to handle {@link QualityGateStatus}. Default implementation is {@link SetBuildResultStatusHandler}
+ */
+public interface QualityGateStatusHandler {
+
+    /**
+     * Called to handle the {@link QualityGateStatus} created by a
+     * {@link QualityGateEvaluator#evaluate(IssuesStatistics, FormattedLogger)} call.
+     *
+     * @param status
+     *         the status to handle
+     */
+    void handleStatus(QualityGateStatus status);
+
+    /**
+     * {@link QualityGateStatusHandler} that sets the overall build result if the status is unsuccessful.
+     */
+    class SetBuildResultStatusHandler implements QualityGateStatusHandler {
+        private final Run<?, ?> run;
+
+        /**
+         * Creates a new instance of {@link SetBuildResultStatusHandler}.
+         *
+         * @param run
+         *         the run to set the result for
+         */
+        public SetBuildResultStatusHandler(final Run<?, ?> run) {
+            this.run = run;
+        }
+
+        @Override
+        public void handleStatus(final QualityGateStatus status) {
+            if (!status.isSuccessful()) {
+                run.setResult(status.getResult());
+            }
+        }
+    }
+
+    /**
+     * {@link QualityGateStatusHandler} that sets the overall build result and annotates the given
+     * Pipeline step with a {@link WarningAction} if the status is unsuccessful.
+     */
+    class PipelineStatusHandler implements QualityGateStatusHandler {
+        private final Run<?, ?> run;
+        private final FlowNode flowNode;
+
+        /**
+         * Creates a new instance of {@link PipelineStatusHandler}.
+         *
+         * @param run
+         *         the run to set the result for
+         * @param flowNode
+         *         the flow node to add a warning to
+         */
+        public PipelineStatusHandler(final Run<?, ?> run, final FlowNode flowNode) {
+            this.run = run;
+            this.flowNode = flowNode;
+        }
+
+        @Override
+        public void handleStatus(final QualityGateStatus status) {
+            if (!status.isSuccessful()) {
+                Result result = status.getResult();
+                run.setResult(result);
+                WarningAction existing = flowNode.getPersistentAction(WarningAction.class);
+                if (existing == null || existing.getResult().isBetterThan(result)) {
+                    flowNode.addOrReplaceAction(new WarningAction(result)
+                            .withMessage("Some quality gates have been missed: overall result is " + status));
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/config.jelly
@@ -1,0 +1,25 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:i="/issues" xmlns:f="/lib/form">
+
+  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/custom-style.css"/>
+
+  <f:entry title="${%title.tool}" >
+    <div id="tools">
+      <f:repeatableProperty minimum="1" field="toolProxies" add="${%Add Tool}" />
+    </div>
+  </f:entry>
+
+  <f:entry title="${%title.aggregatingResults}" description="${%description.aggregatingResults}" field="aggregatingResults">
+    <f:checkbox />
+  </f:entry>
+
+  <f:entry title="${%title.enabledForFailure}" description="${%description.enabledForFailure}" field="enabledForFailure">
+    <f:checkbox />
+  </f:entry>
+
+  <f:advanced>
+    <i:scan-parameters/>
+    <i:publish-parameters/>
+  </f:advanced>
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/config.properties
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/config.properties
@@ -1,0 +1,8 @@
+title.tool=Static Analysis Tools
+description.tool=Select one or more static analysis tools.
+
+title.enabledForFailure=Run always
+description.enabledForFailure=Enable recording for failed builds.
+
+title.aggregatingResults=Aggregate results
+description.aggregatingResults=Aggregate results of all tools into a single result.

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-aggregatingResults.html
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-aggregatingResults.html
@@ -1,0 +1,4 @@
+By default, each static analysis result will be recorded as a separate result
+that is presented as an individual Jenkins Action with separate UI and dashboard. If you rather prefer aggregation
+of the results into a single result (i.e., single Jenkins Action), then activate this check box. You still can
+see the distribution of issues grouped by static analysis tool in the UI.

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-enabledForFailure.html
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-enabledForFailure.html
@@ -1,0 +1,3 @@
+By default, static analysis results are only recorded for stable or unstable builds, but not for failed builds:
+analysis results might be inaccurate if the build failed. If recording should be enabled for failed builds as well
+then activate this check box.

--- a/src/test/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusHandlerTest.java
@@ -8,11 +8,7 @@ import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link QualityGateStatusHandler}.
@@ -33,7 +29,8 @@ class QualityGateStatusHandlerTest {
     }
 
     @Test
-    void pipelineHandlerShouldSetBuildResultAndAddWarningAction() throws Exception {
+    void pipelineHandlerShouldSetBuildResultAndAddWarningAction()
+            throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
         Run run = mock(Run.class);
         FlowNode flowNode = mock(FlowNode.class);
         // Needed to keep `FlowNode.getPersistentAction` from failing. We can't mock the method directly because it's final.

--- a/src/test/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusHandlerTest.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.analysis.core.util;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import java.lang.reflect.Field;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the class {@link QualityGateStatusHandler}.
+ */
+class QualityGateStatusHandlerTest {
+    @Test
+    void defaultHandlerShouldSetBuildResult() {
+        Run run = mock(Run.class);
+        QualityGateStatusHandler defaultHandler = new QualityGateStatusHandler.SetBuildResultStatusHandler(run);
+        defaultHandler.handleStatus(QualityGateStatus.PASSED);
+        verify(run, never()).setResult(any());
+        defaultHandler.handleStatus(QualityGateStatus.INACTIVE);
+        verify(run, never()).setResult(any());
+        defaultHandler.handleStatus(QualityGateStatus.WARNING);
+        verify(run).setResult(Result.UNSTABLE);
+        defaultHandler.handleStatus(QualityGateStatus.FAILED);
+        verify(run).setResult(Result.FAILURE);
+    }
+
+    @Test
+    void pipelineHandlerShouldSetBuildResultAndAddWarningAction() throws Exception {
+        Run run = mock(Run.class);
+        FlowNode flowNode = mock(FlowNode.class);
+        // Needed to keep `FlowNode.getPersistentAction` from failing. We can't mock the method directly because it's final.
+        Field actions = FlowNode.class.getDeclaredField("actions");
+        actions.setAccessible(true);
+        actions.set(flowNode, new CopyOnWriteArrayList<>());
+        QualityGateStatusHandler pipelineHandler = new QualityGateStatusHandler.PipelineStatusHandler(run, flowNode);
+        pipelineHandler.handleStatus(QualityGateStatus.PASSED);
+        verify(run, never()).setResult(any());
+        verify(flowNode, never()).addOrReplaceAction(any());
+        pipelineHandler.handleStatus(QualityGateStatus.INACTIVE);
+        verify(run, never()).setResult(any());
+        verify(flowNode, never()).addOrReplaceAction(any());
+        pipelineHandler.handleStatus(QualityGateStatus.WARNING);
+        verify(run).setResult(Result.UNSTABLE);
+        verify(flowNode).addOrReplaceAction(refEq(new WarningAction(Result.UNSTABLE)
+                .withMessage("Some quality gates have been missed: overall result is WARNING")));
+        pipelineHandler.handleStatus(QualityGateStatus.FAILED);
+        verify(flowNode).addOrReplaceAction(refEq(new WarningAction(Result.FAILURE)
+                .withMessage("Some quality gates have been missed: overall result is FAILED")));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/util/QualityGateStatusTest.java
@@ -3,10 +3,8 @@ package io.jenkins.plugins.analysis.core.util;
 import org.junit.jupiter.api.Test;
 
 import hudson.model.Result;
-import hudson.model.Run;
 
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link QualityGateStatus}.
@@ -20,19 +18,6 @@ class QualityGateStatusTest {
         assertThat(QualityGateStatus.INACTIVE).isSuccessful().hasColor(Result.NOT_BUILT.color);
         assertThat(QualityGateStatus.WARNING).isNotSuccessful().hasColor(Result.UNSTABLE.color);
         assertThat(QualityGateStatus.FAILED).isNotSuccessful().hasColor(Result.FAILURE.color);
-    }
-    
-    @Test
-    void shouldSetResult() {
-        Run run = mock(Run.class);
-        QualityGateStatus.PASSED.setResult(run);
-        verify(run, never()).setResult(any());
-        QualityGateStatus.INACTIVE.setResult(run);
-        verify(run, never()).setResult(any());
-        QualityGateStatus.WARNING.setResult(run);
-        verify(run).setResult(Result.UNSTABLE);
-        QualityGateStatus.FAILED.setResult(run);
-        verify(run).setResult(Result.FAILURE);
     }
 
     @Test


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-api-plugin/pull/91 and [JENKINS-39203](https://issues.jenkins-ci.org/browse/JENKINS-39203). (I am intentionally not updating the status of that ticket or assigning it to myself until I am ready to merge/release all relevant changes to avoid giving users premature hope of a fix and so that I have clear answers for what will and won't work and when any fixes will be released.)

This PR adds a `WarningAction` to the `StepAtomNode` for `publishIssues` steps that complete with `QualityGateStatus.WARNING` so that the actual stage containing the `publishIssues` step can be visualized as unstable via https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/25. The PR also incrementalifies the plugin (See [JEP-305](https://github.com/jenkinsci/jep/blob/master/jep/305/README.adoc) for details) in order to consume an incremental dependency of workflow-api with the new `WarningAction` class.

As a first pass the new logic is just baked directly into `PublishIssuesStep` because it's Pipeline-specific. Another idea I had was to create some kind of `ResultHandler` class that can be passed to `IssuePublisher` and then to a new `QualityGateStatus.setResult(ResultHandler)` method, but I wasn't sure if we wanted to make those kinds of changes if `publishIssues` is  the only caller that would actually use `ResultHandler`. I added a basic integration test to show that the action is added, but if you think it has low value I am happy to delete it or adjust it as desired.