### PR TITLE
Remove git-forensics dependency, add it as integration test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <script-security.version>1.58</script-security.version>
     <folder-plugin.version>6.1.2</folder-plugin.version>
     <credentials.version>2.1.14</credentials.version>
-    <httpcomponents-client.version>4.5.3-2.0</httpcomponents-client.version>
+    <httpcomponents-client.version>4.5.3-2.1</httpcomponents-client.version>
 
     <!-- Maven plug-in versions -->
     <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -341,12 +341,6 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>git-forensics</artifactId>
-      <version>${git-forensics-plugin.version}</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
       <artifactId>forensics-api</artifactId>
       <version>${forensics-api-plugin.version}</version>
     </dependency>
@@ -363,6 +357,12 @@
       <artifactId>forensics-api</artifactId>
       <version>${forensics-api-plugin.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>git-forensics</artifactId>
+      <version>${git-forensics-plugin.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <script-security.version>1.58</script-security.version>
     <folder-plugin.version>6.1.2</folder-plugin.version>
     <credentials.version>2.1.14</credentials.version>
+    <httpcomponents-client.version>4.5.3-2.0</httpcomponents-client.version>
 
     <!-- Maven plug-in versions -->
     <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>
@@ -320,10 +321,17 @@
       <artifactId>antisamy-markup-formatter</artifactId>
       <version>${antisamy-markup-formatter.version}</version>
     </dependency>
+
+    <!-- AxivionSuite Dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>${credentials.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <version>${httpcomponents-client.version}</version>
     </dependency>
 
     <!-- Optional Jenkins Plug-in Dependencies -->


### PR DESCRIPTION
There is no need to have it as an optional dependency anymore.