### PR TITLE
Add underscores to the allowed set of characters for IDs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <commons.digester.version>2.1</commons.digester.version>
     <commons.digester3.version>3.2</commons.digester3.version>
     <commons.text.version>1.8</commons.text.version>
-    <commons.validator.version>1.6</commons.validator.version>
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
     <j2html.version>1.4.0</j2html.version>
 
@@ -232,11 +231,6 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons.lang.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-validator</groupId>
-      <artifactId>commons-validator</artifactId>
-      <version>${commons.validator.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/ModelValidation.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/ModelValidation.java
@@ -29,7 +29,7 @@ import hudson.util.ListBoxModel;
  */
 public class ModelValidation {
     private static final Set<String> ALL_CHARSETS = Charset.availableCharsets().keySet();
-    private static final Pattern VALID_ID_PATTERN = Pattern.compile("\\p{Alnum}[\\p{Alnum}-_]*");
+    private static final Pattern VALID_ID_PATTERN = Pattern.compile("[a-z0-9][a-z0-9-_]*");
 
     @VisibleForTesting
     static final String NO_REFERENCE_JOB = "-";

--- a/src/main/java/io/jenkins/plugins/analysis/core/util/ModelValidation.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/util/ModelValidation.java
@@ -5,9 +5,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.validator.routines.DomainValidator;
 
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.PathUtil;
@@ -28,8 +28,8 @@ import hudson.util.ListBoxModel;
  * @author Ullrich Hafner
  */
 public class ModelValidation {
-    /** All available character sets. */
     private static final Set<String> ALL_CHARSETS = Charset.availableCharsets().keySet();
+    private static final Pattern VALID_ID_PATTERN = Pattern.compile("\\p{Alnum}[\\p{Alnum}-_]*");
 
     @VisibleForTesting
     static final String NO_REFERENCE_JOB = "-";
@@ -108,7 +108,7 @@ public class ModelValidation {
     }
 
     private boolean isValidId(final String id) {
-        return StringUtils.isEmpty(id) || DomainValidator.getInstance(true).isValid(id);
+        return StringUtils.isEmpty(id) || VALID_ID_PATTERN.matcher(id).matches();
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-id.html
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-id.html
@@ -1,5 +1,6 @@
 <div>
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
+    Allowed elements are characters, digits, dashes and underscores (i.e., the ID must match `[a-z0-9][a-z0-9-_]*`).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-id.html
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-id.html
@@ -1,5 +1,6 @@
 <div>
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
+    Allowed elements are characters, digits, dashes and underscores (i.e., the ID must match `[a-z0-9][a-z0-9-_]*`).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-id.html
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-id.html
@@ -1,5 +1,6 @@
 <div>
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
+    Allowed elements are characters, digits, dashes and underscores (i.e., the ID must match `[a-z0-9][a-z0-9-_]*`).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>

--- a/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-id.html
+++ b/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-id.html
@@ -1,5 +1,6 @@
 <div>
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
+    Allowed elements are characters, digits, dashes and underscores (i.e., the ID must match `[a-z0-9][a-z0-9-_]*`).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>

--- a/src/test/java/io/jenkins/plugins/analysis/core/model/LabelProviderFactoryITest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/model/LabelProviderFactoryITest.java
@@ -8,9 +8,11 @@ import org.jvnet.hudson.test.TestExtension;
 
 import edu.hm.hafner.analysis.IssueParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
+
 import io.jenkins.plugins.analysis.core.model.LabelProviderFactory.StaticAnalysisToolFactory;
-import static io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProviderAssert.assertThat;
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSuite;
+
+import static io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProviderAssert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -19,7 +21,7 @@ import static org.mockito.Mockito.*;
  * @author Ullrich Hafner
  */
 public class LabelProviderFactoryITest extends IntegrationTestWithJenkinsPerSuite {
-    private static final String ANNOTATED_ID = "annotatedTool";
+    private static final String ANNOTATED_ID = "annotated-tool";
     private static final String PROVIDER_ID = "provider";
     private static final String UNDEFINED_ID = "undefined-id";
     private static final String TOOL_NAME = "Tool Name";

--- a/src/test/java/io/jenkins/plugins/analysis/core/util/ModelValidationTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/util/ModelValidationTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.*;
  */
 class ModelValidationTest {
     @ParameterizedTest(name = "{index} => Should be marked as illegal ID: \"{0}\"")
-    @ValueSource(strings = {"a b", "a/b", "a#b", "äöü", "aö"})
+    @ValueSource(strings = {"a b", "a/b", "a#b", "äöü", "aö", "A", "aBc"})
     @DisplayName("should reject IDs")
     void shouldRejectId(final String id) {
         ModelValidation model = new ModelValidation();
@@ -43,7 +43,7 @@ class ModelValidationTest {
     }
 
     @ParameterizedTest(name = "{index} => Should be marked as valid ID: \"{0}\"")
-    @ValueSource(strings = {"", "a", "aWordb", "a-b", "a_b", "", "0", "a0b", "12a34"})
+    @ValueSource(strings = {"", "a", "awordb", "a-b", "a_b", "", "0", "a0b", "12a34"})
     @DisplayName("should accept IDs")
     void shouldAcceptId(final String id) {
         ModelValidation model = new ModelValidation();

--- a/src/test/java/io/jenkins/plugins/analysis/core/util/ModelValidationTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/util/ModelValidationTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.*;
  */
 class ModelValidationTest {
     @ParameterizedTest(name = "{index} => Should be marked as illegal ID: \"{0}\"")
-    @ValueSource(strings = {"a b", "a/b", "a#b"})
+    @ValueSource(strings = {"a b", "a/b", "a#b", "äöü", "aö"})
     @DisplayName("should reject IDs")
     void shouldRejectId(final String id) {
         ModelValidation model = new ModelValidation();
@@ -43,7 +43,7 @@ class ModelValidationTest {
     }
 
     @ParameterizedTest(name = "{index} => Should be marked as valid ID: \"{0}\"")
-    @ValueSource(strings = {"", "a", "aWordb", "a-b"})
+    @ValueSource(strings = {"", "a", "aWordb", "a-b", "a_b", "", "0", "a0b", "12a34"})
     @DisplayName("should accept IDs")
     void shouldAcceptId(final String id) {
         ModelValidation model = new ModelValidation();


### PR DESCRIPTION
Now allowed characters in IDs are: 
- alphanumeric characters (lowercase)
- dashes
- underscores.