### PR TITLE
[JENKINS-59619] Create unit test for JobAction

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
@@ -1,0 +1,54 @@
+package io.jenkins.plugins.analysis.core.model;
+
+import org.junit.jupiter.api.Test;
+
+import hudson.model.Job;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link JobAction}.
+ * 
+ * @author Kasper Heyndrickx
+ */
+class JobActionTest {
+    private static final String LINK_NAME = "link-name";
+    private static final String TREND_NAME = "trend-name";
+    private static final String ID = "jobaction-id";
+
+    @Test
+    void shouldUseLabelProviderLinkNameAsDisplayName() {
+        Job<?, ?> job = mock(Job.class);
+        StaticAnalysisLabelProvider labelProvider = mock(StaticAnalysisLabelProvider.class);
+        when(labelProvider.getLinkName()).thenReturn(LINK_NAME);
+        JobAction action = new JobAction(job, labelProvider, 1);
+        assertThat(action.getDisplayName()).isEqualTo(LINK_NAME);
+    }
+    
+    @Test
+    void shouldUseLabelProviderTrendNameAsTrendName() {
+        Job<?, ?> job = mock(Job.class);
+        StaticAnalysisLabelProvider labelProvider = mock(StaticAnalysisLabelProvider.class);
+        when(labelProvider.getTrendName()).thenReturn(TREND_NAME); 
+        JobAction action = new JobAction(job, labelProvider, 1);
+        assertThat(action.getTrendName()).isEqualTo(TREND_NAME); 
+    } 
+
+    @Test
+    void shouldUseLabelProviderIDAsID() {
+        Job<?, ?> job = mock(Job.class);
+        StaticAnalysisLabelProvider labelProvider = mock(StaticAnalysisLabelProvider.class);
+        when(labelProvider.getId()).thenReturn(ID); 
+        JobAction action = new JobAction(job, labelProvider, 1);
+        assertThat(action.getId()).isEqualTo(ID); 
+    } 
+
+    @Test
+    void shouldSetOwner() {
+        Job<?, ?> job = mock(Job.class);
+        StaticAnalysisLabelProvider labelProvider = mock(StaticAnalysisLabelProvider.class);
+        JobAction action = new JobAction(job, labelProvider, 1);
+        assertThat(action.getOwner()).isEqualTo(job); 
+    } 
+} 


### PR DESCRIPTION
Added some basic unit tests. 
Untested methods use 'createBuildHistory()', which makes it hard to use mocks... I'm not sure how to get around this without some refactoring. 