### PR TITLE
[JENKINS-56699] Replace newlines `\n` with HTML equivalent `<br>` tags

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SourcePrinter.java
@@ -103,7 +103,7 @@ public class SourcePrinter {
         return div().with(table().withClass("analysis-title").with(tr().with(
                 td().with(img().withSrc(iconUrl)),
                 td().withClass("analysis-title-column")
-                        .with(div().withClass("analysis-warning-title").with(unescape(message))),
+                        .with(div().withClass("analysis-warning-title").with(replaceNewLine(message))),
                 createCollapseButton(isCollapseVisible)
         )));
     }
@@ -124,6 +124,11 @@ public class SourcePrinter {
                 div().withClasses("collapse", "analysis-detail")
                         .with(unescape(description))
                         .withId("analysis-description"));
+    }
+
+    private UnescapedText replaceNewLine(final String message) {
+        String m = message.replace("\n", "<br>");
+        return unescape(m);
     }
 
     private UnescapedText unescape(final String message) {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SourcePrinterTest.java
@@ -118,7 +118,26 @@ class SourcePrinterTest extends ResourceTest {
                 .isEqualToIgnoringWhitespace("Hello <b>Description</b>");
     }
 
-    @Test @org.jvnet.hudson.test.Issue("JENKINS-55679")
+    @Test
+    void shouldAddBreakOnNewLine() {
+        IssueBuilder builder = new IssueBuilder();
+        Issue issue = builder.setLineStart(7).setMessage("Hello <b>MessageLine1\nLine2\nLine3</b>").build();
+
+        SourcePrinter printer = new SourcePrinter();
+
+        Document document = Jsoup.parse(printer.render(asStream("format-java.txt"), issue,
+                NO_DESCRIPTION, ICON_URL));
+
+        assertThatCodeIsEqualToSourceText(document);
+
+        assertThat(document.getElementsByClass("analysis-warning-title").html())
+                .isEqualTo("Hello <b>MessageLine1<br>Line2<br>Line3</b>");
+        assertThat(document.getElementsByClass("analysis-detail")).isEmpty();
+        assertThat(document.getElementsByClass("collapse-panel")).isEmpty();
+    }
+
+    @Test
+    @org.jvnet.hudson.test.Issue("JENKINS-55679")
     void shouldRenderXmlFiles() {
         SourcePrinter printer = new SourcePrinter();
 


### PR DESCRIPTION
In reference to [JENKINS-56699](https://issues.jenkins-ci.org/browse/JENKINS-56699). Added a method to replace new lines with `<br>` in messages. Added test for new lines.