### PR TITLE
Add a dummy XStream Converter for `Report` instances

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -27,11 +27,11 @@
     <module.name>${project.groupId}.warnings.ng</module.name>
     <jenkins.version>${jenkins.baseline}.6</jenkins.version>
     
-    <analysis-model-api.version>8.2.0</analysis-model-api.version>
-    <analysis-model-tests.version>8.2.0</analysis-model-tests.version>
+    <analysis-model-api.version>9.0.0</analysis-model-api.version>
+    <analysis-model-tests.version>9.0.0</analysis-model-tests.version>
     <forensics-api-plugin.version>0.7.0</forensics-api-plugin.version>
     <git-forensics-plugin.version>0.7.0</git-forensics-plugin.version>
-    <plugin-util-api.version>1.2.2</plugin-util-api.version>
+    <plugin-util-api.version>1.2.5</plugin-util-api.version>
 
     <font-awesome-api.version>5.13.0-1</font-awesome-api.version>
     <jquery3-api.version>3.5.1-1</jquery3-api.version>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportXmlStream.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportXmlStream.java
@@ -6,8 +6,10 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.mapper.Mapper;
 
 import edu.hm.hafner.analysis.DuplicationGroup;
 import edu.hm.hafner.analysis.Issue;
@@ -19,6 +21,7 @@ import edu.hm.hafner.util.Ensure;
 import edu.hm.hafner.util.TreeString;
 
 import hudson.util.RobustCollectionConverter;
+import hudson.util.RobustReflectionConverter;
 import hudson.util.XStream2;
 
 import io.jenkins.plugins.util.AbstractXmlStream;
@@ -40,6 +43,7 @@ class ReportXmlStream extends AbstractXmlStream<Report> {
 
     @Override
     protected void configureXStream(final XStream2 xStream) {
+        xStream.registerConverter(new ReportConverter(xStream.getMapper(), xStream.getReflectionProvider()));
         xStream.registerConverter(new LineRangeListConverter(xStream));
         xStream.registerConverter(new SeverityConverter());
         xStream.alias("lineRange", LineRange.class);
@@ -52,7 +56,6 @@ class ReportXmlStream extends AbstractXmlStream<Report> {
     /**
      * {@link Converter} implementation for XStream.
      */
-    @SuppressWarnings("rawtypes")
     private static final class LineRangeListConverter extends RobustCollectionConverter {
         /**
          * Creates a nex {@link LineRangeListConverter} instance.
@@ -103,6 +106,34 @@ class ReportXmlStream extends AbstractXmlStream<Report> {
         @Override
         public boolean canConvert(final Class type) {
             return type == Severity.class;
+        }
+    }
+
+    /**
+     * A dummy converter for {@link Report} instances that simply delegates to a {@link RobustReflectionConverter}. This
+     * workaround is required since {@link Report} instances now have custom serialization methods.
+     */
+    private static class ReportConverter implements Converter {
+        private final RobustReflectionConverter ref;
+
+        ReportConverter(final Mapper mapper, final ReflectionProvider reflectionProvider) {
+            this.ref = new RobustReflectionConverter(mapper, reflectionProvider);
+        }
+
+        @Override
+        public void marshal(final Object source, final HierarchicalStreamWriter writer,
+                final MarshallingContext context) {
+            this.ref.marshal(source, writer, context);
+        }
+
+        @Override
+        public Object unmarshal(final HierarchicalStreamReader reader, final UnmarshallingContext context) {
+            return this.ref.unmarshal(reader, context);
+        }
+
+        @Override
+        public boolean canConvert(final Class type) {
+            return type == Report.class;
         }
     }
 }


### PR DESCRIPTION
XStream refuses to serialize Serializable instances with custom read/write methods. Registering a custom converter provides a simple workaround. Required due to changed serialization in https://github.com/jenkinsci/analysis-model/releases/tag/v9.0.0