### PR TITLE
Use the default ID `analysis` for multiple reports if no ID is given (JENKINS-58977)

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -75,6 +75,7 @@ import io.jenkins.plugins.analysis.core.util.StageResultHandler;
 @SuppressWarnings({"PMD.ExcessivePublicCount", "PMD.ExcessiveClassLength", "PMD.ExcessiveImports", "PMD.TooManyFields", "PMD.DataClass", "ClassDataAbstractionCoupling", "ClassFanOutComplexity"})
 public class IssuesRecorder extends Recorder {
     static final String NO_REFERENCE_JOB = "-";
+    static final String DEFAULT_ID = "analysis";
 
     private List<Tool> analysisTools = new ArrayList<>();
 
@@ -516,7 +517,7 @@ public class IssuesRecorder extends Recorder {
             final StageResultHandler statusHandler)
             throws IOException, InterruptedException {
         if (isAggregatingResults && analysisTools.size() > 1) {
-            AnnotatedReport totalIssues = new AnnotatedReport(StringUtils.defaultIfEmpty(id, "analysis"));
+            AnnotatedReport totalIssues = new AnnotatedReport(StringUtils.defaultIfEmpty(id, DEFAULT_ID));
             for (Tool tool : analysisTools) {
                 totalIssues.add(scanWithTool(run, workspace, listener, tool), tool.getActualId());
             }

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -774,14 +774,18 @@ public class PublishIssuesStep extends Step {
             QualityGateEvaluator qualityGate = new QualityGateEvaluator();
             qualityGate.addAll(qualityGates);
 
-            AnnotatedReport report = new AnnotatedReport(StringUtils.defaultIfEmpty(id, reports.get(0).getId()));
+            AnnotatedReport report;
             if (reports.size() > 1) {
+                report = new AnnotatedReport(StringUtils.defaultIfEmpty(id, IssuesRecorder.DEFAULT_ID));
                 report.logInfo("Aggregating reports of:");
                 LabelProviderFactory factory = new LabelProviderFactory();
                 for (AnnotatedReport subReport : reports) {
                     StaticAnalysisLabelProvider labelProvider = factory.create(subReport.getId());
                     report.logInfo("-> %s", labelProvider.getToolTip(subReport.size()));
                 }
+            }
+            else {
+                report = new AnnotatedReport(StringUtils.defaultIfEmpty(id, reports.get(0).getId())); // use ID from single report
             }
             report.addAll(reports);
 

--- a/src/test/java/io/jenkins/plugins/analysis/warnings/StepsITest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/warnings/StepsITest.java
@@ -232,7 +232,7 @@ public class StepsITest extends IntegrationTestWithJenkinsPerTest {
     public void shouldCombineIssuesOfSeveralFiles() {
         publishResultsWithIdAndName(
                 "publishIssues issues:[java, eclipse, javadoc]",
-                "java", "Java Warnings");
+                "analysis", "Static Analysis");
     }
 
     /** Runs the JavaDoc parser and uses a message filter to change the number of recorded warnings. */


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-58977.