### PR TITLE
[JENKINS-56594] - Hide empty trend charts

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
@@ -208,13 +208,11 @@ public class JobAction implements Action, AsyncTrendChart {
 
     public boolean hasNoIssues() {
         History results =createBuildHistory(); //Get past build history
-        if(results instanceof AnalysisHistory){
-            Iterator<BuildResult<AnalysisBuildResult>> it = results.iterator();
-            while(it.hasNext()) {
-                BuildResult<AnalysisBuildResult> nextResult = it.next();
-                if(nextResult.getResult().getTotalSize() - nextResult.getResult().getTotalSizeOf(Severity.ERROR) != 0){
-                    return false;
-                }
+        Iterator<BuildResult<AnalysisBuildResult>> it = results.iterator();
+        while(it.hasNext()) {
+            BuildResult<AnalysisBuildResult> nextResult = it.next();
+            if(nextResult.getResult().getTotalSize() != 0){
+                return false;
             }
         }
         return true;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
@@ -1,8 +1,11 @@
 package io.jenkins.plugins.analysis.core.model;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Optional;
 
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.JacksonFacade;
 import edu.hm.hafner.echarts.LinesChartModel;
@@ -18,6 +21,7 @@ import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.analysis.core.charts.SeverityTrendChart;
 import io.jenkins.plugins.analysis.core.charts.ToolsTrendChart;
+import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 import io.jenkins.plugins.analysis.core.util.TrendChartType;
 import io.jenkins.plugins.echarts.AsyncTrendChart;
 
@@ -200,6 +204,20 @@ public class JobAction implements Action, AsyncTrendChart {
     @Override
     public boolean isTrendVisible() {
         return trendChartType != TrendChartType.NONE && createBuildHistory().hasMultipleResults();
+    }
+
+    public boolean noWarnings(){
+        History results =createBuildHistory(); //Get past build history
+        if(results instanceof AnalysisHistory){
+            Iterator<BuildResult<AnalysisBuildResult>> it = results.iterator();
+            while(it.hasNext()) {
+                BuildResult<AnalysisBuildResult> nextResult = it.next();
+                if(nextResult.getResult().getTotalSize() - nextResult.getResult().getTotalSizeOf(Severity.ERROR) != 0){
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
@@ -206,7 +206,7 @@ public class JobAction implements Action, AsyncTrendChart {
         return trendChartType != TrendChartType.NONE && createBuildHistory().hasMultipleResults();
     }
 
-    public boolean noWarnings(){
+    public boolean hasNoIssues() {
         History results =createBuildHistory(); //Get past build history
         if(results instanceof AnalysisHistory){
             Iterator<BuildResult<AnalysisBuildResult>> it = results.iterator();

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/JobAction/floatingBox.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/JobAction/floatingBox.jelly
@@ -4,12 +4,12 @@
  <j:choose>
    <j:when test="${from.noWarnings()}">
 
-     <c:trend-chart it="${from}" title="${from.trendName}" enableLinks="true"/>
+     <i:zero-issues/>
 
    </j:when>
    <j:otherwise>
 
-     <i:zero-issues/>
+     <c:trend-chart it="${from}" title="${from.trendName}" enableLinks="true"/>
 
    </j:otherwise>
 

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/JobAction/floatingBox.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/JobAction/floatingBox.jelly
@@ -1,6 +1,18 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:c="/charts">
+<j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:i="/issues">
 
-  <c:trend-chart it="${from}" title="${from.trendName}" enableLinks="true"/>
+ <j:choose>
+   <j:when test="${from.noWarnings()}">
+
+     <c:trend-chart it="${from}" title="${from.trendName}" enableLinks="true"/>
+
+   </j:when>
+   <j:otherwise>
+
+     <i:zero-issues/>
+
+   </j:otherwise>
+
+ </j:choose>
 
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/JobAction/floatingBox.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/JobAction/floatingBox.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:i="/issues">
 
  <j:choose>
-   <j:when test="${from.noWarnings()}">
+   <j:when test="${from.hasNoIssues()}">
 
      <i:zero-issues/>
 


### PR DESCRIPTION
Possible solution for Jenkins-56594 bug. Created a noWarnings() method to iterate through results and return true if it finds no warnings. Added check in floatingbox.jelly to display congratulations message if from has no warnings. 