### PR TITLE
Add a Blame model object that encapsulates mapping of blames to issues

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/model/Blame.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/Blame.java
@@ -1,0 +1,63 @@
+package io.jenkins.plugins.analysis.core.model;
+
+import edu.hm.hafner.analysis.Issue;
+
+import io.jenkins.plugins.forensics.blame.Blames;
+import io.jenkins.plugins.forensics.blame.FileBlame;
+
+/**
+ * Enhances an issue with information about the author and the originating commit. If no such information is available,
+ * then default values are returned for all properties.
+ *
+ * @author Ullrich Hafner
+ */
+public class Blame {
+    static final String UNDEFINED = "-";
+    static final int UNDEFINED_DATE = 0;
+
+    private final String author;
+    private final String email;
+    private final String commit;
+    private final int addedAt;
+
+    /**
+     * Creates a new instance of {@link Blame}.
+     *
+     * @param issue
+     *         the issue to blame
+     * @param blames
+     *         the available blames
+     */
+    public Blame(final Issue issue, final Blames blames) {
+        if (blames.contains(issue.getFileName())) {
+            FileBlame blameRequest = blames.getBlame(issue.getFileName());
+            int line = issue.getLineStart();
+            author = blameRequest.getName(line);
+            email = blameRequest.getEmail(line);
+            commit = blameRequest.getCommit(line);
+            addedAt = blameRequest.getTime(line);
+        }
+        else {
+            author = UNDEFINED;
+            email = UNDEFINED;
+            commit = UNDEFINED;
+            addedAt = UNDEFINED_DATE;
+        }
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getCommit() {
+        return commit;
+    }
+
+    public int getAddedAt() {
+        return addedAt;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/Blame.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/Blame.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.forensics.blame.FileBlame;
  *
  * @author Ullrich Hafner
  */
+@SuppressWarnings("PMD.DataClass")
 public class Blame {
     static final String UNDEFINED = "-";
     static final int UNDEFINED_DATE = 0;

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
@@ -11,7 +11,6 @@ import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBui
 import io.jenkins.plugins.datatables.TableColumn;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
 import io.jenkins.plugins.forensics.blame.Blames;
-import io.jenkins.plugins.forensics.blame.FileBlame;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
@@ -73,23 +72,8 @@ public class BlamesModel extends DetailsTableModel {
 
     @Override
     protected BlamesRow getRow(final Issue issue) {
-        BlamesRow row = new BlamesRow(getAgeBuilder(), getFileNameRenderer(), getDescriptionProvider(),
-                issue, getJenkinsFacade());
-        if (blames.contains(issue.getFileName())) {
-            FileBlame blameRequest = blames.getBlame(issue.getFileName());
-            int line = issue.getLineStart();
-            row.setAuthor(blameRequest.getName(line));
-            row.setEmail(blameRequest.getEmail(line));
-            row.setCommit(blameRequest.getCommit(line));
-            row.setAddedAt(blameRequest.getTime(line));
-        }
-        else {
-            row.setAuthor(UNDEFINED);
-            row.setEmail(UNDEFINED);
-            row.setCommit(UNDEFINED);
-            row.setAddedAt(UNDEFINED_DATE);
-        }
-        return row;
+        return new BlamesRow(getAgeBuilder(), getFileNameRenderer(), getDescriptionProvider(),
+                issue, getJenkinsFacade(), new Blame(issue, blames));
     }
 
     /**
@@ -97,46 +81,30 @@ public class BlamesModel extends DetailsTableModel {
      */
     @SuppressWarnings("PMD.DataClass") // Used to automatically convert to JSON object
     public static class BlamesRow extends TableRow {
-        private String author;
-        private String email;
-        private String commit;
-        private int addedAt;
+        private final Blame blame;
 
         BlamesRow(final AgeBuilder ageBuilder, final FileNameRenderer fileNameRenderer,
-                final DescriptionProvider descriptionProvider, final Issue issue, final JenkinsFacade jenkinsFacade) {
+                final DescriptionProvider descriptionProvider, final Issue issue, final JenkinsFacade jenkinsFacade,
+                final Blame blame) {
             super(ageBuilder, fileNameRenderer, descriptionProvider, issue, jenkinsFacade);
+
+            this.blame = blame;
         }
 
         public String getAuthor() {
-            return author;
+            return blame.getAuthor();
         }
 
         public String getEmail() {
-            return email;
+            return blame.getEmail();
         }
 
         public String getCommit() {
-            return commit;
+            return blame.getCommit();
         }
 
         public int getAddedAt() {
-            return addedAt;
-        }
-
-        void setAuthor(final String author) {
-            this.author = author;
-        }
-
-        void setEmail(final String email) {
-            this.email = email;
-        }
-
-        void setCommit(final String commit) {
-            this.commit = commit;
-        }
-
-        public void setAddedAt(final int addedAt) {
-            this.addedAt = addedAt;
+            return blame.getAddedAt();
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/analysis/core/model/BlameTest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/core/model/BlameTest.java
@@ -1,0 +1,57 @@
+package io.jenkins.plugins.analysis.core.model;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.IssueBuilder;
+
+import io.jenkins.plugins.forensics.blame.Blames;
+import io.jenkins.plugins.forensics.blame.FileBlame;
+
+import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link Blame}.
+ *
+ * @author Ullrich Hafner
+ */
+class BlameTest {
+    private static final String COMMIT = "Commit";
+    private static final String AUTHOR = "Author";
+    private static final String EMAIL = "Email";
+    private static final int ADDED_AT = 123;
+
+    @Test
+    void shouldCreateEmptyBlame() {
+        Blame blame = new Blame(new IssueBuilder().build(), new Blames());
+
+        assertThat(blame).hasAuthor(Blame.UNDEFINED);
+        assertThat(blame).hasCommit(Blame.UNDEFINED);
+        assertThat(blame).hasEmail(Blame.UNDEFINED);
+        assertThat(blame).hasAddedAt(Blame.UNDEFINED_DATE);
+    }
+
+    @Test
+    void shouldCreateBlameForIssue() {
+        Blame blame = new Blame(new IssueBuilder().build(), createBlames());
+
+        assertThat(blame).hasAuthor(AUTHOR);
+        assertThat(blame).hasCommit(COMMIT);
+        assertThat(blame).hasEmail(EMAIL);
+        assertThat(blame).hasAddedAt(ADDED_AT);
+    }
+
+    private Blames createBlames() {
+        Blames blames = mock(Blames.class);
+        FileBlame fileBlame = mock(FileBlame.class);
+        when(fileBlame.getCommit(anyInt())).thenReturn(COMMIT);
+        when(fileBlame.getEmail(anyInt())).thenReturn(EMAIL);
+        when(fileBlame.getName(anyInt())).thenReturn(AUTHOR);
+        when(fileBlame.getTime(anyInt())).thenReturn(ADDED_AT);
+
+        when(blames.getBlame(anyString())).thenReturn(fileBlame);
+        when(blames.contains(anyString())).thenReturn(true);
+
+        return blames;
+    }
+}

--- a/src/test/java/io/jenkins/plugins/analysis/warnings/StepsITest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/warnings/StepsITest.java
@@ -84,6 +84,11 @@ public class StepsITest extends IntegrationTestWithJenkinsPerTest {
                 + "         def report = scanForIssues tool: checkStyle(pattern: '**/" + fileName + "*')\n"
                 + "         echo '[total=' + report.size() + ']' \n"
                 + "         echo '[id=' + report.getId() + ']' \n"
+                + "         def issues = report.getIssues()\n"
+                + "         issues.each { issue ->\n"
+                + "             echo issue.toString()\n"
+                + "             echo issue.getOrigin()\n"
+                + "         }"
                 + "  }\n"
                 + "}", true));
     }
@@ -146,7 +151,6 @@ public class StepsITest extends IntegrationTestWithJenkinsPerTest {
                 + "  }\n"
                 + "}", true));
     }
-
 
     /** Verifies that a {@link Tool} defines a {@link Symbol}. */
     @Test

--- a/src/test/java/io/jenkins/plugins/analysis/warnings/StepsITest.java
+++ b/src/test/java/io/jenkins/plugins/analysis/warnings/StepsITest.java
@@ -84,11 +84,6 @@ public class StepsITest extends IntegrationTestWithJenkinsPerTest {
                 + "         def report = scanForIssues tool: checkStyle(pattern: '**/" + fileName + "*')\n"
                 + "         echo '[total=' + report.size() + ']' \n"
                 + "         echo '[id=' + report.getId() + ']' \n"
-                + "         def issues = report.getIssues()\n"
-                + "         issues.each { issue ->\n"
-                + "             echo issue.toString()\n"
-                + "             echo issue.getOrigin()\n"
-                + "         }"
                 + "  }\n"
                 + "}", true));
     }


### PR DESCRIPTION
Since mapping of blames will be required in several places (see https://github.com/jenkinsci/warnings-ng-plugin/pull/389) it makes sense to encapsulate that behavior in a common place.