### PR TITLE
Include counts by severity in aggregation API response.

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -698,7 +698,7 @@ The plugin provides the following REST API endpoints.
 
 All static analysis tools that have been configured in a build can be queried by using the URL 
 `[build-url]/warnings-ng/api/json` (or `[build-url]/warnings-ng/api/xml`). This aggregation shows ID, name, URL and 
-total number of issues for each tool.
+total number of issues, and breakdown of issue count by severity for each tool.
 
 ```json
 {
@@ -708,49 +708,81 @@ total number of issues for each tool.
       "id": "maven",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/maven",
       "name": "Maven Warnings",
-      "size": 9
+      "size": 9,
+      "errorSize": 0,
+      "highSize": 6,
+      "normalSize": 1,
+      "lowSize": 2
     },
     {
       "id": "java",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/java",
       "name": "Java Warnings",
-      "size": 1
+      "size": 1,
+      "errorSize": 1,
+      "highSize": 0,
+      "normalSize": 0, 
+      "lowSize": 0
     },
     {
       "id": "javadoc",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/javadoc",
       "name": "JavaDoc Warnings",
-      "size": 0
+      "size": 0,
+      "errorSize": 0,
+      "highSize": 0,
+      "normalSize": 0,
+      "lowSize": 0
     },
     {
       "id": "checkstyle",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/checkstyle",
       "name": "CheckStyle Warnings",
-      "size": 0
+      "size": 0,
+      "errorSize": 0,
+      "highSize": 0,
+      "normalSize": 0,
+      "lowSize": 0
     },
     {
       "id": "pmd",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/pmd",
       "name": "PMD Warnings",
-      "size": 671
+      "size": 671,
+      "errorSize": 0,
+      "highSize": 1,
+      "normalSize": 70,
+      "lowSize": 600
     },
     {
       "id": "spotbugs",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/spotbugs",
       "name": "SpotBugs Warnings",
-      "size": 0
+      "size": 0,
+      "errorSize": 0,
+      "highSize": 0,
+      "normalSize": 0,
+      "lowSize": 0
     },
     {
       "id": "cpd",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/cpd",
       "name": "CPD Warnings",
-      "size": 123
+      "size": 123,
+      "errorSize": 0,
+      "highSize": 0,
+      "normalSize": 23,
+      "lowSize": 100
     },
     {
       "id": "open-tasks",
       "latestUrl": "http://localhost:8080/view/White%20Mountains/job/New%20-%20Pipeline%20-%20Simple%20Model/26/open-tasks",
       "name": "Open Tasks Scanner Warnings",
-      "size": 11
+      "size": 11,
+      "errorSize": 0,
+      "highSize": 0,
+      "normalSize": 11,
+      "lowSize": 0
     }
   ]
 }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AggregationAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AggregationAction.java
@@ -70,7 +70,7 @@ public class AggregationAction implements RunAction2, LastBuildAction {
 
     private ToolApi createToolApi(final ResultAction result) {
         return new ToolApi(result.getId(), result.getDisplayName(),
-                result.getAbsoluteUrl(), result.getResult().getTotalSize());
+                result.getAbsoluteUrl(), result.getResult().getTotalSize(), result.getResult().getSizePerSeverity());
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/restapi/ToolApi.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/restapi/ToolApi.java
@@ -54,7 +54,7 @@ public class ToolApi {
      * @param size
      *         the number of warnings
      * @param sizePerSeverity
-     *         the number of warnings, grouped by severity.
+     *         the number of warnings, grouped by severity
      */
     public ToolApi(final String id, final String name, final String latestUrl, final int size, final Map<Severity, Integer> sizePerSeverity) {
         this.name = name;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/restapi/ToolApi.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/restapi/ToolApi.java
@@ -1,5 +1,9 @@
 package io.jenkins.plugins.analysis.core.restapi;
 
+import java.util.Map;
+
+import edu.hm.hafner.analysis.Severity;
+
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -16,6 +20,7 @@ public class ToolApi {
     private final String id;
     private final String latestUrl;
     private final int size;
+    private final Map<Severity, Integer> sizePerSeverity;
 
     /**
      * Creates a new instance of {@link ToolApi}.
@@ -28,12 +33,17 @@ public class ToolApi {
      *         the URL to the latest results
      * @param size
      *         the number of warnings
+     * @param sizePerSeverity
+     *         the number of warnings, grouped by severity. Assumption is that
+     *         this is not null, and that it is properly populated with counts
+     *         that when summed, total the "size" parameter.
      */
-    public ToolApi(final String id, final String name, final String latestUrl, final int size) {
+    public ToolApi(final String id, final String name, final String latestUrl, final int size, final Map<Severity, Integer> sizePerSeverity) {
         this.name = name;
         this.id = id;
         this.latestUrl = latestUrl;
         this.size = size;
+        this.sizePerSeverity = sizePerSeverity;
     }
 
     @Exported
@@ -55,4 +65,25 @@ public class ToolApi {
     public String getLatestUrl() {
         return latestUrl;
     }
+
+    @Exported
+    public int getErrorSize() {
+        return sizePerSeverity.getOrDefault(Severity.ERROR, 0);
+    }
+
+    @Exported
+    public int getHighSize() {
+        return sizePerSeverity.getOrDefault(Severity.WARNING_HIGH, 0);
+    }
+
+    @Exported
+    public int getNormalSize() {
+        return sizePerSeverity.getOrDefault(Severity.WARNING_NORMAL, 0);
+    }
+
+    @Exported
+    public int getLowSize() {
+        return sizePerSeverity.getOrDefault(Severity.WARNING_LOW, 0);
+    }
+
 }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/restapi/ToolApi.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/restapi/ToolApi.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.analysis.core.restapi;
 
+import java.util.Collections;
 import java.util.Map;
 
 import edu.hm.hafner.analysis.Severity;
@@ -33,10 +34,27 @@ public class ToolApi {
      *         the URL to the latest results
      * @param size
      *         the number of warnings
+     * @deprecated
+     *         use {@link #ToolApi(String, String, String, int, Map)} instead.
+     */
+    @Deprecated
+    public ToolApi(final String id, final String name, final String latestUrl, final int size) {
+        this(name, id, latestUrl, size, Collections.emptyMap());
+    }
+
+    /**
+     * Creates a new instance of {@link ToolApi}.
+     *
+     * @param id
+     *         unique ID of the tool
+     * @param name
+     *         human readable name of the tool
+     * @param latestUrl
+     *         the URL to the latest results
+     * @param size
+     *         the number of warnings
      * @param sizePerSeverity
-     *         the number of warnings, grouped by severity. Assumption is that
-     *         this is not null, and that it is properly populated with counts
-     *         that when summed, total the "size" parameter.
+     *         the number of warnings, grouped by severity.
      */
     public ToolApi(final String id, final String name, final String latestUrl, final int size, final Map<Severity, Integer> sizePerSeverity) {
         this.name = name;

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AggregationActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AggregationActionTest.java
@@ -2,10 +2,14 @@ package io.jenkins.plugins.analysis.core.model;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.collections.impl.factory.Lists;
 import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.Severity;
 
 import hudson.model.Action;
 import hudson.model.Api;
@@ -62,8 +66,8 @@ class AggregationActionTest {
     void shouldCreateCompleteApi() {
         Run<?, ?> owner = mock(Run.class);
         List<ResultAction> actions = Lists.fixedSize.of(
-                createAction(JobStubs.SPOT_BUGS_ID, JobStubs.SPOT_BUGS_NAME, SIZE),
-                createAction(JobStubs.CHECK_STYLE_NAME, JobStubs.CHECK_STYLE_NAME, SIZE)
+                createAction(JobStubs.SPOT_BUGS_ID, JobStubs.SPOT_BUGS_NAME, SIZE, Severity.ERROR),
+                createAction(JobStubs.CHECK_STYLE_NAME, JobStubs.CHECK_STYLE_NAME, SIZE, Severity.WARNING_HIGH)
         );
         when(owner.getActions(any())).thenAnswer(i -> actions);
         AggregationAction action = new AggregationAction();
@@ -77,13 +81,27 @@ class AggregationActionTest {
         List<ToolApi> actually = action.getTools();
 
         assertThat(actually).hasSize(2);
+
+        assertThat(actually.get(0).getErrorSize()).isEqualTo(SIZE);
+        assertThat(actually.get(0).getHighSize()).isEqualTo(0);
+        assertThat(actually.get(0).getNormalSize()).isEqualTo(0);
+        assertThat(actually.get(0).getLowSize()).isEqualTo(0);
+
+        assertThat(actually.get(1).getErrorSize()).isEqualTo(0);
+        assertThat(actually.get(1).getHighSize()).isEqualTo(SIZE);
+        assertThat(actually.get(1).getNormalSize()).isEqualTo(0);
+        assertThat(actually.get(1).getLowSize()).isEqualTo(0);
     }
 
-    private ResultAction createAction(final String id, final String name, final int size) {
+    private ResultAction createAction(final String id, final String name, final int size, final Severity severity) {
         ResultAction resultAction = mock(ResultAction.class);
+
+        Map<Severity, Integer> sizesPerSeverity = new HashMap<>();
+        sizesPerSeverity.put(severity, size);
 
         AnalysisResult result = mock(AnalysisResult.class);
         when(result.getTotalSize()).thenReturn(size);
+        when(result.getSizePerSeverity()).thenReturn(sizesPerSeverity);
 
         when(resultAction.getId()).thenReturn(id);
         when(resultAction.getDisplayName()).thenReturn(name);


### PR DESCRIPTION
Former versions of analysis plugins included a count breakdown by severity in their APIs. In order to expose the counts by severity, one would need to call the current aggregation API, and then for each tool, call the `latestUrl` and count the issues by severity. Fortunately, the data is already available in a map, and just needs to be passed back in the response. This PR does that.

Initial attempts were to add this method to `ToolApi`

```
@Exported
public Map<Severity, Integer> getSizePerSeverity() {
   ...
}
```

but in the API response, the field was rendered as `sizePerSeverity: [63, 0, 0, 0]` instead of as a JSON map. Wasn't sure how to fix that, so I instead created 4 getters, one for each severity.

Assumption - That the `sizePerSeverity` map is not null and properly populated such that the sum of counts across all severities add up to the total number of issues. That is, all issues have a severity. If this is not the case, then an additional getter could be added to show `unrankedSize`, which would be `(size - (error + high + normal + low)).`

I deployed the compiled `hpi` file to a Jenkins instance. This is a sample response (note that fields come back in alphabetical, rather than logical order as shown in the documentation which should not be an issue for consumers of the API).

```
{
  "_class": "io.jenkins.plugins.analysis.core.restapi.AggregationApi",
  "tools": [
    {
      "errorSize": 63,
      "highSize": 0,
      "id": "checkstyle",
      "latestUrl": "http://.../job/SpringBootApp_IT/30/checkstyle",
      "lowSize": 0,
      "name": "CheckStyle Warnings",
      "normalSize": 0,
      "size": 63
    },
    {
      "errorSize": 0,
      "highSize": 0,
      "id": "pmd",
      "latestUrl": "http://.../job/SpringBootApp_IT/30/pmd",
      "lowSize": 0,
      "name": "PMD Warnings",
      "normalSize": 3,
      "size": 3
    }
  ]
}
```
