### PR TITLE
[JENKINS-48802] Add configuration of additional source roots (outside of workspace)

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/model/SourceRoot.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/SourceRoot.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.analysis.core.model;
+
+import java.io.Serializable;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+
+/**
+ * Defines the properties of a warnings parser that uses a Groovy script to parse the warnings log.
+ *
+ * @author Ullrich Hafner
+ */
+public class SourceRoot extends AbstractDescribableImpl<SourceRoot> implements Serializable {
+    private static final long serialVersionUID = -3864564528382064924L;
+    private final String folderName;
+
+    /**
+     * Creates a new instance of {@link SourceRoot}.
+     *
+     * @param folderName
+     *         the name of the folder
+     */
+    @DataBoundConstructor
+    public SourceRoot(final String folderName) {
+        this.folderName = folderName;
+    }
+
+    public String getFolderName() {
+        return folderName;
+    }
+
+    /**
+     * Descriptor to validate {@link SourceRoot}.
+     *
+     * @author Ullrich Hafner
+     */
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SourceRoot> {
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return StringUtils.EMPTY;
+        }
+    }
+}
+

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/GlobalConfigurationFacade.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/GlobalConfigurationFacade.java
@@ -1,0 +1,36 @@
+package io.jenkins.plugins.analysis.core.util;
+
+import jenkins.model.GlobalConfiguration;
+
+/**
+ * Facade to Jenkins {@link GlobalConfiguration} instance to prevent IO access during tests.
+ *
+ * @author Ullrich Hafner
+ */
+public class GlobalConfigurationFacade {
+    private final GlobalConfiguration configuration;
+
+    /**
+     * Creates a new facade to the specified {@link GlobalConfiguration}.
+     *
+     * @param configuration
+     *         the global configuration instance
+     */
+    public GlobalConfigurationFacade(final GlobalConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    /**
+     * Loads the data from the disk into this object.
+     */
+    public void load() {
+        configuration.load();
+    }
+
+    /**
+     * Saves the configuration info to the disk.
+     */
+    public void save() {
+        configuration.save();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/GlobalConfigurationItem.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/GlobalConfigurationItem.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.analysis.core.util;
+
+import edu.hm.hafner.util.VisibleForTesting;
+
+import jenkins.model.GlobalConfiguration;
+
+/**
+ * Testable base class for items of the {@link GlobalConfiguration} page.
+ *
+ * @author Ullrich Hafner
+ */
+public class GlobalConfigurationItem extends GlobalConfiguration {
+    private final Runnable actualLoad;
+    private final Runnable actualSave;
+
+    /**
+     * Creates a new {@link GlobalConfigurationItem}.
+     */
+    protected GlobalConfigurationItem() {
+        super();
+
+        actualLoad = super::load;
+        actualSave = super::save;
+    }
+
+    /**
+     * Creates a new {@link GlobalConfigurationItem}.
+     *
+     * @param facade
+     *         the facade to use
+     */
+    @VisibleForTesting
+    protected GlobalConfigurationItem(final GlobalConfigurationFacade facade) {
+        super();
+
+        actualLoad = facade::load;
+        actualSave = facade::save;
+    }
+
+    @Override
+    public final synchronized void load() {
+        actualLoad.run();
+    }
+
+    @Override
+    public final synchronized void save() {
+        actualSave.run();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration.java
@@ -1,0 +1,83 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import edu.hm.hafner.util.VisibleForTesting;
+
+import org.kohsuke.stapler.DataBoundSetter;
+import org.jenkinsci.Symbol;
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+
+import io.jenkins.plugins.analysis.core.model.SourceRoot;
+import io.jenkins.plugins.analysis.core.util.GlobalConfigurationFacade;
+import io.jenkins.plugins.analysis.core.util.GlobalConfigurationItem;
+import io.jenkins.plugins.analysis.warnings.groovy.ParserConfiguration;
+
+/**
+ * Global system configuration of the warnings plugin. These configuration options are used globally for all jobs and
+ * require administrator permissions.
+ *
+ * @author Ullrich Hafner
+ */
+@Extension
+@Symbol("warningsPlugin")
+public class WarningsPluginConfiguration extends GlobalConfigurationItem {
+    private List<SourceRoot> sourceRoots = Collections.emptyList();
+
+    /**
+     * Creates the global configuration for the warnings plugins.
+     */
+    public WarningsPluginConfiguration() {
+        super();
+
+        load();
+    }
+
+    @VisibleForTesting
+    WarningsPluginConfiguration(final GlobalConfigurationFacade facade) {
+        super(facade);
+
+        load();
+    }
+
+    /**
+     * Returns the singleton instance of this {@link ParserConfiguration}.
+     *
+     * @return the singleton instance
+     */
+    public static WarningsPluginConfiguration getInstance() {
+        return GlobalConfiguration.all()
+                .get(WarningsPluginConfiguration.class); // FIXME: indirectly calls Jenkins.getInstance
+    }
+
+    /**
+     * Returns the list of additional source root folders.
+     *
+     * @return the source root folders
+     */
+    public List<SourceRoot> getSourceRoots() {
+        return sourceRoots;
+    }
+
+    public List<String> getSourceRootFolders() {
+        return sourceRoots.stream().map(SourceRoot::getFolderName).collect(Collectors.toList());
+    }
+
+    /**
+     * Sets the list of available source root folders to the specified elements. Previously set source root folders will
+     * be removed.
+     *
+     * @param sourceRoots
+     *         the new source root folders
+     */
+    @DataBoundSetter
+    public void setSourceRoots(final List<SourceRoot> sourceRoots) {
+        this.sourceRoots = new ArrayList<>(sourceRoots);
+
+        save();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import edu.hm.hafner.util.NoSuchElementException;
+import edu.hm.hafner.util.VisibleForTesting;
 
 import org.kohsuke.stapler.DataBoundSetter;
 import org.jenkinsci.Symbol;
@@ -17,6 +18,8 @@ import io.jenkins.plugins.analysis.core.model.LabelProviderFactory;
 import io.jenkins.plugins.analysis.core.model.LabelProviderFactory.StaticAnalysisToolFactory;
 import io.jenkins.plugins.analysis.core.model.ReportScanningTool;
 import io.jenkins.plugins.analysis.core.model.Tool;
+import io.jenkins.plugins.analysis.core.util.GlobalConfigurationFacade;
+import io.jenkins.plugins.analysis.core.util.GlobalConfigurationItem;
 import io.jenkins.plugins.analysis.core.util.JenkinsFacade;
 
 /**
@@ -26,14 +29,21 @@ import io.jenkins.plugins.analysis.core.util.JenkinsFacade;
  */
 @Extension
 @Symbol("warningsParsers") 
-public class ParserConfiguration extends GlobalConfiguration {
+public class ParserConfiguration extends GlobalConfigurationItem {
     private List<GroovyParser> parsers = new ArrayList<>();
 
     /**
-     * Loads the configuration from disk.
+     * Creates the Groovy parser configuration for the warnings plugins.
      */
     public ParserConfiguration() {
         super();
+
+        load();
+    }
+
+    @VisibleForTesting
+    ParserConfiguration(final GlobalConfigurationFacade facade) {
+        super(facade);
 
         load();
     }
@@ -65,6 +75,7 @@ public class ParserConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setParsers(final List<GroovyParser> parsers) {
         this.parsers = new ArrayList<>(parsers);
+
         save();
     }
 

--- a/src/main/resources/io/jenkins/plugins/analysis/core/model/SourceRoot/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/model/SourceRoot/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+  <f:entry title="${%Absolute path of folder}" field="folderName">
+    <f:textbox/>
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration/config.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:i="/issues" xmlns:f="/lib/form">
+
+  <f:section title="${%Warnings Next Generation Plugin Global Settings}">
+    <f:entry title="${%sourceRoots.title}" description="${%sourceRoots.description}">
+      <i:repeatable field="sourceRoots">
+        <f:entry title="">
+          <div align="right">
+            <f:repeatableDeleteButton/>
+          </div>
+        </f:entry>
+      </i:repeatable>
+    </f:entry>
+
+  </f:section>
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration/config.properties
+++ b/src/main/resources/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration/config.properties
@@ -1,0 +1,2 @@
+sourceRoots.title=Source code roots
+sourceRoots.description=Valid and permitted source code locations on agents (outside of the workspace).

--- a/src/main/resources/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration/help-sourceRoots.html
+++ b/src/main/resources/io/jenkins/plugins/analysis/warnings/WarningsPluginConfiguration/help-sourceRoots.html
@@ -1,0 +1,7 @@
+<div>
+    The warnings plugin copies all affected source code files to Jenkins build folder, in order to show \
+    them along with the issues in the user interface. If these files are not part of the workspace of a build then \
+    the warnings plugin does not show them: otherwise sensitive files could be shown by accident. You can provide a
+    whitelist of additional source code root folders that are allowed to be shown in Jenkins UI here. Note, that these
+    folders must be absolute paths on the agent that executes the build.
+</div>

--- a/src/test/java/io/jenkins/plugins/analysis/warnings/WarningsPluginConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/warnings/WarningsPluginConfigurationTest.java
@@ -1,0 +1,41 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.jenkins.plugins.analysis.core.model.SourceRoot;
+import io.jenkins.plugins.analysis.core.util.GlobalConfigurationFacade;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link WarningsPluginConfiguration}.
+ *
+ * @author Ullrich Hafner
+ */
+class WarningsPluginConfigurationTest {
+    private static final List<SourceRoot> SOURCE_ROOTS = Arrays.asList(new SourceRoot("One"), new SourceRoot("Two"));
+
+    @Test
+    void shouldHaveNoRootFoldersWhenCreated() {
+        WarningsPluginConfiguration configuration = new WarningsPluginConfiguration(mock(GlobalConfigurationFacade.class));
+
+        assertThat(configuration.getSourceRoots()).isEmpty();
+        assertThat(configuration.getSourceRootFolders()).isEmpty();
+    }
+
+    @Test
+    void shouldSaveConfigurationIfFoldersAreAdded() {
+        GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
+
+        WarningsPluginConfiguration configuration = new WarningsPluginConfiguration(facade);
+        configuration.setSourceRoots(SOURCE_ROOTS);
+
+        verify(facade).save();
+        assertThat(configuration.getSourceRoots()).isEqualTo(SOURCE_ROOTS);
+        assertThat(configuration.getSourceRootFolders()).contains("One", "Two");
+    }
+}

--- a/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
@@ -1,0 +1,38 @@
+package io.jenkins.plugins.analysis.warnings.groovy;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.jenkins.plugins.analysis.core.util.GlobalConfigurationFacade;
+
+import static io.jenkins.plugins.analysis.core.testutil.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link ParserConfiguration}.
+ *
+ * @author Ullrich Hafner
+ */
+class ParserConfigurationTest {
+    private static final List<GroovyParser> PARSERS = Collections.singletonList(mock(GroovyParser.class));
+
+    @Test
+    void shouldHaveNoRootFoldersWhenCreated() {
+        ParserConfiguration configuration = new ParserConfiguration(mock(GlobalConfigurationFacade.class));
+
+        assertThat(configuration.getParsers()).isEmpty();
+    }
+
+    @Test
+    void shouldSaveConfigurationIfFoldersAreAdded() {
+        GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
+
+        ParserConfiguration configuration = new ParserConfiguration(facade);
+        configuration.setParsers(PARSERS);
+
+        verify(facade).save();
+        assertThat(configuration.getParsers()).isEqualTo(PARSERS);
+    }
+}


### PR DESCRIPTION
The warnings plugin copies all affected source code files to Jenkins build folder, in order to show them along with the issues in the user interface. If these files are not part of the workspace of a build then the warnings plugin does not show them: otherwise sensitive files could be shown by accident. This PR adds an option to provide source code root folders that are allowed to be shown in Jenkins UI here. Note, that these folders must be absolute paths on the agent that executes the build.

- Add a global configuration object for the source roots
- New base class for plugin configuration.
- UI configuration of source roots.