### PR TITLE
[JENKINS-58826] Fix visible number of build results in charts

### DIFF
--- a/etc/pmd-configuration.xml
+++ b/etc/pmd-configuration.xml
@@ -13,6 +13,11 @@
     <exclude name="GuardLogStatement"/>
     <exclude name="AccessorMethodGeneration"/>
   </rule>
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
+    <properties>
+      <property name="ignoredAnnotations" value="java.lang.Deprecated," />
+    </properties>
+  </rule>
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor"/>
     <exclude name="UnnecessaryConstructor"/>

--- a/etc/pmd-configuration.xml
+++ b/etc/pmd-configuration.xml
@@ -13,11 +13,6 @@
     <exclude name="GuardLogStatement"/>
     <exclude name="AccessorMethodGeneration"/>
   </rule>
-  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
-    <properties>
-      <property name="ignoredAnnotations" value="java.lang.Deprecated," />
-    </properties>
-  </rule>
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor"/>
     <exclude name="UnnecessaryConstructor"/>

--- a/src/main/java/io/jenkins/plugins/analysis/core/charts/CompositeResult.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/charts/CompositeResult.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.analysis.core.charts;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -31,7 +32,7 @@ public class CompositeResult implements Iterable<AnalysisBuildResult> {
      *         the history of results for each tool
      */
     public CompositeResult(final List<Iterable<? extends AnalysisBuildResult>> historyOfTools) {
-        SortedMap<AnalysisBuild, AnalysisBuildResult> resultsByBuild = new TreeMap<>();
+        SortedMap<AnalysisBuild, AnalysisBuildResult> resultsByBuild = new TreeMap<>(Collections.reverseOrder());
         for (Iterable<? extends AnalysisBuildResult> toolHistory : historyOfTools) {
             for (AnalysisBuildResult toolResult : toolHistory) {
                 resultsByBuild.merge(toolResult.getBuild(), toolResult, CompositeAnalysisBuildResult::new);
@@ -40,6 +41,11 @@ public class CompositeResult implements Iterable<AnalysisBuildResult> {
         results = resultsByBuild.values();
     }
 
+    /**
+     * Returns an iterator over the composition of the {@link AnalysisBuildResult static analysis results}.
+     *
+     * @return an iterator, starting with the latest build (descending order).
+     */
     @NonNull
     @Override
     public Iterator<AnalysisBuildResult> iterator() {

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/BuildResultStubs.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/BuildResultStubs.java
@@ -1,0 +1,78 @@
+package io.jenkins.plugins.analysis.core.charts;
+
+import org.eclipse.collections.impl.factory.Maps;
+
+import edu.hm.hafner.analysis.Severity;
+
+import io.jenkins.plugins.analysis.core.model.AnalysisResult.BuildProperties;
+import io.jenkins.plugins.analysis.core.util.AnalysisBuild;
+import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Provides factory methods to create {@link AnalysisBuildResult} stubs.
+ *
+ * @author Ullrich Hafner
+ */
+final class BuildResultStubs {
+    static AnalysisBuildResult createResult(final int buildNumber,
+            final int errors, final int high, final int normal, final int low) {
+        AnalysisBuildResult buildResult = createBuildResult(buildNumber);
+
+        when(buildResult.getTotalSizeOf(Severity.ERROR)).thenReturn(errors);
+        when(buildResult.getTotalSizeOf(Severity.WARNING_HIGH)).thenReturn(high);
+        when(buildResult.getTotalSizeOf(Severity.WARNING_NORMAL)).thenReturn(normal);
+        when(buildResult.getTotalSizeOf(Severity.WARNING_LOW)).thenReturn(low);
+        when(buildResult.getTotalSize()).thenReturn(low + normal + high + errors);
+
+        return buildResult;
+    }
+
+    static AnalysisBuildResult createResultWithNewIssues(final int buildNumber,
+            final int errors, final int high, final int normal, final int low) {
+        AnalysisBuildResult buildResult = createBuildResult(buildNumber);
+
+        when(buildResult.getNewSizeOf(Severity.ERROR)).thenReturn(errors);
+        when(buildResult.getNewSizeOf(Severity.WARNING_HIGH)).thenReturn(high);
+        when(buildResult.getNewSizeOf(Severity.WARNING_NORMAL)).thenReturn(normal);
+        when(buildResult.getNewSizeOf(Severity.WARNING_LOW)).thenReturn(low);
+        when(buildResult.getNewSize()).thenReturn(low + normal + high + errors);
+
+        return buildResult;
+    }
+
+    static AnalysisBuildResult createResultWithNewAndFixedIssues(final int buildNumber, final int newSize, final int fixedSize) {
+        AnalysisBuildResult buildResult = createBuildResult(buildNumber);
+
+        when(buildResult.getFixedSize()).thenReturn(fixedSize);
+        when(buildResult.getNewSize()).thenReturn(newSize);
+
+        return buildResult;
+    }
+
+    static AnalysisBuildResult createResult(final int buildNumber, final String toolId, final int total) {
+        AnalysisBuildResult buildResult = createBuildResult(buildNumber);
+
+        when(buildResult.getSizePerOrigin()).thenReturn(Maps.mutable.of(toolId, total));
+
+        return buildResult;
+    }
+
+    private static AnalysisBuildResult createBuildResult(final int buildNumber) {
+        AnalysisBuildResult buildResult = mock(AnalysisBuildResult.class);
+
+        AnalysisBuild build = createBuild(buildNumber);
+        when(buildResult.getBuild()).thenReturn(build);
+
+        return buildResult;
+    }
+
+    static AnalysisBuild createBuild(final int buildNumber) {
+        return new BuildProperties(buildNumber, "#" + buildNumber, 10);
+    }
+
+    private BuildResultStubs() {
+        // prevents instantiation
+    }
+}

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/CompositeResultTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/CompositeResultTest.java
@@ -14,6 +14,7 @@ import io.jenkins.plugins.analysis.core.charts.CompositeResult.CompositeAnalysis
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+import static io.jenkins.plugins.analysis.core.charts.BuildResultStubs.*;
 
 /**
  * Tests the class {@link CompositeResult}.
@@ -27,12 +28,12 @@ class CompositeResultTest {
     @Test
     void shouldCreateResultOfSequenceWithIdenticalBuilds() {
         List<AnalysisBuildResult> resultsCheckStyle = new ArrayList<>();
-        resultsCheckStyle.add(BuildResultStubs.createResult(2, 0, 2, 4, 6));
-        resultsCheckStyle.add(BuildResultStubs.createResult(1, 0, 1, 2, 3));
+        resultsCheckStyle.add(createResult(2, 0, 2, 4, 6));
+        resultsCheckStyle.add(createResult(1, 0, 1, 2, 3));
 
         List<AnalysisBuildResult> resultsSpotBugs = new ArrayList<>();
-        resultsSpotBugs.add(BuildResultStubs.createResult(2, 0, 12, 14, 16));
-        resultsSpotBugs.add(BuildResultStubs.createResult(1, 0, 11, 12, 13));
+        resultsSpotBugs.add(createResult(2, 0, 12, 14, 16));
+        resultsSpotBugs.add(createResult(1, 0, 11, 12, 13));
 
         CompositeResult compositeResult = new CompositeResult(asList(resultsCheckStyle, resultsSpotBugs));
 
@@ -41,13 +42,13 @@ class CompositeResultTest {
         Iterator<AnalysisBuildResult> iterator = compositeResult.iterator();
 
         AnalysisBuildResult first = iterator.next();
-        assertThat(first).hasBuild(BuildResultStubs.createBuild(2));
+        assertThat(first).hasBuild(createBuild(2));
         assertThat(first.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(14);
         assertThat(first.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(18);
         assertThat(first.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(22);
 
         AnalysisBuildResult second = iterator.next();
-        assertThat(second).hasBuild(BuildResultStubs.createBuild(1));
+        assertThat(second).hasBuild(createBuild(1));
         assertThat(second.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(12);
         assertThat(second.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(14);
         assertThat(second.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(16);
@@ -56,12 +57,12 @@ class CompositeResultTest {
     @Test
     void shouldCreatePriorityChartForJobAndMultipleActions() {
         List<AnalysisBuildResult> resultsCheckStyle = new ArrayList<>();
-        resultsCheckStyle.add(BuildResultStubs.createResult(2, CHECK_STYLE, 2));
-        resultsCheckStyle.add(BuildResultStubs.createResult(1, CHECK_STYLE, 1));
+        resultsCheckStyle.add(createResult(2, CHECK_STYLE, 2));
+        resultsCheckStyle.add(createResult(1, CHECK_STYLE, 1));
 
         List<AnalysisBuildResult> resultsSpotBugs = new ArrayList<>();
-        resultsSpotBugs.add(BuildResultStubs.createResult(2, SPOT_BUGS, 4));
-        resultsSpotBugs.add(BuildResultStubs.createResult(1, SPOT_BUGS, 3));
+        resultsSpotBugs.add(createResult(2, SPOT_BUGS, 4));
+        resultsSpotBugs.add(createResult(1, SPOT_BUGS, 3));
 
         CompositeResult compositeResult = new CompositeResult(asList(resultsCheckStyle, resultsSpotBugs));
 
@@ -71,8 +72,8 @@ class CompositeResultTest {
         AnalysisBuildResult first = iterator.next();
         AnalysisBuildResult second = iterator.next();
 
-        assertThat(first).hasBuild(BuildResultStubs.createBuild(2));
-        assertThat(second).hasBuild(BuildResultStubs.createBuild(1));
+        assertThat(first).hasBuild(createBuild(2));
+        assertThat(second).hasBuild(createBuild(1));
 
         assertThat(first.getSizePerOrigin()).contains(entry(CHECK_STYLE, 2), entry(SPOT_BUGS, 4));
         assertThat(second.getSizePerOrigin()).contains(entry(CHECK_STYLE, 1), entry(SPOT_BUGS, 3));
@@ -90,45 +91,45 @@ class CompositeResultTest {
     class CompositeAnalysisBuildResultTest {
         @Test
         void shouldMergeNumberOfTotalIssues() {
-            AnalysisBuildResult first = BuildResultStubs.createResult(1, 0, 3, 1, 6);
-            AnalysisBuildResult second = BuildResultStubs.createResult(1, 0, 1, 3, 9);
+            AnalysisBuildResult first = createResult(1, 0, 3, 1, 6);
+            AnalysisBuildResult second = createResult(1, 0, 1, 3, 9);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
+            assertThat(run).hasBuild(createBuild(1));
             assertThat(run).hasTotalSize(23);
         }
 
         @Test
         void shouldMergeNumberOfFixedIssues() {
-            AnalysisBuildResult first = BuildResultStubs.createResultWithNewAndFixedIssues(1, 0, 2);
-            AnalysisBuildResult second = BuildResultStubs.createResultWithNewAndFixedIssues(1, 0, 3);
+            AnalysisBuildResult first = createResultWithNewAndFixedIssues(1, 0, 2);
+            AnalysisBuildResult second = createResultWithNewAndFixedIssues(1, 0, 3);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
+            assertThat(run).hasBuild(createBuild(1));
             assertThat(run.getFixedSize()).isEqualTo(5);
         }
 
         @Test
         void shouldMergeNumberOfNewIssues() {
-            AnalysisBuildResult first = BuildResultStubs.createResultWithNewIssues(1, 0, 5, 2, 6);
-            AnalysisBuildResult second = BuildResultStubs.createResultWithNewIssues(1, 0, 4, 2, 7);
+            AnalysisBuildResult first = createResultWithNewIssues(1, 0, 5, 2, 6);
+            AnalysisBuildResult second = createResultWithNewIssues(1, 0, 4, 2, 7);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
+            assertThat(run).hasBuild(createBuild(1));
             assertThat(run).hasNewSize(26);
         }
 
         @Test
         void shouldMergeTotalNumberOfIssuesBySeverity() {
-            AnalysisBuildResult first = BuildResultStubs.createResult(1, 0, 1, 2, 3);
-            AnalysisBuildResult second = BuildResultStubs.createResult(1, 0, 4, 5, 6);
+            AnalysisBuildResult first = createResult(1, 0, 1, 2, 3);
+            AnalysisBuildResult second = createResult(1, 0, 4, 5, 6);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
+            assertThat(run).hasBuild(createBuild(1));
             assertThat(run.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(5);
             assertThat(run.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(7);
             assertThat(run.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(9);
@@ -136,12 +137,12 @@ class CompositeResultTest {
 
         @Test
         void shouldMergeNumberOfNewIssuesBySeverity() {
-            AnalysisBuildResult first = BuildResultStubs.createResultWithNewIssues(1, 0, 2, 6, 2);
-            AnalysisBuildResult second = BuildResultStubs.createResultWithNewIssues(1, 0, 5, 2, 2);
+            AnalysisBuildResult first = createResultWithNewIssues(1, 0, 2, 6, 2);
+            AnalysisBuildResult second = createResultWithNewIssues(1, 0, 5, 2, 2);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
+            assertThat(run).hasBuild(createBuild(1));
             assertThat(run.getNewSizeOf(Severity.WARNING_HIGH)).isEqualTo(7);
             assertThat(run.getNewSizeOf(Severity.WARNING_NORMAL)).isEqualTo(8);
             assertThat(run.getNewSizeOf(Severity.WARNING_LOW)).isEqualTo(4);

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/CompositeResultTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/CompositeResultTest.java
@@ -5,19 +5,15 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import org.eclipse.collections.impl.factory.Maps;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.Severity;
 
 import io.jenkins.plugins.analysis.core.charts.CompositeResult.CompositeAnalysisBuildResult;
-import io.jenkins.plugins.analysis.core.model.AnalysisResult.BuildProperties;
-import io.jenkins.plugins.analysis.core.util.AnalysisBuild;
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link CompositeResult}.
@@ -31,42 +27,41 @@ class CompositeResultTest {
     @Test
     void shouldCreateResultOfSequenceWithIdenticalBuilds() {
         List<AnalysisBuildResult> resultsCheckStyle = new ArrayList<>();
-        resultsCheckStyle.add(createResult(1, 2, 3, 1));
-        resultsCheckStyle.add(createResult(2, 4, 6, 2));
+        resultsCheckStyle.add(BuildResultStubs.createResult(2, 0, 2, 4, 6));
+        resultsCheckStyle.add(BuildResultStubs.createResult(1, 0, 1, 2, 3));
 
         List<AnalysisBuildResult> resultsSpotBugs = new ArrayList<>();
-        resultsSpotBugs.add(createResult(11, 12, 13, 1));
-        resultsSpotBugs.add(createResult(12, 14, 16, 2));
+        resultsSpotBugs.add(BuildResultStubs.createResult(2, 0, 12, 14, 16));
+        resultsSpotBugs.add(BuildResultStubs.createResult(1, 0, 11, 12, 13));
 
         CompositeResult compositeResult = new CompositeResult(asList(resultsCheckStyle, resultsSpotBugs));
 
         assertThat(compositeResult.iterator()).toIterable().hasSize(2);
 
         Iterator<AnalysisBuildResult> iterator = compositeResult.iterator();
+
         AnalysisBuildResult first = iterator.next();
+        assertThat(first).hasBuild(BuildResultStubs.createBuild(2));
+        assertThat(first.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(14);
+        assertThat(first.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(18);
+        assertThat(first.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(22);
+
         AnalysisBuildResult second = iterator.next();
-
-        assertThat(first).hasBuild(createBuild(1));
-        assertThat(second).hasBuild(createBuild(2));
-
-        assertThat(first.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(12);
-        assertThat(first.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(14);
-        assertThat(first.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(16);
-
-        assertThat(second.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(14);
-        assertThat(second.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(18);
-        assertThat(second.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(22);
+        assertThat(second).hasBuild(BuildResultStubs.createBuild(1));
+        assertThat(second.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(12);
+        assertThat(second.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(14);
+        assertThat(second.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(16);
     }
 
     @Test
     void shouldCreatePriorityChartForJobAndMultipleActions() {
         List<AnalysisBuildResult> resultsCheckStyle = new ArrayList<>();
-        resultsCheckStyle.add(createResult(1, CHECK_STYLE, 1));
-        resultsCheckStyle.add(createResult(2, CHECK_STYLE, 2));
+        resultsCheckStyle.add(BuildResultStubs.createResult(2, CHECK_STYLE, 2));
+        resultsCheckStyle.add(BuildResultStubs.createResult(1, CHECK_STYLE, 1));
 
         List<AnalysisBuildResult> resultsSpotBugs = new ArrayList<>();
-        resultsSpotBugs.add(createResult(1, SPOT_BUGS, 3));
-        resultsSpotBugs.add(createResult(2, SPOT_BUGS, 4));
+        resultsSpotBugs.add(BuildResultStubs.createResult(2, SPOT_BUGS, 4));
+        resultsSpotBugs.add(BuildResultStubs.createResult(1, SPOT_BUGS, 3));
 
         CompositeResult compositeResult = new CompositeResult(asList(resultsCheckStyle, resultsSpotBugs));
 
@@ -76,71 +71,16 @@ class CompositeResultTest {
         AnalysisBuildResult first = iterator.next();
         AnalysisBuildResult second = iterator.next();
 
-        assertThat(first).hasBuild(createBuild(1));
-        assertThat(second).hasBuild(createBuild(2));
+        assertThat(first).hasBuild(BuildResultStubs.createBuild(2));
+        assertThat(second).hasBuild(BuildResultStubs.createBuild(1));
 
-        assertThat(first.getSizePerOrigin()).contains(entry(CHECK_STYLE, 1), entry(SPOT_BUGS, 3));
-        assertThat(second.getSizePerOrigin()).contains(entry(CHECK_STYLE, 2), entry(SPOT_BUGS, 4));
+        assertThat(first.getSizePerOrigin()).contains(entry(CHECK_STYLE, 2), entry(SPOT_BUGS, 4));
+        assertThat(second.getSizePerOrigin()).contains(entry(CHECK_STYLE, 1), entry(SPOT_BUGS, 3));
     }
 
     private List<Iterable<? extends AnalysisBuildResult>> asList(final List<AnalysisBuildResult> resultsCheckStyle,
             final List<AnalysisBuildResult> resultsSpotBugs) {
         return Arrays.asList(resultsCheckStyle, resultsSpotBugs);
-    }
-
-    private AnalysisBuildResult createResult(final int high, final int normal, final int low, final int number) {
-        AnalysisBuildResult buildResult = createBuildResultMock(number);
-
-        when(buildResult.getTotalSizeOf(Severity.WARNING_HIGH)).thenReturn(high);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_NORMAL)).thenReturn(normal);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_LOW)).thenReturn(low);
-        when(buildResult.getTotalSize()).thenReturn(low + normal + high);
-
-        return buildResult;
-    }
-
-    private AnalysisBuildResult createResultWithNewIssues(final int high, final int normal, final int low,
-            final int number) {
-        AnalysisBuildResult buildResult = createBuildResultMock(number);
-
-        when(buildResult.getNewSizeOf(Severity.WARNING_HIGH)).thenReturn(high);
-        when(buildResult.getNewSizeOf(Severity.WARNING_NORMAL)).thenReturn(normal);
-        when(buildResult.getNewSizeOf(Severity.WARNING_LOW)).thenReturn(low);
-        when(buildResult.getNewSize()).thenReturn(low + normal + high);
-
-        return buildResult;
-    }
-
-    private AnalysisBuildResult createResultWithFixedIssues(final int fixedIssues, final int number) {
-        AnalysisBuildResult buildResult = createBuildResultMock(number);
-
-        when(buildResult.getFixedSize()).thenReturn(fixedIssues);
-
-        AnalysisBuild build = createBuild(number);
-        when(buildResult.getBuild()).thenReturn(build);
-        return buildResult;
-    }
-
-    private AnalysisBuildResult createBuildResultMock(final int number) {
-        AnalysisBuildResult buildResult = mock(AnalysisBuildResult.class);
-
-        AnalysisBuild build = createBuild(number);
-        when(buildResult.getBuild()).thenReturn(build);
-        return buildResult;
-    }
-
-    private AnalysisBuildResult createResult(final int buildNumber, final String toolId, final int total) {
-        AnalysisBuildResult buildResult = mock(AnalysisBuildResult.class);
-
-        when(buildResult.getSizePerOrigin()).thenReturn(Maps.mutable.of(toolId, total));
-
-        AnalysisBuild build = new BuildProperties(buildNumber, "#" + buildNumber, 10);
-        when(buildResult.getBuild()).thenReturn(build);
-        return buildResult;
-    }
-
-    private AnalysisBuild createBuild(final int number) {
-        return new BuildProperties(number, "#" + number, 10);
     }
 
     /**
@@ -150,45 +90,45 @@ class CompositeResultTest {
     class CompositeAnalysisBuildResultTest {
         @Test
         void shouldMergeNumberOfTotalIssues() {
-            AnalysisBuildResult first = createResult(3, 1, 6, 1);
-            AnalysisBuildResult second = createResult(1, 3, 9, 1);
+            AnalysisBuildResult first = BuildResultStubs.createResult(1, 0, 3, 1, 6);
+            AnalysisBuildResult second = BuildResultStubs.createResult(1, 0, 1, 3, 9);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(createBuild(1));
+            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
             assertThat(run).hasTotalSize(23);
         }
 
         @Test
         void shouldMergeNumberOfFixedIssues() {
-            AnalysisBuildResult first = createResultWithFixedIssues(2, 1);
-            AnalysisBuildResult second = createResultWithFixedIssues(3, 1);
+            AnalysisBuildResult first = BuildResultStubs.createResultWithNewAndFixedIssues(1, 0, 2);
+            AnalysisBuildResult second = BuildResultStubs.createResultWithNewAndFixedIssues(1, 0, 3);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(createBuild(1));
+            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
             assertThat(run.getFixedSize()).isEqualTo(5);
         }
 
         @Test
         void shouldMergeNumberOfNewIssues() {
-            AnalysisBuildResult first = createResultWithNewIssues(5, 2, 6, 1);
-            AnalysisBuildResult second = createResultWithNewIssues(4, 2, 7, 1);
+            AnalysisBuildResult first = BuildResultStubs.createResultWithNewIssues(1, 0, 5, 2, 6);
+            AnalysisBuildResult second = BuildResultStubs.createResultWithNewIssues(1, 0, 4, 2, 7);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(createBuild(1));
+            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
             assertThat(run).hasNewSize(26);
         }
 
         @Test
         void shouldMergeTotalNumberOfIssuesBySeverity() {
-            AnalysisBuildResult first = createResult(1, 2, 3, 1);
-            AnalysisBuildResult second = createResult(4, 5, 6, 1);
+            AnalysisBuildResult first = BuildResultStubs.createResult(1, 0, 1, 2, 3);
+            AnalysisBuildResult second = BuildResultStubs.createResult(1, 0, 4, 5, 6);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(createBuild(1));
+            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
             assertThat(run.getTotalSizeOf(Severity.WARNING_HIGH)).isEqualTo(5);
             assertThat(run.getTotalSizeOf(Severity.WARNING_NORMAL)).isEqualTo(7);
             assertThat(run.getTotalSizeOf(Severity.WARNING_LOW)).isEqualTo(9);
@@ -196,12 +136,12 @@ class CompositeResultTest {
 
         @Test
         void shouldMergeNumberOfNewIssuesBySeverity() {
-            AnalysisBuildResult first = createResultWithNewIssues(2, 6, 2, 1);
-            AnalysisBuildResult second = createResultWithNewIssues(5, 2, 2, 1);
+            AnalysisBuildResult first = BuildResultStubs.createResultWithNewIssues(1, 0, 2, 6, 2);
+            AnalysisBuildResult second = BuildResultStubs.createResultWithNewIssues(1, 0, 5, 2, 2);
 
             CompositeAnalysisBuildResult run = new CompositeAnalysisBuildResult(first, second);
 
-            assertThat(run).hasBuild(createBuild(1));
+            assertThat(run).hasBuild(BuildResultStubs.createBuild(1));
             assertThat(run.getNewSizeOf(Severity.WARNING_HIGH)).isEqualTo(7);
             assertThat(run.getNewSizeOf(Severity.WARNING_NORMAL)).isEqualTo(8);
             assertThat(run.getNewSizeOf(Severity.WARNING_LOW)).isEqualTo(4);

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChartTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChartTest.java
@@ -7,14 +7,12 @@ import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.Severity;
 
-import io.jenkins.plugins.analysis.core.model.AnalysisResult.BuildProperties;
-import io.jenkins.plugins.analysis.core.util.AnalysisBuild;
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 import io.jenkins.plugins.analysis.core.util.HealthDescriptor;
 
+import static io.jenkins.plugins.analysis.core.charts.BuildResultStubs.*;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link HealthTrendChart}.
@@ -62,24 +60,11 @@ class HealthTrendChartTest {
 
     private List<AnalysisBuildResult> createBuildResults() {
         List<AnalysisBuildResult> resultsCheckStyle = new ArrayList<>();
-        resultsCheckStyle.add(createResult(0, 0, 0, 1));
-        resultsCheckStyle.add(createResult(5, 0, 0, 2));
-        resultsCheckStyle.add(createResult(5, 5, 0, 3));
-        resultsCheckStyle.add(createResult(5, 5, 5, 4));
+        resultsCheckStyle.add(createResult(1, 0, 0, 0, 0));
+        resultsCheckStyle.add(createResult(2, 0, 5, 0, 0));
+        resultsCheckStyle.add(createResult(3, 0, 5, 5, 0));
+        resultsCheckStyle.add(createResult(4, 0, 5, 5, 5));
         return resultsCheckStyle;
-    }
-
-    private AnalysisBuildResult createResult(final int high, final int normal, final int low, final int number) {
-        AnalysisBuildResult buildResult = mock(AnalysisBuildResult.class);
-
-        when(buildResult.getTotalSize()).thenReturn(high + normal + low);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_HIGH)).thenReturn(high);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_NORMAL)).thenReturn(normal);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_LOW)).thenReturn(low);
-
-        AnalysisBuild build = new BuildProperties(number, "#" + number, 10);
-        when(buildResult.getBuild()).thenReturn(build);
-        return buildResult;
     }
 
     private void verifySeries(final LinesChartModel model, final int index, final int... numbers) {

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChartTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChartTest.java
@@ -5,12 +5,10 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import io.jenkins.plugins.analysis.core.model.AnalysisResult.BuildProperties;
-import io.jenkins.plugins.analysis.core.util.AnalysisBuild;
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 
+import static io.jenkins.plugins.analysis.core.charts.BuildResultStubs.*;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link NewVersusFixedTrendChart}.
@@ -23,8 +21,8 @@ class NewVersusFixedTrendChartTest {
         NewVersusFixedTrendChart chart = new NewVersusFixedTrendChart();
 
         List<AnalysisBuildResult> results = new ArrayList<>();
-        results.add(createResult(10, 11, 1));
-        results.add(createResult(20, 21, 2));
+        results.add(createResultWithNewAndFixedIssues(2, 20, 21));
+        results.add(createResultWithNewAndFixedIssues(1, 10, 11));
 
         LinesChartModel model = chart.create(results, new ChartModelConfiguration());
 
@@ -46,16 +44,5 @@ class NewVersusFixedTrendChartTest {
         for (int value : values) {
             assertThatJson(series).node("data").isArray().hasSize(values.length).contains(value);
         }
-    }
-
-    private AnalysisBuildResult createResult(final int newSize, final int fixedSize, final int number) {
-        AnalysisBuildResult buildResult = mock(AnalysisBuildResult.class);
-
-        when(buildResult.getFixedSize()).thenReturn(fixedSize);
-        when(buildResult.getNewSize()).thenReturn(newSize);
-
-        AnalysisBuild build = new BuildProperties(number, "#" + number, 10);
-        when(buildResult.getBuild()).thenReturn(build);
-        return buildResult;
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityPieChartTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityPieChartTest.java
@@ -38,7 +38,7 @@ class SeverityPieChartTest {
     void shouldCreateChartFromReportWithOneError() {
         SeverityPieChart severityPieChart = new SeverityPieChart();
 
-        PieChartModel pieChartModel = severityPieChart.create(createReport(0, 0, 0, 1));
+        PieChartModel pieChartModel = severityPieChart.create(createReport(1, 0, 0, 0));
         List<PieData> data = pieChartModel.getData();
 
         assertThat(data.get(0)).isEqualTo(new PieData("Error", 1));
@@ -63,12 +63,12 @@ class SeverityPieChartTest {
         assertThat(data.get(3)).isEqualTo(new PieData("Low", 1));
     }
 
-    private Report createReport(final int high, final int normal, final int low, final int error) {
+    private Report createReport(final int error, final int high, final int normal, final int low) {
         Report buildResult = mock(Report.class);
+        when(buildResult.getSizeOf(Severity.ERROR)).thenReturn(error);
         when(buildResult.getSizeOf(Severity.WARNING_HIGH)).thenReturn(high);
         when(buildResult.getSizeOf(Severity.WARNING_NORMAL)).thenReturn(normal);
         when(buildResult.getSizeOf(Severity.WARNING_LOW)).thenReturn(low);
-        when(buildResult.getSizeOf(Severity.ERROR)).thenReturn(error);
         return buildResult;
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/SeveritySeriesBuilderTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/SeveritySeriesBuilderTest.java
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.Lists;
 
 import io.jenkins.plugins.analysis.core.charts.ChartModelConfiguration.AxisType;
-import io.jenkins.plugins.analysis.core.util.AnalysisBuild;
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 
 import static edu.hm.hafner.analysis.Severity.*;
+import static io.jenkins.plugins.analysis.core.charts.BuildResultStubs.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -43,8 +43,7 @@ class SeveritySeriesBuilderTest {
     void shouldHaveThreeValuesForSingleBuild() {
         SeveritySeriesBuilder builder = new SeveritySeriesBuilder();
 
-        AnalysisBuildResult singleResult = createBuildResult(1,
-                1, 2, 3);
+        AnalysisBuildResult singleResult = createResult(1, 0, 1, 2, 3);
 
         LinesDataSet dataSet = builder.createDataSet(createConfiguration(), Lists.newArrayList(singleResult));
 
@@ -60,24 +59,33 @@ class SeveritySeriesBuilderTest {
         assertThat(dataSet.getSeries(ERROR.getName())).containsExactly(0);
     }
 
-    private AnalysisBuildResult createBuildResult(final int buildNumber, final int numberOfHighPriorityIssues,
-            final int numberOfNormalPriorityIssues, final int numberOfLowPriorityIssues) {
-        AnalysisBuildResult buildResult = mock(AnalysisBuildResult.class);
+    /**
+     * Verifies that the number of builds in the chart is limited by the {@link ChartModelConfiguration} settings.
+     */
+    @Test
+    void shouldHaveNotMoreValuesThatAllowed() {
+        SeveritySeriesBuilder builder = new SeveritySeriesBuilder();
 
-        when(buildResult.getTotalSizeOf(WARNING_HIGH)).thenReturn(numberOfHighPriorityIssues);
-        when(buildResult.getTotalSizeOf(WARNING_NORMAL)).thenReturn(numberOfNormalPriorityIssues);
-        when(buildResult.getTotalSizeOf(WARNING_LOW)).thenReturn(numberOfLowPriorityIssues);
+        ChartModelConfiguration configuration = createConfiguration();
+        when(configuration.getBuildCount()).thenReturn(3);
+        when(configuration.isBuildCountDefined()).thenReturn(true);
 
-        AnalysisBuild build = createRun(buildNumber);
-        when(buildResult.getBuild()).thenReturn(build);
+        LinesDataSet dataSet = builder.createDataSet(configuration, Lists.newArrayList(
+                createResult(4, 4000, 400, 40, 4),
+                createResult(3, 3000, 300, 30, 3),
+                createResult(2, 2000, 200, 20, 2),
+                createResult(1, 1000, 100, 10, 1)
+        ));
 
-        return buildResult;
-    }
+        assertThat(dataSet.getXAxisSize()).isEqualTo(3);
+        assertThat(dataSet.getXAxisLabels()).containsExactly("#2", "#3", "#4");
 
-    private AnalysisBuild createRun(final int number) {
-        AnalysisBuild run = mock(AnalysisBuild.class);
-        when(run.getNumber()).thenReturn(number);
-        when(run.getDisplayName()).thenReturn("#" + number);
-        return run;
+        assertThat(dataSet.getDataSetIds()).containsExactlyInAnyOrder(
+                ERROR.getName(), WARNING_HIGH.getName(), WARNING_NORMAL.getName(), WARNING_LOW.getName());
+
+        assertThat(dataSet.getSeries(ERROR.getName())).containsExactly(2000, 3000, 4000);
+        assertThat(dataSet.getSeries(WARNING_HIGH.getName())).containsExactly(200, 300, 400);
+        assertThat(dataSet.getSeries(WARNING_NORMAL.getName())).containsExactly(20, 30, 40);
+        assertThat(dataSet.getSeries(WARNING_LOW.getName())).containsExactly(2, 3, 4);
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
@@ -109,6 +109,7 @@ class SeverityTrendChartTest {
                 .isArray().hasSize(4);
     }
 
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> createResults() {
         return Stream.of(
                 Arguments.of(createSingleResults(), "single AnalysisBuildResult instances"),

--- a/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
@@ -1,17 +1,24 @@
 package io.jenkins.plugins.analysis.core.charts;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import edu.hm.hafner.analysis.Severity;
 
-import io.jenkins.plugins.analysis.core.model.AnalysisResult.BuildProperties;
-import io.jenkins.plugins.analysis.core.util.AnalysisBuild;
+import io.jenkins.plugins.analysis.core.charts.ChartModelConfiguration.AxisType;
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 import io.jenkins.plugins.analysis.core.util.LocalizedSeverity;
 
+import static io.jenkins.plugins.analysis.core.charts.BuildResultStubs.*;
 import static java.util.Arrays.*;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 import static org.mockito.Mockito.*;
@@ -28,12 +35,12 @@ class SeverityTrendChartTest {
         SeverityTrendChart chart = new SeverityTrendChart();
 
         List<AnalysisBuildResult> resultsCheckStyle = new ArrayList<>();
-        resultsCheckStyle.add(createResult(3, 1, 2, 3, 1));
-        resultsCheckStyle.add(createResult(0, 2, 4, 6, 2));
+        resultsCheckStyle.add(createResult(2, 0, 2, 4, 6));
+        resultsCheckStyle.add(createResult(1, 3, 1, 2, 3));
 
         List<AnalysisBuildResult> resultsSpotBugs = new ArrayList<>();
-        resultsSpotBugs.add(createResult(1, 11, 12, 13, 1));
-        resultsSpotBugs.add(createResult(0, 12, 14, 16, 2));
+        resultsSpotBugs.add(createResult(2, 0, 12, 14, 16));
+        resultsSpotBugs.add(createResult(1, 1, 11, 12, 13));
 
         LinesChartModel model = chart.create(
                 new CompositeResult(asList(resultsCheckStyle, resultsSpotBugs)), new ChartModelConfiguration());
@@ -56,10 +63,10 @@ class SeverityTrendChartTest {
         SeverityTrendChart chart = new SeverityTrendChart();
 
         List<AnalysisBuildResult> results = new ArrayList<>();
-        results.add(createResult(3, 1, 2, 3, 1));
-        results.add(createResult(2, 2, 4, 6, 2));
-        results.add(createResult(0, 0, 0, 0, 3));
-        results.add(createResult(0, 0, 0, 0, 4));
+        results.add(createResult(4, 0, 0, 0, 0));
+        results.add(createResult(3, 0, 0, 0, 0));
+        results.add(createResult(2, 2, 2, 4, 6));
+        results.add(createResult(1, 3, 1, 2, 3));
 
         LinesChartModel model = chart.create(results, new ChartModelConfiguration());
 
@@ -76,13 +83,65 @@ class SeverityTrendChartTest {
                 .isArray().hasSize(4);
     }
 
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("createResults")
+    @DisplayName("shouldHaveNotMoreValuesThatAllowed")
+    void shouldHaveNotMoreValuesThatAllowed(final Iterable<? extends AnalysisBuildResult> results, final String name) {
+        SeverityTrendChart chart = new SeverityTrendChart();
+
+        ChartModelConfiguration configuration = mock(ChartModelConfiguration.class);
+        when(configuration.getBuildCount()).thenReturn(3);
+        when(configuration.getAxisType()).thenReturn(AxisType.BUILD);
+        when(configuration.isBuildCountDefined()).thenReturn(true);
+
+        LinesChartModel model = chart.create(results, configuration);
+
+        verifySeries(model.getSeries().get(3), Severity.ERROR, 2000, 3000, 4000);
+        verifySeries(model.getSeries().get(2), Severity.WARNING_HIGH, 200, 300, 400);
+        verifySeries(model.getSeries().get(1), Severity.WARNING_NORMAL, 20, 30, 40);
+        verifySeries(model.getSeries().get(0), Severity.WARNING_LOW, 2, 3, 4);
+
+        assertThatJson(model).node("xAxisLabels")
+                .isArray().hasSize(3).containsExactly("#2", "#3", "#4");
+        assertThatJson(model).node("buildNumbers")
+                .isArray().hasSize(3).containsExactly(2, 3, 4);
+        assertThatJson(model).node("series")
+                .isArray().hasSize(4);
+    }
+
+    private static Stream<Arguments> createResults() {
+        return Stream.of(
+                Arguments.of(createSingleResults(), "single AnalysisBuildResult instances"),
+                Arguments.of(createCompositeResults(), "aggregation by CompositeResult")
+        );
+    }
+
+    private static Iterable<? extends AnalysisBuildResult> createSingleResults() {
+        List<AnalysisBuildResult> results = new ArrayList<>();
+        results.add(createResult(4, 4000, 400, 40, 4));
+        results.add(createResult(3, 3000, 300, 30, 3));
+        results.add(createResult(2, 2000, 200, 20, 2));
+        results.add(createResult(1, 1000, 100, 10, 1));
+        return results;
+    }
+
+    private static CompositeResult createCompositeResults() {
+        List<Iterable<? extends AnalysisBuildResult>> results = new ArrayList<>();
+        Iterator<? extends AnalysisBuildResult> singleResults = createSingleResults().iterator();
+        results.add(Collections.singletonList(singleResults.next()));
+        results.add(Collections.singletonList(singleResults.next()));
+        results.add(Collections.singletonList(singleResults.next()));
+        results.add(Collections.singletonList(singleResults.next()));
+        return new CompositeResult(results);
+    }
+
     @Test
     void shouldCreatePriorityChartWithoutErrors() {
         SeverityTrendChart chart = new SeverityTrendChart();
 
         List<AnalysisBuildResult> results = new ArrayList<>();
-        results.add(createResult(0, 1, 2, 3, 1));
-        results.add(createResult(0, 2, 4, 6, 2));
+        results.add(createResult(2, 0, 2, 4, 6));
+        results.add(createResult(1, 0, 1, 2, 3));
 
         LinesChartModel model = chart.create(results, new ChartModelConfiguration());
 
@@ -104,8 +163,8 @@ class SeverityTrendChartTest {
         SeverityTrendChart chart = new SeverityTrendChart();
 
         List<AnalysisBuildResult> results = new ArrayList<>();
-        results.add(createResult(5, 1, 2, 3, 1));
-        results.add(createResult(8, 2, 4, 6, 2));
+        results.add(createResult(2, 8, 2, 4, 6));
+        results.add(createResult(1, 5, 1, 2, 3));
 
         LinesChartModel model = chart.create(results, new ChartModelConfiguration());
 
@@ -130,16 +189,4 @@ class SeverityTrendChartTest {
         }
     }
 
-    private AnalysisBuildResult createResult(final int error, final int high, final int normal, final int low, final int number) {
-        AnalysisBuildResult buildResult = mock(AnalysisBuildResult.class);
-
-        when(buildResult.getTotalSizeOf(Severity.ERROR)).thenReturn(error);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_HIGH)).thenReturn(high);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_NORMAL)).thenReturn(normal);
-        when(buildResult.getTotalSizeOf(Severity.WARNING_LOW)).thenReturn(low);
-
-        AnalysisBuild build = new BuildProperties(number, "#" + number, 10);
-        when(buildResult.getBuild()).thenReturn(build);
-        return buildResult;
-    }
 }


### PR DESCRIPTION
See [JENKINS-58826](https://issues.jenkins-ci.org/browse/JENKINS-58826).

The number of builds which are included into a trend chart is currently limited by the fixed number of 50 builds. This limit is currently only working correctly in single trend charts. In aggregations (and charts with days as domain axis), this limit is applied on the wrong side, i.e. the charts are showing the first 50 builds and not the last 50 builds.
