### PR TITLE
[JENKINS-59617] Create unit test for IconLabelProvider

### DIFF
--- a/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
@@ -15,15 +15,6 @@ class IconLabelProviderTest {
     private static final String ICON_NAME = "icon-name";
 
     /**
-     * This field has to be the same as in IconLabelProvider. Create this
-     * to avoid using reflection or adding getters in the origin class.
-     */
-    private static final String ICONS_URL = "/plugin/warnings-ng/icons/";
-
-    private static final String SMALL_ICON_URL_SUFFIX = "-24x24.png";
-    private static final String LARGE_ICON_URL_SUFFIX = "-48x48.png";
-
-    /**
      * Verifies that the name of the icon in URL is obtained from the icon id, if
      * the {@code iconName} parameter is empty.
      */

--- a/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
@@ -10,9 +10,9 @@ import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
  * @author Kezhi Xiong
  */
 class IconLabelProviderTest {
-    private static final String iconId = "icon-id";
-    private static final String toolName = "tool-name";
-    private static final String iconName = "icon-name";
+    private static final String ICON_ID = "icon-id";
+    private static final String TOOL_NAME = "tool-name";
+    private static final String ICON_NAME = "icon-name";
 
     /**
      * This field has to be the same as in IconLabelProvider. Create this
@@ -20,8 +20,8 @@ class IconLabelProviderTest {
      */
     private static final String ICONS_URL = "/plugin/warnings-ng/icons/";
 
-    private static final String smallIconUrlSuffix = "-24x24.png";
-    private static final String largeIconUrlSuffix = "-48x48.png";
+    private static final String SMALL_ICON_URL_SUFFIX = "-24x24.png";
+    private static final String LARGE_ICON_URL_SUFFIX = "-48x48.png";
 
     /**
      * Verifies that the name of the icon in URL is obtained from the icon id, if
@@ -29,11 +29,11 @@ class IconLabelProviderTest {
      */
     @Test
     void shouldUseIdIfParameterIconNameIsBlank() {
-        IconLabelProvider iconLabelProvider = new IconLabelProvider(iconId, toolName);
+        IconLabelProvider iconLabelProvider = new IconLabelProvider(ICON_ID, TOOL_NAME);
 
-        assertThat(iconLabelProvider).hasId(iconId).hasName(toolName)
-                .hasSmallIconUrl(ICONS_URL + iconId + smallIconUrlSuffix)
-                .hasLargeIconUrl(ICONS_URL + iconId + largeIconUrlSuffix);
+        assertThat(iconLabelProvider).hasId(ICON_ID).hasName(TOOL_NAME)
+                .hasSmallIconUrl(ICONS_URL + ICON_ID + SMALL_ICON_URL_SUFFIX)
+                .hasLargeIconUrl(ICONS_URL + ICON_ID + LARGE_ICON_URL_SUFFIX);
     }
 
     /**
@@ -42,10 +42,10 @@ class IconLabelProviderTest {
      */
     @Test
     void shouldParameterNameIfNotBlank() {
-        IconLabelProvider iconLabelProvider = new IconLabelProvider(iconId, toolName, iconName);
+        IconLabelProvider iconLabelProvider = new IconLabelProvider(ICON_ID, TOOL_NAME, ICON_NAME);
 
-        assertThat(iconLabelProvider).hasId(iconId).hasName(toolName)
-                .hasSmallIconUrl(ICONS_URL + iconName + smallIconUrlSuffix)
-                .hasLargeIconUrl(ICONS_URL + iconName + largeIconUrlSuffix);
+        assertThat(iconLabelProvider).hasId(ICON_ID).hasName(TOOL_NAME)
+                .hasSmallIconUrl(ICONS_URL + ICON_NAME + SMALL_ICON_URL_SUFFIX)
+                .hasLargeIconUrl(ICONS_URL + ICON_NAME + LARGE_ICON_URL_SUFFIX);
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
@@ -32,8 +32,8 @@ class IconLabelProviderTest {
         IconLabelProvider iconLabelProvider = new IconLabelProvider(ICON_ID, TOOL_NAME);
 
         assertThat(iconLabelProvider).hasId(ICON_ID).hasName(TOOL_NAME)
-                .hasSmallIconUrl(ICONS_URL + ICON_ID + SMALL_ICON_URL_SUFFIX)
-                .hasLargeIconUrl(ICONS_URL + ICON_ID + LARGE_ICON_URL_SUFFIX);
+                .hasSmallIconUrl("/plugin/warnings-ng/icons/icon-id-24x24.png")
+                .hasLargeIconUrl("/plugin/warnings-ng/icons/icon-id-48x48.png");
     }
 
     /**
@@ -45,7 +45,7 @@ class IconLabelProviderTest {
         IconLabelProvider iconLabelProvider = new IconLabelProvider(ICON_ID, TOOL_NAME, ICON_NAME);
 
         assertThat(iconLabelProvider).hasId(ICON_ID).hasName(TOOL_NAME)
-                .hasSmallIconUrl(ICONS_URL + ICON_NAME + SMALL_ICON_URL_SUFFIX)
-                .hasLargeIconUrl(ICONS_URL + ICON_NAME + LARGE_ICON_URL_SUFFIX);
+                .hasSmallIconUrl("/plugin/warnings-ng/icons/icon-name-24x24.png")
+                .hasLargeIconUrl("/plugin/warnings-ng/icons/icon-name-48x48.png");
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
@@ -1,0 +1,51 @@
+package io.jenkins.plugins.analysis.core.model;
+
+import org.junit.jupiter.api.Test;
+
+import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+
+/**
+ * Tests the class {@link IconLabelProvider}.
+ *
+ * @author Kezhi Xiong
+ */
+class IconLabelProviderTest {
+    private static final String iconId = "icon-id";
+    private static final String toolName = "tool-name";
+    private static final String iconName = "icon-name";
+
+    /**
+     * This field has to be the same as in IconLabelProvider. Create this
+     * to avoid using reflection or adding getters in the origin class.
+     */
+    private static final String ICONS_URL = "/plugin/warnings-ng/icons/";
+
+    private static final String smallIconUrlSuffix = "-24x24.png";
+    private static final String largeIconUrlSuffix = "-48x48.png";
+
+    /**
+     * Verifies that the name of the icon in URL is obtained from the icon id, if
+     * the {@code iconName} parameter is empty.
+     */
+    @Test
+    void shouldUseIdIfParameterIconNameIsBlank() {
+        IconLabelProvider iconLabelProvider = new IconLabelProvider(iconId, toolName);
+
+        assertThat(iconLabelProvider).hasId(iconId).hasName(toolName)
+                .hasSmallIconUrl(ICONS_URL + iconId + smallIconUrlSuffix)
+                .hasLargeIconUrl(ICONS_URL + iconId + largeIconUrlSuffix);
+    }
+
+    /**
+     * Verifies the name of the icon in URL is obtained from parameter, if the
+     * {@code iconName} parameter is provided.
+     */
+    @Test
+    void shouldParameterNameIfNotBlank() {
+        IconLabelProvider iconLabelProvider = new IconLabelProvider(iconId, toolName, iconName);
+
+        assertThat(iconLabelProvider).hasId(iconId).hasName(toolName)
+                .hasSmallIconUrl(ICONS_URL + iconName + smallIconUrlSuffix)
+                .hasLargeIconUrl(ICONS_URL + iconName + largeIconUrlSuffix);
+    }
+}


### PR DESCRIPTION
[JENKINS-59617](https://issues.jenkins-ci.org/browse/JENKINS-59617) I have one question for this test. During the test, I have to access the ICONS_URL field which is static and private in the original class, so in order not to use reflection or add additional getter in the original class, I create a same field in this test class. I don't know whether this solution is correct.