### PR TITLE
[JENKINS-59986] Handle broken paths silently

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/util/AbsolutePathGenerator.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/AbsolutePathGenerator.java
@@ -115,7 +115,7 @@ public class AbsolutePathGenerator {
     private Optional<String> resolveAbsolutePath(final String fileName, final Collection<String> sourceDirectories) {
         PathUtil pathUtil = new PathUtil();
         if (pathUtil.isAbsolute(fileName)) {
-            return resolveAbsolutePath(Paths.get(fileName));
+            return resolveAbsolutePath(fileName);
         }
         return resolveRelativePath(fileName, sourceDirectories);
     }
@@ -129,18 +129,18 @@ public class AbsolutePathGenerator {
 
     private Optional<String> resolveAbsolutePath(final String parent, final String fileName) {
         try {
-            return resolveAbsolutePath(Paths.get(parent, fileName));
+            return Optional.of(new PathUtil().toString(Paths.get(parent, fileName)));
         }
-        catch (InvalidPathException ignored) {
+        catch (IOException | InvalidPathException ignored) {
             return Optional.empty();
         }
     }
 
-    private Optional<String> resolveAbsolutePath(final Path path) {
+    private Optional<String> resolveAbsolutePath(final String path) {
         try {
-            return Optional.of(new PathUtil().toString(path));
+            return Optional.of(new PathUtil().toString(Paths.get(path)));
         }
-        catch (IOException ignored) {
+        catch (IOException | InvalidPathException ignored) {
             return Optional.empty();
         }
     }

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/AbsolutePathGenerator.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/AbsolutePathGenerator.java
@@ -127,18 +127,9 @@ public class AbsolutePathGenerator {
                 .findFirst();
     }
 
-    private Optional<String> resolveAbsolutePath(final String parent, final String fileName) {
+    private Optional<String> resolveAbsolutePath(final String first, final String... other) {
         try {
-            return Optional.of(new PathUtil().toString(Paths.get(parent, fileName)));
-        }
-        catch (IOException | InvalidPathException ignored) {
-            return Optional.empty();
-        }
-    }
-
-    private Optional<String> resolveAbsolutePath(final String path) {
-        try {
-            return Optional.of(new PathUtil().toString(Paths.get(path)));
+            return Optional.of(new PathUtil().toString(Paths.get(first, other)));
         }
         catch (IOException | InvalidPathException ignored) {
             return Optional.empty();

--- a/src/test/java/io/jenkins/plugins/analysis/core/util/AbsolutePathGeneratorTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/util/AbsolutePathGeneratorTest.java
@@ -44,8 +44,9 @@ class AbsolutePathGeneratorTest {
      * Ensures that illegal file names are processed without problems. Afterwards, the path name should be unchanged.
      */
     @ParameterizedTest(name = "[{index}] Illegal filename = {0}")
-    @ValueSource(strings = {"/does/not/exist", "!<>$&/&(", "\0 Null-Byte"})
+    @ValueSource(strings = {"/does/not/exist", "!<>$&/&(", "\0 Null-Byte", "C:/!<>$&/&( \0", "/!<>$&/&( \0"})
     @DisplayName("Should not change path on errors")
+    @org.jvnet.hudson.test.Issue("JENKINS-59986")
     void shouldReturnFallbackOnError(final String fileName) {
         Report report = createIssuesSingleton(fileName, new IssueBuilder());
 


### PR DESCRIPTION
Catch all exceptions during resolving of absolute paths.

Fixes: 
- https://issues.jenkins-ci.org/browse/JENKINS-59986
- https://issues.jenkins-ci.org/browse/JENKINS-60033
