### PR TITLE
Support withChecks

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -1055,6 +1055,13 @@ In order to disable the checks feature, set the property `skipPublishingChecks` 
 recordIssues skipPublishingChecks: true, tool: java(pattern: '*.log')
 ```
 
+The publisher will respect a `withChecks` context:
+```groovy
+withChecks('My Custom Checks Name') {
+  recordIssues tool: java(pattern: '*.log')
+}
+```
+
 ## Transition from the static analysis suite
 
 Previously the same set of features has been provided by the plugins of the static analysis suite 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -80,6 +80,7 @@
     <form-element-path.version>1.10</form-element-path.version>
     <folder.version>6.15</folder.version>
     <scm-api.version>2.6.3</scm-api.version>
+    <checks-api.version>1.2.0</checks-api.version>
 
     <!-- Maven Surefire ArgLine -->
     <argLine>-Djava.awt.headless=true -Xmx1024m -Djenkins.test.timeout=1000</argLine>
@@ -293,6 +294,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>checks-api</artifactId>
+      <version>${checks-api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.github.spotbugs</groupId>
@@ -390,6 +392,20 @@
       <version>${data-tables-api.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>checks-api</artifactId>
+      <version>${checks-api.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Form element path plugin to simplify location of UI elements in HtmlUnit tests -->

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -57,6 +57,7 @@ import io.jenkins.plugins.analysis.core.util.QualityGateEvaluator;
 import io.jenkins.plugins.analysis.core.util.RunResultHandler;
 import io.jenkins.plugins.analysis.core.util.StageResultHandler;
 import io.jenkins.plugins.analysis.core.util.TrendChartType;
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
@@ -111,6 +112,8 @@ public class IssuesRecorder extends Recorder {
     private transient boolean isForensicsDisabled;
 
     private boolean skipPublishingChecks; // by default, checks will be published
+
+    private ChecksInfo checksInfo;
 
     private String id;
     private String name;
@@ -591,6 +594,10 @@ public class IssuesRecorder extends Recorder {
         this.filters = new ArrayList<>(filters);
     }
 
+    public void setChecksInfo(final ChecksInfo checksInfo) {
+        this.checksInfo = checksInfo;
+    }
+
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
@@ -737,7 +744,7 @@ public class IssuesRecorder extends Recorder {
         ResultAction action = publisher.attachAction(trendChartType);
 
         if (!skipPublishingChecks) {
-            WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, listener);
+            WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, listener, checksInfo);
             checksPublisher.publishChecks();
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -113,6 +113,7 @@ public class IssuesRecorder extends Recorder {
 
     private boolean skipPublishingChecks; // by default, checks will be published
 
+    @CheckForNull
     private ChecksInfo checksInfo;
 
     private String id;
@@ -594,7 +595,7 @@ public class IssuesRecorder extends Recorder {
         this.filters = new ArrayList<>(filters);
     }
 
-    public void setChecksInfo(final ChecksInfo checksInfo) {
+    public void setChecksInfo(@CheckForNull final ChecksInfo checksInfo) {
         this.checksInfo = checksInfo;
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -857,8 +857,7 @@ public class PublishIssuesStep extends Step implements Serializable {
             ResultAction action = publisher.attachAction(step.getTrendChartType());
 
             if (!step.isSkipPublishingChecks()) {
-                String checksName = Optional.ofNullable(getContext().get(ChecksInfo.class)).map(ChecksInfo::getName).orElse(null);
-                WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, getTaskListener(), checksName);
+                WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, getTaskListener(), getContext().get(ChecksInfo.class));
                 checksPublisher.publishChecks();
             }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.collections.impl.factory.Sets;
 
@@ -855,7 +857,8 @@ public class PublishIssuesStep extends Step implements Serializable {
             ResultAction action = publisher.attachAction(step.getTrendChartType());
 
             if (!step.isSkipPublishingChecks()) {
-                WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, getTaskListener());
+                String checksName = Optional.ofNullable(getContext().get(ChecksInfo.class)).map(ChecksInfo::getName).orElse(null);
+                WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, getTaskListener(), checksName);
                 checksPublisher.publishChecks();
             }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
@@ -41,6 +41,7 @@ import io.jenkins.plugins.analysis.core.util.QualityGate.QualityGateType;
 import io.jenkins.plugins.analysis.core.util.QualityGateEvaluator;
 import io.jenkins.plugins.analysis.core.util.StageResultHandler;
 import io.jenkins.plugins.analysis.core.util.TrendChartType;
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 
 /**
  * Pipeline step that scans report files or the console log for issues. Stores the created issues in an {@link
@@ -1054,6 +1055,7 @@ public class RecordIssuesStep extends Step implements Serializable {
             recorder.setFailOnError(step.getFailOnError());
             recorder.setTrendChartType(step.getTrendChartType());
             recorder.setSourceDirectory(step.getSourceDirectory());
+            recorder.setChecksInfo(getContext().get(ChecksInfo.class));
             StageResultHandler statusHandler = new PipelineResultHandler(getRun(),
                     getContext().get(FlowNode.class));
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -14,6 +14,7 @@ import org.jsoup.nodes.TextNode;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.util.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import hudson.model.TaskListener;
 
@@ -42,9 +43,10 @@ import io.jenkins.plugins.checks.steps.ChecksInfo;
 class WarningChecksPublisher {
     private final ResultAction action;
     private final TaskListener listener;
+    @CheckForNull
     private final ChecksInfo checksInfo;
 
-    WarningChecksPublisher(final ResultAction action, final TaskListener listener, final ChecksInfo checksInfo) {
+    WarningChecksPublisher(final ResultAction action, final TaskListener listener, @CheckForNull final ChecksInfo checksInfo) {
         this.action = action;
         this.listener = listener;
         this.checksInfo = checksInfo;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.analysis.core.steps;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +32,7 @@ import io.jenkins.plugins.checks.api.ChecksOutput.ChecksOutputBuilder;
 import io.jenkins.plugins.checks.api.ChecksPublisher;
 import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
 import io.jenkins.plugins.checks.api.ChecksStatus;
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 
 /**
  * Publishes warnings as checks to scm platforms.
@@ -40,16 +42,12 @@ import io.jenkins.plugins.checks.api.ChecksStatus;
 class WarningChecksPublisher {
     private final ResultAction action;
     private final TaskListener listener;
-    private final String checksName;
+    private final ChecksInfo checksInfo;
 
-    WarningChecksPublisher(final ResultAction action, final TaskListener listener, final String checksName) {
+    WarningChecksPublisher(final ResultAction action, final TaskListener listener, final ChecksInfo checksInfo) {
         this.action = action;
         this.listener = listener;
-        this.checksName = checksName;
-    }
-
-    WarningChecksPublisher(final ResultAction action, final TaskListener listener) {
-        this(action, listener, null);
+        this.checksInfo = checksInfo;
     }
 
     /**
@@ -68,8 +66,12 @@ class WarningChecksPublisher {
 
         StaticAnalysisLabelProvider labelProvider = action.getLabelProvider();
 
+        String checksName = Optional.ofNullable(checksInfo).map(ChecksInfo::getName)
+                .filter(StringUtils::isNotEmpty)
+                .orElse(labelProvider.getName());
+
         return new ChecksDetailsBuilder()
-                .withName(StringUtils.defaultIfEmpty(checksName, labelProvider.getName()))
+                .withName(checksName)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(extractChecksConclusion(result.getQualityGateStatus()))
                 .withOutput(new ChecksOutputBuilder()

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -42,7 +42,7 @@ class WarningChecksPublisher {
     private final TaskListener listener;
     private final String checksName;
 
-    WarningChecksPublisher(ResultAction action, TaskListener listener, String checksName) {
+    WarningChecksPublisher(final ResultAction action, final TaskListener listener, final String checksName) {
         this.action = action;
         this.listener = listener;
         this.checksName = checksName;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -40,10 +40,16 @@ import io.jenkins.plugins.checks.api.ChecksStatus;
 class WarningChecksPublisher {
     private final ResultAction action;
     private final TaskListener listener;
+    private final String checksName;
 
-    WarningChecksPublisher(final ResultAction action, final TaskListener listener) {
+    WarningChecksPublisher(ResultAction action, TaskListener listener, String checksName) {
         this.action = action;
         this.listener = listener;
+        this.checksName = checksName;
+    }
+
+    WarningChecksPublisher(final ResultAction action, final TaskListener listener) {
+        this(action, listener, null);
     }
 
     /**
@@ -63,7 +69,7 @@ class WarningChecksPublisher {
         StaticAnalysisLabelProvider labelProvider = action.getLabelProvider();
 
         return new ChecksDetailsBuilder()
-                .withName(labelProvider.getName())
+                .withName(StringUtils.defaultIfEmpty(checksName, labelProvider.getName()))
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(extractChecksConclusion(result.getQualityGateStatus()))
                 .withOutput(new ChecksOutputBuilder()

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -44,9 +44,15 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
     private static final String OLD_CHECKSTYLE_REPORT = "checkstyle.xml";
     private static final String NEW_CHECKSTYLE_REPORT = "checkstyle1.xml";
 
+    /**
+     * Capturing checks publisher for inspection of checks created during a run.
+     */
     @TestExtension
     public static final CapturingChecksPublisher.Factory PUBLISHER_FACTORY = new CapturingChecksPublisher.Factory();
 
+    /**
+     * Resets captured checks after each test.
+     */
     @After
     public void clearPublisher() {
         PUBLISHER_FACTORY.getPublishedChecks().clear();
@@ -203,6 +209,9 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasFieldOrPropertyWithValue("endColumn", Optional.empty());
     }
 
+    /**
+     * Test that publishIssues honors the checks name provided by a withChecks context.
+     */
     @Test
     public void shouldHonorWithChecksContext() {
         WorkflowJob project = createPipeline();

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -213,7 +213,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
      * Test that publishIssues honors the checks name provided by a withChecks context.
      */
     @Test
-    public void shouldHonorWithChecksContext() {
+    public void shouldHonorWithChecksContextPublishIssues() {
         WorkflowJob project = createPipeline();
         copySingleFileToWorkspace(project, NEW_CHECKSTYLE_REPORT);
         project.setDefinition(asStage("withChecks('Custom Checks Name') {", createScanForIssuesStep(new CheckStyle()), PUBLISH_ISSUES_STEP, "}"));
@@ -224,7 +224,26 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
         assertThat(publishedChecks.size()).isEqualTo(2);
 
         publishedChecks.forEach(check -> assertThat(check.getName()).isPresent().get().isEqualTo("Custom Checks Name"));
+    }
 
+    /**
+     * Test that recordIssues honors the checks name provided by a withChecks context.
+     */
+    @Test
+    public void shouldHonorWithChecksContextRecordIssues() {
+        WorkflowJob project = createPipeline();
+        copySingleFileToWorkspace(project, NEW_CHECKSTYLE_REPORT);
+        project.setDefinition(asStage(String.format(""
+                + "withChecks('Custom Checks Name') {\n"
+                + "  recordIssues(tools: [%s(pattern: '%s')])\n"
+                + "}", new CheckStyle().getSymbolName(), NEW_CHECKSTYLE_REPORT)));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = PUBLISHER_FACTORY.getPublishedChecks();
+
+        assertThat(publishedChecks.size()).isEqualTo(2);
+
+        publishedChecks.forEach(check -> assertThat(check.getName()).isPresent().get().isEqualTo("Custom Checks Name"));
     }
 
     private ChecksDetails createExpectedCheckStyleDetails() {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -79,7 +79,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasNewSize(2);
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL);
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
         assertThat(publisher.extractChecksDetails())
                 .hasFieldOrPropertyWithValue("detailsURL", Optional.of(getResultAction(run).getAbsoluteUrl()))
                 .usingRecursiveComparison()
@@ -94,7 +94,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 recorder -> recorder.addQualityGate(10, QualityGateType.TOTAL, QualityGateResult.UNSTABLE));
 
         Run<?, ?> build = buildSuccessfully(project);
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL);
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL, null);
 
         assertThat(publisher.extractChecksDetails().getConclusion())
                 .isEqualTo(ChecksConclusion.SUCCESS);
@@ -120,7 +120,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
         copySingleFileToWorkspace(project, "PVSReport.xml", "PVSReport.plog");
         Run<?, ?> run = buildSuccessfully(project);
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL);
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
         ChecksDetails details = publisher.extractChecksDetails();
 
         assertThat(details.getOutput().get().getChecksAnnotations())
@@ -142,7 +142,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(0)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL)
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null)
                 .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
@@ -159,7 +159,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(4)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL)
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null)
                 .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
@@ -182,7 +182,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasNewSize(6);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL)
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null)
                 .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()
@@ -199,7 +199,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
         copySingleFileToWorkspace(project, "pmd.xml");
         Run<?, ?> run = buildSuccessfully(project);
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL);
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
         ChecksDetails details = publisher.extractChecksDetails();
 
         assertThat(details.getOutput().get().getChecksAnnotations().get(0))
@@ -308,7 +308,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasTotalSize(6)
                 .hasQualityGateStatus(qualityGateResult.getStatus());
 
-        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL);
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL, null);
         assertThat(publisher.extractChecksDetails().getConclusion())
                 .isEqualTo(ChecksConclusion.FAILURE);
     }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/IntegrationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/IntegrationTest.java
@@ -584,6 +584,18 @@ public abstract class IntegrationTest extends ResourceTest {
     }
 
     /**
+     * Creates a pipeline step that records issues of the specified tool.
+     *
+     * @param tool
+     *         the class of the tool to use
+     *
+     * @return the pipeline step
+     */
+    protected String createRecordIssuesStep(final ReportScanningTool tool) {
+        return String.format("recordIssues(tools: [%s(pattern: '**/*issues.txt', reportEncoding:'UTF-8')])", tool.getSymbolName());
+    }
+
+    /**
      * Wraps the specified steps into a stage.
      *
      * @param steps


### PR DESCRIPTION
This PR adds support for the `withChecks` step recently added to the `checks-api` plugin, that allows for customization of published checks names by context.