### PR TITLE
[JENKINS-59172] load documentation from GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>Warnings Next Generation Plugin</name>
   <version>6.0.3-SNAPSHOT</version>
-  <url>https://wiki.jenkins.io/x/1YTeCQ</url>
+  <url>https://github.com/jenkinsci/warnings-ng-plugin</url>
   <description>Jenkins Warnings Next Generation plugin collects compiler warnings or issues reported by static
     analysis tools and visualizes the results. It has built-in support for numerous static analysis tools
     (including several compilers), see the list of supported report formats.


### PR DESCRIPTION
See [JENKINS-59172](https://issues.jenkins-ci.org/browse/JENKINS-59172). The goal is to avoid duplicating effort updating docs in two places. 