### PR TITLE
JENKINS-60149: Add UI test for Global Configuration

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -266,6 +266,9 @@ In order to let the plugin display those files you can add an additional source 
 
 ![affected files configuration](images/affected-files.png) 
 
+To enable additional source directories for scanning, the directories have to be added in the global configuration. 
+To select enabled directories for scanning, the directories have to be configured on job level.
+
 An example pipeline with these options is shown in the following snippet, note that the encoding of the report 
 files may be set differently if required:
 

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GlobalWarningsSettings.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GlobalWarningsSettings.java
@@ -5,6 +5,9 @@ import org.openqa.selenium.By;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.JenkinsConfig;
 
+/**
+ * Class representing the available global setting for the warnings-ng plugin
+ */
 public class GlobalWarningsSettings extends JenkinsConfig {
 
     private static final String XPATH_PLUGIN_CONFIG = "//*[@path='%s']";
@@ -22,7 +25,7 @@ public class GlobalWarningsSettings extends JenkinsConfig {
 
     /**
      * Enters the given sourcedirectory path on the system configuration page from jenkins.
-     * @param absolutePath: sourcedirectory path as absoule path.
+     * @param absolutePath sourcedirectory path as absoule path.
      */
     public void enterSourceDirectoryPath(final String absolutePath) {
         ensureConfigPage();

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GlobalWarningsSettings.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GlobalWarningsSettings.java
@@ -7,23 +7,51 @@ import org.jenkinsci.test.acceptance.po.JenkinsConfig;
 
 public class GlobalWarningsSettings extends JenkinsConfig {
 
-    private static final String XPATH_PLUGIN_CONFIG = "//*[@path='/io-jenkins-plugins-analysis-core-model-WarningsPluginConfiguration/%s']";
+    private static final String XPATH_PLUGIN_CONFIG = "//*[@path='%s']";
+
+    private static final String PATH_PREFIX = "/io-jenkins-plugins-analysis-";
+    private static final String GROOVY_PATH = PATH_PREFIX + "warnings-groovy-ParserConfiguration/";
+    private static final String SOURCE_DIR_PATH = PATH_PREFIX + "core-model-WarningsPluginConfiguration/";
+    private static final String BUTTON_ADD = "repeatable-add";
+    private static final String SOURCE_PATH_FIELD = "sourceDirectories/path";
+    private static final String PARSERS_PREFIX = "parsers/";
 
     public GlobalWarningsSettings(final Jenkins jenkins) {
         super(jenkins);
     }
 
+    /**
+     * Enters the given sourcedirectory path on the system configuration page from jenkins.
+     * @param absolutePath: sourcedirectory path as absoule path.
+     */
     public void enterSourceDirectoryPath(final String absolutePath) {
         ensureConfigPage();
 
-        driver.findElement(By.xpath(String.format(XPATH_PLUGIN_CONFIG, "repeatable-add"))).click();
-        driver.findElement(By.xpath(String.format(XPATH_PLUGIN_CONFIG, "sourceDirectories/path")))
+        driver.findElement(By.xpath(String.format(XPATH_PLUGIN_CONFIG, SOURCE_DIR_PATH + BUTTON_ADD))).click();
+        driver.findElement(By.xpath(String.format(XPATH_PLUGIN_CONFIG, SOURCE_DIR_PATH + SOURCE_PATH_FIELD)))
                 .sendKeys(absolutePath);
     }
 
+    /**
+     * Returns the home directory of the current jenkins instance which is displayed on the system configuration page.
+     * @return home directory of the current jenkins instance.
+     */
     public String getHomeDirectory() {
+        ensureConfigPage();
+
         return driver.findElement(By.xpath("//td[contains(text(), 'Home directory')]//..//*[@class='setting-main']"))
                 .getText();
+    }
+
+    /**
+     * Opens the groovy parser configuration section on the system configuration page from jenkins.
+     * @return GroovyConfiguration Page Object to fill the parser configuration.
+     */
+    public GroovyConfiguration openGroovyConfiguration() {
+        ensureConfigPage();
+
+        driver.findElement(By.xpath(String.format(XPATH_PLUGIN_CONFIG, GROOVY_PATH + BUTTON_ADD))).click();
+        return new GroovyConfiguration(this, url, GROOVY_PATH + PARSERS_PREFIX, XPATH_PLUGIN_CONFIG);
     }
 
 }

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GlobalWarningsSettings.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GlobalWarningsSettings.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import org.openqa.selenium.By;
+
+import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.jenkinsci.test.acceptance.po.JenkinsConfig;
+
+public class GlobalWarningsSettings extends JenkinsConfig {
+
+    private static final String XPATH_PLUGIN_CONFIG = "//*[@path='/io-jenkins-plugins-analysis-core-model-WarningsPluginConfiguration/%s']";
+
+    public GlobalWarningsSettings(final Jenkins jenkins) {
+        super(jenkins);
+    }
+
+    public void enterSourceDirectoryPath(final String absolutePath) {
+        ensureConfigPage();
+
+        driver.findElement(By.xpath(String.format(XPATH_PLUGIN_CONFIG, "repeatable-add"))).click();
+        driver.findElement(By.xpath(String.format(XPATH_PLUGIN_CONFIG, "sourceDirectories/path")))
+                .sendKeys(absolutePath);
+    }
+
+    public String getHomeDirectory() {
+        return driver.findElement(By.xpath("//td[contains(text(), 'Home directory')]//..//*[@class='setting-main']"))
+                .getText();
+    }
+
+}

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GroovyConfiguration.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GroovyConfiguration.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.analysis.warnings;
 import java.net.URL;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 import org.jenkinsci.test.acceptance.po.PageObject;
 
@@ -14,13 +13,11 @@ public class GroovyConfiguration extends PageObject {
 
     private final String pathPrefix;
     private final String xpathPattern;
-    private WebDriverWait wait;
 
     protected GroovyConfiguration(final PageObject context, final URL url, final String pathPrefix, final String xpathPattern) {
         super(context, url);
         this.pathPrefix = pathPrefix;
         this.xpathPattern = xpathPattern;
-        this.wait = new WebDriverWait(driver, 10);
     }
 
     /**

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GroovyConfiguration.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GroovyConfiguration.java
@@ -7,6 +7,9 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import org.jenkinsci.test.acceptance.po.PageObject;
 
+/**
+ * Class representing the groovy parser configuration in the global settings.
+ */
 public class GroovyConfiguration extends PageObject {
 
     private final String pathPrefix;

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GroovyConfiguration.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/GroovyConfiguration.java
@@ -1,0 +1,66 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import java.net.URL;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import org.jenkinsci.test.acceptance.po.PageObject;
+
+public class GroovyConfiguration extends PageObject {
+
+    private final String pathPrefix;
+    private final String xpathPattern;
+    private WebDriverWait wait;
+
+    protected GroovyConfiguration(final PageObject context, final URL url, final String pathPrefix, final String xpathPattern) {
+        super(context, url);
+        this.pathPrefix = pathPrefix;
+        this.xpathPattern = xpathPattern;
+        this.wait = new WebDriverWait(driver, 10);
+    }
+
+    /**
+     * enters given param into the name field of the groovy script.
+     * @param name to be entered.
+     */
+    public void enterName(final String name) {
+        enterIntoInput(name, "name");
+    }
+
+    /**
+     * enters given param into the id field of the groovy script.
+     * @param id to be entered.
+     */
+    public void enterId(final String id) {
+        enterIntoInput(id, "id");
+    }
+
+    /**
+     * enters given param into the regex field of the groovy script.
+     * @param regex to be entered.
+     */
+    public void enterRegex(final String regex) {
+        enterIntoInput(regex, "regexp");
+    }
+
+    /**
+     * enters given param into the script field of the groovy script.
+     * @param script to be entered. Should not contain '\t' characters.
+     */
+    public void enterScript(final String script) {
+        enterIntoInput(script, "script");
+    }
+
+    /**
+     * enters given param into the example message field of the groovy script.
+     * @param exampleMessage to be entered. Should not contain '\t' characters.
+     */
+    public void enterExampleLogMessage(final String exampleMessage) {
+        enterIntoInput(exampleMessage, "example");
+    }
+
+    private void enterIntoInput(final String text, final String path) {
+        driver.findElement(By.xpath(String.format(xpathPattern, pathPrefix + path))).sendKeys(text);
+    }
+}

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
@@ -28,6 +28,7 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
     private final Control referenceJobField = control("referenceJob");
     private final Control aggregatingResultsCheckBox = control("aggregatingResults");
     private final Control sourceCodeEncoding = control("sourceCodeEncoding");
+    private final Control sourceDirectory = control("sourceDirectory");
 
     /**
      * Determines the result of the quality gate.
@@ -161,6 +162,19 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
     }
 
     /**
+     * Sets the path to the folder that contains the source code. If not relative and thus not part of the workspace
+     * then this folder needs to be added in Jenkins global configuration.
+     *
+     * @param sourceDirectory
+     *         a folder containing the source code
+     */
+    public void setSourceDirectory(final String sourceDirectory) {
+        openAdvancedOptions();
+
+        this.sourceDirectory.set(sourceDirectory);
+    }
+
+    /**
      * Enables or disables the checkbox 'enabledForFailure'.
      *
      * @param isChecked
@@ -258,7 +272,7 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
         qualityGate.setType(type);
         qualityGate.setUnstable(result == QualityGateBuildResult.UNSTABLE);
     }
-    
+
     /**
      * Adds a new issue filter.
      *

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/AbstractUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/AbstractUiTest.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.jenkinsci.test.acceptance.po.Job;
+
+public abstract class AbstractUiTest extends AbstractJUnitTest {
+
+    protected static final String WARNINGS_PLUGIN_PREFIX = "/";
+
+
+    protected FreeStyleJob createFreeStyleJob(final String... resourcesToCopy) {
+        FreeStyleJob job = jenkins.getJobs().create(FreeStyleJob.class);
+        ScrollerUtil.hideScrollerTabBar(driver);
+        for (String resource : resourcesToCopy) {
+            job.copyResource(WARNINGS_PLUGIN_PREFIX + resource);
+        }
+        return job;
+    }
+
+    protected Build buildJob(final Job job) {
+        return job.startBuild().waitUntilFinished();
+    }
+}

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/GlobalConfigurationUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/GlobalConfigurationUiTest.java
@@ -1,0 +1,84 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+
+import io.jenkins.plugins.analysis.warnings.AnalysisResult.Tab;
+import io.jenkins.plugins.analysis.warnings.AnalysisSummary.InfoType;
+
+import static io.jenkins.plugins.analysis.warnings.Assertions.*;
+
+@WithPlugins("warnings-ng")
+public class GlobalConfigurationUiTest extends AbstractUiTest {
+
+    private static final String GCC_ID = "gcc";
+
+    @Test
+    public void shouldRunJobWithDifferentSourceCodeDirectory() throws IOException, URISyntaxException {
+        FreeStyleJob job = createFreeStyleJob();
+        addRecorder(job);
+        job.save();
+
+        // set global settings
+        GlobalWarningsSettings settings = new GlobalWarningsSettings(jenkins);
+        settings.configure();
+        String homeDir = settings.getHomeDirectory();
+        String jobDir = homeDir + File.separator + "jobs" + File.separator + job.name;
+        settings.enterSourceDirectoryPath(jobDir);
+        settings.save();
+
+        // create dynamically built file in target workspace
+        String content = String.format("%s/config.xml:451: warning: foo defined but not used%n", jobDir);
+
+        Path workspacePath = Paths.get(homeDir).resolve("workspace");
+        Files.createDirectory(workspacePath);
+        workspacePath = workspacePath.resolve(job.name);
+        Files.createDirectory(workspacePath);
+
+        File newFile = workspacePath.resolve("gcc.log").toFile();
+        boolean newFile1 = newFile.createNewFile();
+        FileWriter writer = new FileWriter(newFile);
+        writer.write(content);
+        writer.flush();
+        writer.close();
+
+        // start building and verifying result
+        Build build = buildJob(job);
+
+        verifyGcc(build);
+    }
+
+    private IssuesRecorder addRecorder(final FreeStyleJob job) {
+        return job.addPublisher(IssuesRecorder.class, recorder -> {
+            recorder.setTool("GNU C Compiler (gcc)", gcc -> gcc.setPattern("**/gcc.log"));
+            recorder.setEnabledForFailure(true);
+            recorder.setSourceCodeEncoding("UTF-8");
+        });
+    }
+
+    private void verifyGcc(final Build build) {
+        build.open();
+        AnalysisSummary gcc = new AnalysisSummary(build, GCC_ID);
+        assertThat(gcc).isDisplayed()
+                .hasTitleText("GNU C Compiler (gcc): One warning")
+                .hasReferenceBuild(0)
+                .hasInfoType(InfoType.INFO);
+
+        AnalysisResult gccDetails = gcc.openOverallResult();
+        assertThat(gccDetails).hasActiveTab(Tab.ISSUES);
+
+        IssuesTableRow row = gccDetails.openIssuesTable().getRowAs(0, IssuesTableRow.class);
+        assertThat(row.getFileLink()).isNotNull();
+    }
+}

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/GlobalConfigurationUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/GlobalConfigurationUiTest.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.analysis.warnings;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,10 +24,10 @@ public class GlobalConfigurationUiTest extends AbstractUiTest {
     private static final String GCC_ID = "gcc";
 
     @Test
-    public void shouldRunJobWithDifferentSourceCodeDirectory() throws IOException, URISyntaxException {
+    public void shouldRunJobWithDifferentSourceCodeDirectory() throws IOException {
         String homeDir = getHomeDir();
 
-        FreeStyleJob job = initJob();
+        FreeStyleJob job = initJob(homeDir);
 
         // create dynamically built file in target workspace
         createFileInWorkspace(job, homeDir);
@@ -42,9 +41,9 @@ public class GlobalConfigurationUiTest extends AbstractUiTest {
         verifyGcc(build);
     }
 
-    private FreeStyleJob initJob() {
+    private FreeStyleJob initJob(final String homeDir) {
         FreeStyleJob job = createFreeStyleJob();
-        addRecorder(job);
+        addRecorder(job, homeDir);
         job.save();
         return job;
     }
@@ -92,11 +91,12 @@ public class GlobalConfigurationUiTest extends AbstractUiTest {
         return homeDir + File.separator + "jobs" + File.separator + job.name;
     }
 
-    private IssuesRecorder addRecorder(final FreeStyleJob job) {
+    private IssuesRecorder addRecorder(final FreeStyleJob job, final String homeDir) {
         return job.addPublisher(IssuesRecorder.class, recorder -> {
             recorder.setTool("GNU C Compiler (gcc)", gcc -> gcc.setPattern("**/gcc.log"));
             recorder.setEnabledForFailure(true);
             recorder.setSourceCodeEncoding("UTF-8");
+            recorder.setSourceDirectory(getJobDir(homeDir, job));
         });
     }
 

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/GlobalConfigurationUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/GlobalConfigurationUiTest.java
@@ -23,6 +23,9 @@ public class GlobalConfigurationUiTest extends AbstractUiTest {
 
     private static final String GCC_ID = "gcc";
 
+    /**
+     * Verifies that a source code file will be copied from outside the workspace and linked in the open issues tab.
+     */
     @Test
     public void shouldRunJobWithDifferentSourceCodeDirectory() throws IOException {
         String homeDir = getHomeDir();

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/WarningsPluginUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/WarningsPluginUiTest.java
@@ -56,8 +56,7 @@ import static io.jenkins.plugins.analysis.warnings.Assertions.*;
  */
 @WithPlugins("warnings-ng")
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity", "PMD.SystemPrintln", "PMD.ExcessiveImports"})
-public class WarningsPluginUiTest extends AbstractJUnitTest {
-    private static final String WARNINGS_PLUGIN_PREFIX = "/";
+public class WarningsPluginUiTest extends  AbstractUiTest {
 
     private static final String CHECKSTYLE_ID = "checkstyle";
     private static final String ANALYSIS_ID = "analysis";
@@ -532,23 +531,10 @@ public class WarningsPluginUiTest extends AbstractJUnitTest {
         return agent;
     }
 
-    private FreeStyleJob createFreeStyleJob(final String... resourcesToCopy) {
-        FreeStyleJob job = jenkins.getJobs().create(FreeStyleJob.class);
-        ScrollerUtil.hideScrollerTabBar(driver);
-        for (String resource : resourcesToCopy) {
-            job.copyResource(WARNINGS_PLUGIN_PREFIX + resource);
-        }
-        return job;
-    }
-
     private MavenModuleSet createMavenProject() {
         MavenInstallation.installMaven(jenkins, MavenInstallation.DEFAULT_MAVEN_ID, "3.6.3");
 
         return jenkins.getJobs().create(MavenModuleSet.class);
-    }
-
-    private Build buildJob(final Job job) {
-        return job.startBuild().waitUntilFinished();
     }
 
     private void copyResourceFilesToWorkspace(final Job job, final String... resources) {

--- a/ui-tests/src/test/resources/groovy_parser/pep8Test.txt
+++ b/ui-tests/src/test/resources/groovy_parser/pep8Test.txt
@@ -1,0 +1,8 @@
+optparse.py:69:11: E401 multiple imports on one line
+optparse.py:77:1: E302 expected 2 blank lines, found 1
+optparse.py:88:5: E301 expected 1 blank line, found 0
+optparse.py:222:34: W602 deprecated form of raising exception
+optparse.py:347:31: E211 whitespace before '('
+optparse.py:357:17: E201 whitespace after '{'
+optparse.py:472:29: E221 multiple spaces before operator
+optparse.py:544:21: W601 .has_key() is deprecated, use 'in'


### PR DESCRIPTION
@uhafner: Ich stoße leider gerade auf eine Wand. Ich hoffe, Sie könnten mir eventuell weiter helfen :)

Und zwar habe ich mich für den Test an ```AffectedFilesResolverITest#shouldShowFileOutsideWorkspaceIfConfigured()``` gehalten.

Den Testaufbau habe ich absolut identisch, aber bei mir wird der Link zum Source Code irgendwie nicht erstellt. Das unterschiedliche Ergebnis lässt sich auf eine Zeile im Log zurück führen:

An meinem Orientierungstest wird die Datei mit den Issues gelesen und erkannt. Anschließend wird die Datei kopiert und es kommt zu folgender Log-Meldung:

```
[GNU C Compiler (gcc)] Creating fingerprints for all affected code blocks to track issues over different builds
[GNU C Compiler (gcc)] -> created fingerprints for 1 issues (skipped 0 issues)
[GNU C Compiler (gcc)] Copying affected files to Jenkins' build folder 'C:\Users\ANDREA~1\AppData\Local\Temp\j h8689302102478511521\jobs\test0\builds\2\files-with-issues'
[GNU C Compiler (gcc)] -> 1 copied, 0 not in workspace, 0 not-found, 0 with I/O error
```

Bei meinem Test hingegen wird die Datei nicht kopiert und die Log-Meldung lautet:

```
[GNU C Compiler (gcc)] -> created fingerprints for 1 issues (skipped 0 issues)
[GNU C Compiler (gcc)] Copying affected files to Jenkins' build folder 'E:\projects\testen\warnings-ng-plugin\ui-tests\target\jenkins7580279650552198810home\jobs\flexible_knife\builds\1\files-with-issues'
[GNU C Compiler (gcc)] -> 0 copied, 1 not in workspace, 0 not-found, 0 with I/O error
```

Der Rest des Logs ist komplett identisch. (Die angegeben Dateipfade sind aufgrund der unterschiedlichen Tests anders. Die Pfade sind aber korrekt)

Ich hab auch die Job- und Systemkonfigurationen zur Laufzeit verglichen und die sind auch identisch. 

Haben Sie eventuell eine Idee, was ich noch übersehen haben könnte? Oder habe ich tatsächlich einen Bug entdeckt? :)