### PR TITLE
[JENKINS-56264] Use build numbers in URLs, not display name

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
@@ -31,7 +31,7 @@ public class HealthTrendChart implements TrendChart {
         LinesDataSet dataSet = builder.createDataSet(configuration, results);
 
         LinesChartModel model = new LinesChartModel();
-        model.addXAxisLabels(dataSet.getXAxisLabels());
+        model.setXAxisLabels(dataSet.getXAxisLabels());
 
         if (healthDescriptor.isEnabled()) {
             LineSeries healthy = createSeries(Messages.Healthy_Name(), Palette.GREEN);

--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/LinesChartModel.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/LinesChartModel.java
@@ -22,6 +22,7 @@ import io.jenkins.plugins.analysis.core.util.JacksonFacade;
 @SuppressWarnings("PMD.DataClass")
 public class LinesChartModel {
     private final List<String> xAxisLabels = new ArrayList<>();
+    private final List<Integer> buildNumbers = new ArrayList<>();
     private final List<LineSeries> series = new ArrayList<>();
     private String id;
 
@@ -53,21 +54,21 @@ public class LinesChartModel {
     /**
      * Adds the specified X axis labels to this model.
      *
-     * @param builds
+     * @param labels
      *         the X-axis labels of the model
      */
-    void addXAxisLabels(final List<String> builds) {
-        xAxisLabels.addAll(builds);
+    void setXAxisLabels(final List<String> labels) {
+        xAxisLabels.addAll(labels);
     }
 
     /**
-     * Adds the specified X axis label to this model.
+     * Adds the specified build numbers to this model.
      *
-     * @param build
-     *         the X-axis label of the model
+     * @param builds
+     *         the build numbers of the model
      */
-    void addXAxisLabel(final String build) {
-        xAxisLabels.add(0, build);
+    void setBuildNumbers(final List<Integer> builds) {
+        buildNumbers.addAll(builds);
     }
 
     /**
@@ -93,6 +94,10 @@ public class LinesChartModel {
     @JsonProperty("xAxisLabels")
     public List<String> getXAxisLabels() {
         return xAxisLabels;
+    }
+
+    public List<Integer> getBuildNumbers() {
+        return buildNumbers;
     }
 
     public List<LineSeries> getSeries() {

--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/LinesDataSet.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/LinesDataSet.java
@@ -19,6 +19,7 @@ import edu.hm.hafner.util.Ensure;
 public class LinesDataSet {
     private final Map<String, List<Integer>> dataSetSeries = new HashMap<>();
     private final List<String> xAxisLabels = new ArrayList<>();
+    private final List<Integer> buildNumbers = new ArrayList<>();
 
     int getXAxisSize() {
         return xAxisLabels.size();
@@ -70,5 +71,31 @@ public class LinesDataSet {
             dataSetSeries.putIfAbsent(dataPoints.getKey(), new ArrayList<>());
             dataSetSeries.get(dataPoints.getKey()).add(dataPoints.getValue());
         }
+    }
+
+    /**
+     * Adds data points for a new xAxisLabel. The data points for the X-axis tick are given by a map. Each dataSetId
+     * provides one value for the specified X-axis label.
+     *
+     * @param xAxisLabel
+     *         the label of the X-axis
+     * @param dataSetValues
+     *         the values for each of the series at the given X-axis tick
+     * @param buildNumber
+     *         the number of the associated build
+     */
+    public void add(final String xAxisLabel, final Map<String, Integer> dataSetValues, final int buildNumber) {
+        add(xAxisLabel, dataSetValues);
+
+        if (buildNumbers.contains(buildNumber)) {
+            throw new IllegalStateException("Build number already registered: " + buildNumber);
+        }
+
+
+        buildNumbers.add(buildNumber);
+    }
+
+    List<Integer> getBuildNumbers() {
+        return buildNumbers;
     }
 }

--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChart.java
@@ -17,7 +17,7 @@ public class NewVersusFixedTrendChart implements TrendChart {
         LinesDataSet dataSet = builder.createDataSet(configuration, results);
 
         LinesChartModel model = new LinesChartModel();
-        model.addXAxisLabels(dataSet.getXAxisLabels());
+        model.setXAxisLabels(dataSet.getXAxisLabels());
 
         LineSeries newSeries = getSeries(dataSet, Messages.New_Warnings_Short(), Palette.RED,
                 NewVersusFixedSeriesBuilder.NEW);

--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/SeriesBuilder.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/SeriesBuilder.java
@@ -128,7 +128,7 @@ abstract class SeriesBuilder {
             final SortedMap<AnalysisBuild, Map<String, Integer>> valuesPerBuild) {
         LinesDataSet model = new LinesDataSet();
         for (Entry<AnalysisBuild, Map<String, Integer>> series : valuesPerBuild.entrySet()) {
-            model.add(series.getKey().getDisplayName(), series.getValue());
+            model.add(series.getKey().getDisplayName(), series.getValue(), series.getKey().getNumber());
         }
         return model;
     }

--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
@@ -22,7 +22,8 @@ public class SeverityTrendChart implements TrendChart {
         LinesDataSet dataSet = builder.createDataSet(configuration, results);
 
         LinesChartModel model = new LinesChartModel();
-        model.addXAxisLabels(dataSet.getXAxisLabels());
+        model.setXAxisLabels(dataSet.getXAxisLabels());
+        model.setBuildNumbers(dataSet.getBuildNumbers());
 
         Severity[] visibleSeverities
                 = {Severity.WARNING_LOW, Severity.WARNING_NORMAL, Severity.WARNING_HIGH, Severity.ERROR};

--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/ToolsTrendChart.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/ToolsTrendChart.java
@@ -30,7 +30,7 @@ public class ToolsTrendChart implements TrendChart {
             model.addSeries(lineSeries);
         }
 
-        model.addXAxisLabels(lineModel.getXAxisLabels());
+        model.setXAxisLabels(lineModel.getXAxisLabels());
 
         return model;
     }

--- a/src/main/webapp/js/simple-trend-chart.js
+++ b/src/main/webapp/js/simple-trend-chart.js
@@ -6,21 +6,22 @@
  * @param {String} urlName - the URL to the results, if empty or unset then clicking on the chart is disabled
  */
 function renderTrendChart(chartDivId, model, urlName) {
-    var chartModel = JSON.parse(model);
-    var chartPlaceHolder = document.getElementById(chartDivId);
-    var currentSelection; // the tooltip formatter will change this value while hoovering
+    let chartModel = JSON.parse(model);
+    let chartPlaceHolder = document.getElementById(chartDivId);
+
+    let selectedBuild; // the tooltip formatter will change this value while hoovering
 
     if (urlName) {
         chartPlaceHolder.onclick = function () {
-            if (urlName && currentSelection) {
-                window.location.assign(currentSelection.substring(1) + '/' + urlName);
+            if (urlName && selectedBuild > 0) {
+                window.location.assign(selectedBuild + '/' + urlName);
             }
         };
     }
 
-    var chart = echarts.init(chartPlaceHolder);
+    let chart = echarts.init(chartPlaceHolder);
     chartPlaceHolder.echart = chart;
-    var options = {
+    let options = {
         tooltip: {
             trigger: 'axis',
             axisPointer: {
@@ -31,12 +32,21 @@ function renderTrendChart(chartDivId, model, urlName) {
             },
             formatter: function (params, ticket, callback) {
                 if (params.componentType === 'legend') {
-                    currentSelection = null;
+                    selectedBuild = 0;
                     return params.name;
                 }
-                currentSelection = params[0].name;
-                var text = 'Build ' + params[0].name;
-                for (var i = 0, l = params.length; i < l; i++) {
+
+                let builds = chartModel.buildNumbers;
+                let labels = chartModel.xAxisLabels;
+                for (let i = 0; i < builds.length; i++) {
+                    if (params[0].name === labels[i]) {
+                        selectedBuild = builds[i];
+                        break;
+                    }
+                }
+
+                let text = 'Build ' + params[0].name;
+                for (let i = 0, l = params.length; i < l; i++) {
                     text += '<br/>' + params[i].marker + params[i].seriesName + ' : ' + params[i].value;
                 }
                 text += '<br />';
@@ -70,7 +80,7 @@ function renderTrendChart(chartDivId, model, urlName) {
     };
     chart.setOption(options);
     chart.on('legendselectchanged', function (params) {
-            currentSelection = null; // clear selection to avoid navigating to the selected build
+            selectedBuild = 0; // clear selection to avoid navigating to the selected build
         }
     );
     chart.resize();

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/LinesChartModelTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/LinesChartModelTest.java
@@ -41,7 +41,7 @@ class LinesChartModelTest {
         assertThat(model.size()).isEqualTo(3);
         assertThat(model.getXAxisLabels()).hasSize(3);
         assertThat(model.toString()).isEqualTo(
-                "{\"series\":[],\"id\":\"spotbugs\",\"xAxisLabels\":[\"#1\",\"#2\",\"#3\"]}");
+                "{\"buildNumbers\":[],\"series\":[],\"id\":\"spotbugs\",\"xAxisLabels\":[\"#1\",\"#2\",\"#3\"]}");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/LinesChartModelTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/LinesChartModelTest.java
@@ -36,7 +36,7 @@ class LinesChartModelTest {
     void shouldAddLabels() {
         LinesChartModel model = new LinesChartModel(ID);
 
-        model.addXAxisLabels(BUILDS);
+        model.setXAxisLabels(BUILDS);
 
         assertThat(model.size()).isEqualTo(3);
         assertThat(model.getXAxisLabels()).hasSize(3);
@@ -66,17 +66,17 @@ class LinesChartModelTest {
     @Test
     void testGetXAxisLabels() {
         LinesChartModel modelForSingleXAxisLabelTest = new LinesChartModel(ID);
-        modelForSingleXAxisLabelTest.addXAxisLabel("a");
+        modelForSingleXAxisLabelTest.setXAxisLabels(Collections.singletonList("a"));
         assertThat(modelForSingleXAxisLabelTest.getXAxisLabels())
                 .hasSize(1)
                 .isEqualTo(Collections.singletonList("a"));
 
         LinesChartModel modelForXAxisListLabelTest = new LinesChartModel(ID);
-        modelForXAxisListLabelTest.addXAxisLabels(Arrays.asList("a", "b", "c"));
+        modelForXAxisListLabelTest.setXAxisLabels(Arrays.asList("a", "b", "c"));
         assertThat(modelForXAxisListLabelTest.getXAxisLabels())
                 .hasSize(3)
                 .isEqualTo(Arrays.asList("a", "b", "c"));
-        modelForXAxisListLabelTest.addXAxisLabels(Arrays.asList("d", "e", "f"));
+        modelForXAxisListLabelTest.setXAxisLabels(Arrays.asList("d", "e", "f"));
         assertThat(modelForXAxisListLabelTest.getXAxisLabels())
                 .hasSize(6)
                 .isEqualTo(Arrays.asList("a", "b", "c", "d", "e", "f"));
@@ -100,7 +100,7 @@ class LinesChartModelTest {
             }
         }
 
-        model.addXAxisLabels(builds);
+        model.setXAxisLabels(builds);
         model.addSeries(series);
 
         assertThatJson(model).node("xAxisLabels")

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/LinesDataSetTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/LinesDataSetTest.java
@@ -9,25 +9,28 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.*;
 
 /**
- * Testclass for LinesDataSet.
+ * Test the class {@link LinesDataSet}.
  *
  * @author Lorenz Munsch
+ * @author Ullrich Hafner
  */
 class LinesDataSetTest {
     private static final String X_AXIS_LABEL = "X_AXIS_LABEL";
     private static final String FIRST_DATA_SET = "Eins";
     private static final String SECOND_DATA_SET = "Zwei";
+    private static final String ANOTHER_LABEL = "another-label";
 
     @Test
-    void shouldAddAndVerifySeries() {
+    void shouldAddSeries() {
         LinesDataSet linesDataSet  = new LinesDataSet();
         assertThat(linesDataSet.getXAxisSize()).isEqualTo(0);
         assertThat(linesDataSet.hasSeries(FIRST_DATA_SET)).isFalse();
 
-        linesDataSet.add(X_AXIS_LABEL, createSeries());
+        linesDataSet.add(X_AXIS_LABEL, createSeries(1));
         assertThat(linesDataSet.getXAxisSize()).isEqualTo(1);
         assertThat(linesDataSet.getXAxisLabels()).containsOnly(X_AXIS_LABEL);
         assertThat(linesDataSet.getDataSetIds()).containsOnlyOnce(FIRST_DATA_SET, SECOND_DATA_SET);
+        assertThat(linesDataSet.getBuildNumbers()).isEmpty();
 
         assertThat(linesDataSet.hasSeries(FIRST_DATA_SET)).isTrue();
         assertThat(linesDataSet.getSeries(FIRST_DATA_SET)).containsOnly(1);
@@ -37,10 +40,42 @@ class LinesDataSetTest {
     }
 
     @Test
+    void shouldAddSeriesWithUrls() {
+        LinesDataSet linesDataSet  = new LinesDataSet();
+        assertThat(linesDataSet.getXAxisSize()).isEqualTo(0);
+        assertThat(linesDataSet.hasSeries(FIRST_DATA_SET)).isFalse();
+
+        linesDataSet.add(X_AXIS_LABEL, createSeries(1), 1);
+        assertThat(linesDataSet.getXAxisSize()).isEqualTo(1);
+        assertThat(linesDataSet
+                .getXAxisLabels()).containsOnly(X_AXIS_LABEL);
+        assertThat(linesDataSet.getBuildNumbers()).containsOnly(1);
+        assertThat(linesDataSet.getDataSetIds()).containsOnlyOnce(FIRST_DATA_SET, SECOND_DATA_SET);
+
+        assertThat(linesDataSet.hasSeries(FIRST_DATA_SET)).isTrue();
+        assertThat(linesDataSet.getSeries(FIRST_DATA_SET)).containsOnly(1);
+
+        assertThat(linesDataSet.hasSeries(SECOND_DATA_SET)).isTrue();
+        assertThat(linesDataSet.getSeries(SECOND_DATA_SET)).containsOnly(2);
+
+        linesDataSet.add(ANOTHER_LABEL, createSeries(3), 2);
+        assertThat(linesDataSet.getXAxisSize()).isEqualTo(2);
+        assertThat(linesDataSet.getXAxisLabels()).containsOnly(X_AXIS_LABEL, ANOTHER_LABEL);
+        assertThat(linesDataSet.getBuildNumbers()).containsOnly(1, 2);
+        assertThat(linesDataSet.getDataSetIds()).containsOnlyOnce(FIRST_DATA_SET, SECOND_DATA_SET);
+
+        assertThat(linesDataSet.hasSeries(FIRST_DATA_SET)).isTrue();
+        assertThat(linesDataSet.getSeries(FIRST_DATA_SET)).containsExactly(1, 3);
+
+        assertThat(linesDataSet.hasSeries(SECOND_DATA_SET)).isTrue();
+        assertThat(linesDataSet.getSeries(SECOND_DATA_SET)).containsExactly(2, 4);
+    }
+
+    @Test
     void shouldThrowExceptionIfSeriesDoesNotExist() {
         LinesDataSet linesDataSet  = new LinesDataSet();
 
-        linesDataSet.add(X_AXIS_LABEL, createSeries());
+        linesDataSet.add(X_AXIS_LABEL, createSeries(1));
 
         assertThatThrownBy(() -> linesDataSet.getSeries("WrongId"))
                 .isInstanceOf(AssertionError.class)
@@ -56,15 +91,25 @@ class LinesDataSetTest {
         linesDataSet.add(X_AXIS_LABEL, dataSetSeries);
         assertThatThrownBy(() -> linesDataSet.add(X_AXIS_LABEL, dataSetSeries))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Label already registered:");
+                .hasMessage("Label already registered: " + X_AXIS_LABEL);
     }
 
-    private Map<String, Integer> createSeries() {
+    @Test
+    void shouldThrowExceptionIfSameBuildNumberIsAddedTwice() {
+        LinesDataSet linesDataSet  = new LinesDataSet();
+        Map<String, Integer>  dataSetSeries = Collections.emptyMap();
+
+        linesDataSet.add(X_AXIS_LABEL, dataSetSeries, 1);
+        assertThatThrownBy(() -> linesDataSet.add(ANOTHER_LABEL, dataSetSeries, 1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Build number already registered: 1");
+    }
+
+    private Map<String, Integer> createSeries(final int start) {
         Map<String, Integer> dataSetSeries = new HashMap<>();
-        dataSetSeries.put(FIRST_DATA_SET, 1);
-        dataSetSeries.put(SECOND_DATA_SET, 2);
+        dataSetSeries.put(FIRST_DATA_SET, start);
+        dataSetSeries.put(SECOND_DATA_SET, start + 1);
 
         return dataSetSeries;
     }
-
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.*;
  */
 class SeverityTrendChartTest {
     @Test
-    void shouldCreatePriorityChartForJobAndMultipleActions() {
+    void shouldCreatePriorityChartWithDifferentDisplayNames() {
         SeverityTrendChart chart = new SeverityTrendChart();
 
         List<AnalysisBuildResult> resultsCheckStyle = new ArrayList<>();
@@ -45,6 +45,8 @@ class SeverityTrendChartTest {
 
         assertThatJson(model).node("xAxisLabels")
                 .isArray().hasSize(2).containsExactly("#1", "#2");
+        assertThatJson(model).node("buildNumbers")
+                .isArray().hasSize(2).containsExactly(1, 2);
         assertThatJson(model).node("series")
                 .isArray().hasSize(4);
     }
@@ -68,6 +70,8 @@ class SeverityTrendChartTest {
 
         assertThatJson(model).node("xAxisLabels")
                 .isArray().hasSize(4).containsExactly("#1", "#2", "#3", "#4");
+        assertThatJson(model).node("buildNumbers")
+                .isArray().hasSize(4).containsExactly(1, 2, 3, 4);
         assertThatJson(model).node("series")
                 .isArray().hasSize(4);
     }
@@ -87,9 +91,9 @@ class SeverityTrendChartTest {
         verifySeries(model.getSeries().get(2), Severity.WARNING_HIGH, 1, 2);
 
         assertThatJson(model).node("xAxisLabels")
-                .isArray().hasSize(2)
-                .contains("#1")
-                .contains("#2");
+                .isArray().hasSize(2).containsExactly("#1", "#2");
+        assertThatJson(model).node("buildNumbers")
+                .isArray().hasSize(2).containsExactly(1, 2);
 
         assertThatJson(model).node("series")
                 .isArray().hasSize(3);
@@ -111,9 +115,9 @@ class SeverityTrendChartTest {
         verifySeries(model.getSeries().get(3), Severity.ERROR, 5, 8);
 
         assertThatJson(model).node("xAxisLabels")
-                .isArray().hasSize(2)
-                .contains("#1")
-                .contains("#2");
+                .isArray().hasSize(2).containsExactly("#1", "#2");
+        assertThatJson(model).node("buildNumbers")
+                .isArray().hasSize(2).containsExactly(1, 2);
 
         assertThatJson(model).node("series")
                 .isArray().hasSize(4);


### PR DESCRIPTION
See [JENKINS-56264](https://issues.jenkins-ci.org/browse/JENKINS-56264). 

The trend chart on the job page should use the build number in URLs. The URL is used when clicking into the trend chart at the specific x-axis position.