### PR TITLE
Update checks-api to 0.2.0

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -82,7 +82,7 @@
     <form-element-path.version>1.8</form-element-path.version>
     <folder.version>6.9</folder.version>
     <scm-api.version>2.6.3</scm-api.version>
-    <checks-api.version>0.1.0</checks-api.version>
+    <checks-api.version>0.2.0</checks-api.version>
 
     <!-- Maven Surefire ArgLine -->
     <argLine>-Djava.awt.headless=true -Xmx1024m</argLine>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -721,7 +721,7 @@ public class IssuesRecorder extends Recorder {
         ResultAction action = publisher.attachAction(trendChartType);
 
         if (!skipPublishingChecks) {
-            WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action);
+            WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, listener);
             checksPublisher.publishChecks();
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -831,7 +831,7 @@ public class PublishIssuesStep extends Step implements Serializable {
             ResultAction action = publisher.attachAction(step.getTrendChartType());
 
             if (!step.isSkipPublishingChecks()) {
-                WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action);
+                WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, getTaskListener());
                 checksPublisher.publishChecks();
             }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -13,7 +13,6 @@ import org.jsoup.nodes.TextNode;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.util.VisibleForTesting;
 
-import hudson.model.Queue.Task;
 import hudson.model.TaskListener;
 
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -13,6 +13,9 @@ import org.jsoup.nodes.TextNode;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.util.VisibleForTesting;
 
+import hudson.model.Queue.Task;
+import hudson.model.TaskListener;
+
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider;
@@ -36,9 +39,11 @@ import io.jenkins.plugins.checks.api.ChecksStatus;
  */
 class WarningChecksPublisher {
     private final ResultAction action;
+    private final TaskListener listener;
 
-    WarningChecksPublisher(final ResultAction action) {
+    WarningChecksPublisher(final ResultAction action, final TaskListener listener) {
         this.action = action;
+        this.listener = listener;
     }
 
     /**
@@ -46,7 +51,7 @@ class WarningChecksPublisher {
      * checks.
      */
     void publishChecks() {
-        ChecksPublisher publisher = ChecksPublisherFactory.fromRun(action.getOwner());
+        ChecksPublisher publisher = ChecksPublisherFactory.fromRun(action.getOwner(), listener);
         publisher.publish(extractChecksDetails());
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -11,6 +11,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleProject;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSuite;
 import io.jenkins.plugins.analysis.core.util.QualityGate.QualityGateResult;
@@ -27,6 +28,7 @@ import io.jenkins.plugins.checks.api.ChecksOutput.ChecksOutputBuilder;
 import io.jenkins.plugins.checks.api.ChecksStatus;
 
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link WarningChecksPublisher}.
@@ -57,7 +59,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasNewSize(2);
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class));
         assertThat(publisher.extractChecksDetails())
                 .hasFieldOrPropertyWithValue("detailsURL", Optional.of(getResultAction(run).getAbsoluteUrl()))
                 .usingRecursiveComparison()
@@ -72,7 +74,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 recorder -> recorder.addQualityGate(10, QualityGateType.TOTAL, QualityGateResult.UNSTABLE));
 
         Run<?, ?> build = buildSuccessfully(project);
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), mock(TaskListener.class));
 
         assertThat(publisher.extractChecksDetails().getConclusion())
                 .isEqualTo(ChecksConclusion.SUCCESS);
@@ -98,7 +100,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
         copySingleFileToWorkspace(project, "PVSReport.xml", "PVSReport.plog");
         Run<?, ?> run = buildSuccessfully(project);
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class));
         ChecksDetails details = publisher.extractChecksDetails();
 
         assertThat(details.getOutput().get().getChecksAnnotations())
@@ -120,7 +122,8 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(0)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run)).extractChecksDetails().getOutput())
+        assertThat(new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class))
+                .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
                 .hasFieldOrPropertyWithValue("title", Optional.of("No issues."));
@@ -136,7 +139,8 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(4)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run)).extractChecksDetails().getOutput())
+        assertThat(new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class))
+                .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
                 .hasFieldOrPropertyWithValue("title", Optional.of("No new issues, 4 total."));
@@ -158,7 +162,8 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasNewSize(6);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run)).extractChecksDetails().getOutput())
+        assertThat(new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class))
+                .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
                 .hasFieldOrPropertyWithValue("title", Optional.of("6 new issues."));
@@ -245,7 +250,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasQualityGateStatus(qualityGateResult.getStatus());
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), mock(TaskListener.class));
         assertThat(publisher.extractChecksDetails().getConclusion())
                 .isEqualTo(ChecksConclusion.FAILURE);
     }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -28,7 +28,6 @@ import io.jenkins.plugins.checks.api.ChecksOutput.ChecksOutputBuilder;
 import io.jenkins.plugins.checks.api.ChecksStatus;
 
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link WarningChecksPublisher}.
@@ -59,7 +58,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasNewSize(2);
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL);
         assertThat(publisher.extractChecksDetails())
                 .hasFieldOrPropertyWithValue("detailsURL", Optional.of(getResultAction(run).getAbsoluteUrl()))
                 .usingRecursiveComparison()
@@ -74,7 +73,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 recorder -> recorder.addQualityGate(10, QualityGateType.TOTAL, QualityGateResult.UNSTABLE));
 
         Run<?, ?> build = buildSuccessfully(project);
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), mock(TaskListener.class));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL);
 
         assertThat(publisher.extractChecksDetails().getConclusion())
                 .isEqualTo(ChecksConclusion.SUCCESS);
@@ -100,7 +99,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
         copySingleFileToWorkspace(project, "PVSReport.xml", "PVSReport.plog");
         Run<?, ?> run = buildSuccessfully(project);
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL);
         ChecksDetails details = publisher.extractChecksDetails();
 
         assertThat(details.getOutput().get().getChecksAnnotations())
@@ -122,7 +121,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(0)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class))
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL)
                 .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
@@ -139,7 +138,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(4)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class))
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL)
                 .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
@@ -162,7 +161,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasNewSize(6);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), mock(TaskListener.class))
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL)
                 .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
@@ -250,7 +249,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasQualityGateStatus(qualityGateResult.getStatus());
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), mock(TaskListener.class));
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL);
         assertThat(publisher.extractChecksDetails().getConclusion())
                 .isEqualTo(ChecksConclusion.FAILURE);
     }


### PR DESCRIPTION
Update checks-api to 0.2.0 to adopt in-compatible new methods with task listener.

cc @timja 