### PR TITLE
Update antisamy-markup-formatter-plugin version

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -65,7 +65,7 @@
     <junit-plugin.version>1.24</junit-plugin.version>
     <git-plugin.version>4.2.2</git-plugin.version>
     <structs.version>1.20</structs.version>
-    <antisamy-markup-formatter.version>1.5</antisamy-markup-formatter.version>
+    <antisamy-markup-formatter.version>2.1</antisamy-markup-formatter.version>
     <dashboard-view.version>2.9.4</dashboard-view.version>
     <script-security.version>1.62</script-security.version>
     <credentials.version>2.3.0</credentials.version>
@@ -702,4 +702,3 @@
   </pluginRepositories>
 
 </project>
-

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
@@ -31,9 +31,9 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class AbstractDetailsModelTest {
     static final String DESCRIPTION
-            = join("Hello description with", a().withHref("url").withText("link")).render();
+            = join("Hello description with", a().withHref("url").withText("link").withRel("nofollow")).render();
     private static final String MESSAGE
-            = join("Hello message with", a().withHref("url").withText("link")).render();
+            = join("Hello message with", a().withHref("url").withText("link").withRel("nofollow")).render();
     /** Details icon that opens a new row. */
     protected static final String DETAILS_ICON = "<svg class=\"details-icon svg-icon\"><use href=\"/path/to/icon\"></use></svg>";
     static final String EXPECTED_DESCRIPTION = String.format(


### PR DESCRIPTION
See https://github.com/jenkinsci/plugin-compat-tester/pull/249

I'm trying to make Warnings NG Plugin executable on PCT. Using a war with latest LTS and recent versions of plugins bundled on it, the execution throws some errors:
```
[INFO] Failed: 5
[INFO] - io.jenkins.plugins.analysis.core.model.BlamesModelTest.shouldShowIssueWithBlames
[INFO] - io.jenkins.plugins.analysis.core.model.BlamesModelTest.shouldShowIssueWithoutBlames
[INFO] - io.jenkins.plugins.analysis.core.model.ForensicsModelTest.shouldShowIssueWithForensics
[INFO] - io.jenkins.plugins.analysis.core.model.ForensicsModelTest.shouldShowIssueWithoutForensics
[INFO] - io.jenkins.plugins.analysis.core.model.IssuesModelTest.shouldConvertIssuesToArrayWithAllColumns
```
I've analysed the errors just in case the PCT was throwing some sort of incompatibility between plugins, but it's not the case. What I've seen is this plugin has an old version of `antisamy-markup-formatter-plugin`. Newer versions include new elements/tags such as `rel="nofollow"`. My testing has probed me there is no impact in the plugin, but the tests have to be updated.

### Updating the version is safe for this plugin:
- https://github.com/jenkinsci/antisamy-markup-formatter-plugin/compare/antisamy-markup-formatter-1.5...antisamy-markup-formatter-2.1
- From plugin documentation: https://github.com/jenkinsci/antisamy-markup-formatter-plugin/#owasp-markup-formatter-plugin
  - The update is safe
  - Version 2.0 reduced the set of allowed elements, so it's a good idea to update.

@uhafner 