### PR TITLE
hpi-plugin.version=3.13 to fix bundling of transitive deps

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -26,6 +26,8 @@
 
     <module.name>${project.groupId}.warnings.ng</module.name>
 
+    <hpi-plugin.version>3.13</hpi-plugin.version> <!-- TODO pending 4.x parent in analysis-pom -->
+
     <analysis-model-api.version>8.0.1</analysis-model-api.version>
     <analysis-model-tests.version>8.0.1</analysis-model-tests.version>
     <forensics-api-plugin.version>0.7.0</forensics-api-plugin.version>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/maven-hpi-plugin/pull/172 to avoid

```
[WARNING] Bundling transitive dependency jsr305-2.0.3.jar (via docker-fixtures)
```

Would also suffice to pick up https://github.com/jenkinsci/docker-fixtures/pull/27.

(Why do you still use `analysis-pom` in `warnings-ng`? Better IMO to directly include the stock `plugin-pom`, which would make Dependabot easier to set up too.)