### PR TITLE
Add test case that tries to expose JENKINS-61593

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-    Map params = [platform: "docker && highmem", jdk: "8"]
+    Map params = [platform: "docker && highmem", jdk: "8", timeout: 120]
 
     // Faster build and reduces IO needs
     properties([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,15 +119,15 @@
                             }
 
                             if (first) {
-                                recordIssues enabledForFailure: true, tool: mavenConsole()
-                                recordIssues enabledForFailure: true, tool: errorProne()
-                                recordIssues enabledForFailure: true, tools: [java(), javaDoc()], sourceCodeEncoding: 'UTF-8'
-                                recordIssues tools: [spotBugs(), checkStyle(), pmdParser(), cpd()], sourceCodeEncoding: 'UTF-8'
+                                recordIssues enabledForFailure: true, tool: mavenConsole(), referenceJobName: 'Plugins/warnings-ng-plugin/master'
+                                recordIssues enabledForFailure: true, tool: errorProne(), referenceJobName: 'Plugins/warnings-ng-plugin/master'
+                                recordIssues enabledForFailure: true, tools: [java(), javaDoc()], sourceCodeEncoding: 'UTF-8', referenceJobName: 'Plugins/warnings-ng-plugin/master'
+                                recordIssues tools: [spotBugs(), checkStyle(), pmdParser(), cpd()], sourceCodeEncoding: 'UTF-8', referenceJobName: 'Plugins/warnings-ng-plugin/master'
                                 recordIssues enabledForFailure: true, tool: taskScanner(
                                         includePattern:'**/*.java',
                                         excludePattern:'target/**',
                                         highTags:'FIXME',
-                                        normalTags:'TODO'), sourceCodeEncoding: 'UTF-8'
+                                        normalTags:'TODO'), sourceCodeEncoding: 'UTF-8', referenceJobName: 'Plugins/warnings-ng-plugin/master'
                                 if (failFast && currentBuild.result == 'UNSTABLE') {
                                     error 'There were static analysis warnings; halting early'
                                 }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/Sanitizer.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/Sanitizer.java
@@ -10,7 +10,7 @@ import hudson.markup.MarkupFormatter;
 import hudson.markup.RawHtmlMarkupFormatter;
 
 /**
- * Sanitizes a piece of unsafe HTML code so that it can be rendered in an UI view.
+ * Sanitizes a piece of unsafe HTML code so that it can be rendered in a UI view.
  *
  * @author Ullrich Hafner
  */

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/recorder/all-severities.xml
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/recorder/all-severities.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="5.0">
+  <file name="/testfile.java">
+    <error line="1" column="1" severity="error" message="This is a error message." source="source"/>
+    <error line="1" column="1" severity="warning" message="This is a warning message." source="source"/>
+    <error line="1" column="1" severity="info" message="This is a info message." source="source"/>
+   </file>
+</checkstyle>


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-61593.

Since the test is successful, maybe the main problem was the wrong documentation. The documentation has been fixed with https://github.com/jenkinsci/warnings-ng-plugin/pull/434.