### PR TITLE
Fix title of origin breadcrumb

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
@@ -177,9 +177,18 @@ public class DetailFactory {
     }
 
     private String getDisplayNameOfDetails(final String property, final Report selectedIssues) {
+        if ("origin".equals(property)) {
+            LabelProviderFactory factory = createFactory();
+            return factory.create(getPropertyValueAsString(property, selectedIssues)).getName();
+        }
         return getColumnHeaderFor(selectedIssues, property)
                 + " "
                 + getPropertyValueAsString(property, selectedIssues);
+    }
+
+    @VisibleForTesting
+    private LabelProviderFactory createFactory() {
+        return new LabelProviderFactory(jenkins);
     }
 
     private String getPropertyValueAsString(final String property, final Report selectedIssues) {


### PR DESCRIPTION
Rather than showing a generic title the breadcrumb should show the name of the Tool.