### PR TITLE
Improve layout of checks markup

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -1036,10 +1036,9 @@ Examples:
 * the configuration of GitHub App credentials, see [this guide](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc) for more details
 
 If not disabled in the job configuration, this plugin will publish warnings to GitHub through 
-[GitHub checks API](https://docs.github.com/en/rest/reference/checks).
-
-The plugin publishes the results of each analysis tool as an individual check, the quality gate is visible as check result.
-You can choose whether to report all or ony new issues by toggling the property `publishAllIssues`.
+[GitHub checks API](https://docs.github.com/en/rest/reference/checks). It publishes the results of each analysis tool
+as an individual check. If a quality gate has been configured, then the result will be published as check result 
+(success or failed).
 
 ![check quality gate](images/check-quality-gate.png)
 
@@ -1048,8 +1047,14 @@ issues statistics will be displayed.
 
 ![checks](images/checks.png)
 
-When a new pull request or commit causes new issues, they will be added as annotations below the code where the issues 
-have been reported. 
+When a new pull request or commit causes new issues, these issues will be added as annotations right below the source
+code. You can also choose to show all issues by toggling the property `publishAllIssues`. In this case not only new issues
+will be highlighted but also outstanding ones. (Note: GitHub renders annotations only for source
+code blocks that have been changed in a commit.)
+
+```groovy
+recordIssues publishAllIssues: true, tool: java(pattern: '*.log')
+```
 
 ![check annotation](images/check-annotation.png)
 

--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -1033,20 +1033,23 @@ Examples:
 
 :warning: This feature requires:
 * the installation of an additional plugin: [GitHub Checks Plugin](https://github.com/jenkinsci/github-checks-plugin)
-* the configuration of GitHub App credentails, see [this guide](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc) for more details
+* the configuration of GitHub App credentials, see [this guide](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc) for more details
 
-If not disabled in the job configuration, this plugin will publish warnings to GitHub through [GitHub checks API](https://docs.github.com/en/rest/reference/checks).
+If not disabled in the job configuration, this plugin will publish warnings to GitHub through 
+[GitHub checks API](https://docs.github.com/en/rest/reference/checks).
 
-Each analysis tool is published as an individual check, the quality gate is published as the check result.
+The plugin publishes the results of each analysis tool as an individual check, the quality gate is visible as check result.
+You can choose whether to report all or ony new issues by toggling the property `publishAllIssues`.
 
 ![check quality gate](images/check-quality-gate.png)
 
-
-In the *Details* view of each check ([example](https://github.com/jenkinsci/warnings-ng-plugin/pull/593/checks?check_run_id=1026691589)), issues statistics will be displayed.
+In the *Details* view of each check ([example](https://github.com/jenkinsci/warnings-ng-plugin/pull/593/checks?check_run_id=1026691589)), 
+issues statistics will be displayed.
 
 ![checks](images/checks.png)
 
-When new issues are produced by a pull request, they will be added as annotations below the code where the issues are introduced.
+When a new pull request or commit causes new issues, they will be added as annotations below the code where the issues 
+have been reported. 
 
 ![check annotation](images/check-annotation.png)
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -47,6 +47,7 @@ import io.jenkins.plugins.analysis.core.model.ResultAction;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider;
 import io.jenkins.plugins.analysis.core.model.Tool;
 import io.jenkins.plugins.analysis.core.steps.IssuesScanner.BlameMode;
+import io.jenkins.plugins.analysis.core.steps.WarningChecksPublisher.AnnotationScope;
 import io.jenkins.plugins.analysis.core.util.HealthDescriptor;
 import io.jenkins.plugins.analysis.core.util.LogHandler;
 import io.jenkins.plugins.analysis.core.util.ModelValidation;
@@ -111,6 +112,7 @@ public class IssuesRecorder extends Recorder {
     private transient boolean isForensicsDisabled;
 
     private boolean skipPublishingChecks; // by default, checks will be published
+    private boolean publishAllIssues; // by default, only new issues will be published
 
     private String id;
     private String name;
@@ -406,6 +408,21 @@ public class IssuesRecorder extends Recorder {
     @DataBoundSetter
     public void setSkipPublishingChecks(final boolean skipPublishingChecks) {
         this.skipPublishingChecks = skipPublishingChecks;
+    }
+
+    /**
+     * Returns whether all issues should be published using the Checks API. If set to {@code false} only new issues will
+     * be published.
+     *
+     * @return {@code true} if all issues should be published, {@code false} if only new issues should be published
+     */
+    public boolean isPublishAllIssues() {
+        return publishAllIssues;
+    }
+
+    @DataBoundSetter
+    public void setPublishAllIssues(final boolean publishAllIssues) {
+        this.publishAllIssues = publishAllIssues;
     }
 
     /**
@@ -752,7 +769,8 @@ public class IssuesRecorder extends Recorder {
 
         if (!skipPublishingChecks) {
             WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, listener);
-            checksPublisher.publishChecks();
+            checksPublisher.publishChecks(
+                    isPublishAllIssues() ? AnnotationScope.PUBLISH_ALL_ISSUES : AnnotationScope.PUBLISH_NEW_ISSUES);
         }
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -47,7 +47,7 @@ import io.jenkins.plugins.checks.steps.ChecksInfo;
  * Otherwise a default ID is used to publish the results. In any case, the computed ID can be overwritten by specifying
  * an ID as step parameter.
  */
-@SuppressWarnings({"InstanceVariableMayNotBeInitialized", "PMD.ExcessiveImports", "PMD.ExcessivePublicCount", "PMD.DataClass", "PMD.TooManyFields"})
+@SuppressWarnings({"InstanceVariableMayNotBeInitialized", "PMD.ExcessiveImports", "PMD.ExcessivePublicCount", "PMD.DataClass", "PMD.GodClass", "PMD.TooManyFields"})
 public class PublishIssuesStep extends Step implements Serializable {
     private static final long serialVersionUID = -1833335402353771148L;
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -4,10 +4,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
-import io.jenkins.plugins.checks.steps.ChecksInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.collections.impl.factory.Sets;
 
@@ -41,6 +39,7 @@ import io.jenkins.plugins.analysis.core.util.QualityGate.QualityGateType;
 import io.jenkins.plugins.analysis.core.util.QualityGateEvaluator;
 import io.jenkins.plugins.analysis.core.util.StageResultHandler;
 import io.jenkins.plugins.analysis.core.util.TrendChartType;
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 
 /**
  * Publish issues created by a static analysis build. The recorded issues are stored as a {@link ResultAction} in the
@@ -876,7 +875,7 @@ public class PublishIssuesStep extends Step implements Serializable {
             if (!step.isSkipPublishingChecks()) {
                 WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, getTaskListener(), getContext().get(ChecksInfo.class));
                 checksPublisher.publishChecks(
-                        isPublishAllIssues() ? AnnotationScope.PUBLISH_ALL_ISSUES : AnnotationScope.PUBLISH_NEW_ISSUES);
+                        step.isPublishAllIssues() ? AnnotationScope.PUBLISH_ALL_ISSUES : AnnotationScope.PUBLISH_NEW_ISSUES);
             }
 
             return action;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -28,6 +28,7 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.analysis.core.model.LabelProviderFactory;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider;
+import io.jenkins.plugins.analysis.core.steps.WarningChecksPublisher.AnnotationScope;
 import io.jenkins.plugins.analysis.core.util.HealthDescriptor;
 import io.jenkins.plugins.analysis.core.util.LogHandler;
 import io.jenkins.plugins.analysis.core.util.ModelValidation;
@@ -60,6 +61,7 @@ public class PublishIssuesStep extends Step implements Serializable {
     private boolean failOnError = false; // by default, it should not fail on error
 
     private boolean skipPublishingChecks; // by default, warnings should be published to SCM platforms
+    private boolean publishAllIssues; // by default, only new issues will be published
 
     private int healthy;
     private int unhealthy;
@@ -162,6 +164,21 @@ public class PublishIssuesStep extends Step implements Serializable {
     @SuppressWarnings("unused") // Used by Stapler
     public void setSkipPublishingChecks(final boolean skipPublishingChecks) {
         this.skipPublishingChecks = skipPublishingChecks;
+    }
+
+    /**
+     * Returns whether all issues should be published using the Checks API. If set to {@code false} only new issues will
+     * be published.
+     *
+     * @return {@code true} if all issues should be published, {@code false} if only new issues should be published
+     */
+    public boolean isPublishAllIssues() {
+        return publishAllIssues;
+    }
+
+    @DataBoundSetter
+    public void setPublishAllIssues(final boolean publishAllIssues) {
+        this.publishAllIssues = publishAllIssues;
     }
 
     /**
@@ -856,7 +873,8 @@ public class PublishIssuesStep extends Step implements Serializable {
 
             if (!step.isSkipPublishingChecks()) {
                 WarningChecksPublisher checksPublisher = new WarningChecksPublisher(action, getTaskListener());
-                checksPublisher.publishChecks();
+                checksPublisher.publishChecks(
+                        step.isPublishAllIssues() ? AnnotationScope.PUBLISH_ALL_ISSUES : AnnotationScope.PUBLISH_NEW_ISSUES);
             }
 
             return action;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -46,7 +46,7 @@ import io.jenkins.plugins.analysis.core.util.TrendChartType;
  * Otherwise a default ID is used to publish the results. In any case, the computed ID can be overwritten by specifying
  * an ID as step parameter.
  */
-@SuppressWarnings({"InstanceVariableMayNotBeInitialized", "PMD.ExcessiveImports", "PMD.ExcessivePublicCount", "PMD.DataClass"})
+@SuppressWarnings({"InstanceVariableMayNotBeInitialized", "PMD.ExcessiveImports", "PMD.ExcessivePublicCount", "PMD.DataClass", "PMD.TooManyFields"})
 public class PublishIssuesStep extends Step implements Serializable {
     private static final long serialVersionUID = -1833335402353771148L;
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
@@ -84,6 +84,7 @@ public class RecordIssuesStep extends Step implements Serializable {
     private boolean isBlameDisabled;
 
     private boolean skipPublishingChecks; // by default, checks will be published
+    private boolean publishAllIssues; // by default, only new issues will be published
 
     private String id;
     private String name;
@@ -826,6 +827,21 @@ public class RecordIssuesStep extends Step implements Serializable {
     }
 
     /**
+     * Returns whether all issues should be published using the Checks API. If set to {@code false} only new issues will
+     * be published.
+     *
+     * @return {@code true} if all issues should be published, {@code false} if only new issues should be published
+     */
+    public boolean isPublishAllIssues() {
+        return publishAllIssues;
+    }
+
+    @DataBoundSetter
+    public void setPublishAllIssues(final boolean publishAllIssues) {
+        this.publishAllIssues = publishAllIssues;
+    }
+
+    /**
      * Returns whether recording should be enabled for failed builds as well.
      *
      * @return {@code true}  if recording should be enabled for failed builds as well, {@code false} if recording is
@@ -1058,6 +1074,7 @@ public class RecordIssuesStep extends Step implements Serializable {
             recorder.setAggregatingResults(step.getAggregatingResults());
             recorder.setBlameDisabled(step.getBlameDisabled());
             recorder.setSkipPublishingChecks(step.isSkipPublishingChecks());
+            recorder.setPublishAllIssues(step.isPublishAllIssues());
             recorder.setId(step.getId());
             recorder.setName(step.getName());
             recorder.setQualityGates(step.getQualityGates());

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -42,6 +42,7 @@ import io.jenkins.plugins.checks.steps.ChecksInfo;
  *
  * @author Kezhi Xiong
  */
+@SuppressWarnings("PMD.ExcessiveImports")
 class WarningChecksPublisher {
     enum AnnotationScope {
         PUBLISH_ALL_ISSUES,

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -90,9 +90,9 @@ class WarningChecksPublisher {
 
     private String extractReferenceBuild(final AnalysisResult result,
             final StaticAnalysisLabelProvider labelProvider) {
-        return action.getResult()
-                .getReferenceBuild()
-                .map(labelProvider::getReferenceBuild).map(DomContent::render)
+        return result.getReferenceBuild()
+                .map(labelProvider::getReferenceBuild)
+                .map(DomContent::render)
                 .orElse(StringUtils.EMPTY);
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -97,7 +97,7 @@ class WarningChecksPublisher {
         }
     }
 
-    private String formatColumns(final Object[] columns) {
+    private String formatColumns(final Object... columns) {
         StringBuilder row = new StringBuilder();
         for (Object column : columns) {
             row.append(String.format("|%s", column));

--- a/plugin/src/main/resources/issues/publish-parameters.jelly
+++ b/plugin/src/main/resources/issues/publish-parameters.jelly
@@ -10,6 +10,9 @@
   <f:entry field="skipPublishingChecks">
     <f:checkbox title="${%title.skipPublishingChecks}" />
   </f:entry>
+  <f:entry field="publishAllIssues">
+    <f:checkbox title="${%title.publishAllIssues}" />
+  </f:entry>
   <f:entry field="failOnError">
     <f:checkbox title="${%title.failOnError}"/>
   </f:entry>

--- a/plugin/src/main/resources/issues/publish-parameters.properties
+++ b/plugin/src/main/resources/issues/publish-parameters.properties
@@ -18,3 +18,4 @@ title.trendChartType=Trend chart type
 description.trendChartType=Select trend charts and their position.
 
 title.skipPublishingChecks=Skip publishing of checks to SCM provider platforms
+title.publishAllIssues=Publish new and outstanding issues to SCM provider platforms

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -41,6 +41,7 @@ import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
  *
  * @author Kezhi Xiong
  */
+@SuppressWarnings("PMD.ExcessiveImports")
 public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String OLD_CHECKSTYLE_REPORT = "checkstyle.xml";
     private static final String NEW_CHECKSTYLE_REPORT = "checkstyle1.xml";

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -67,6 +67,9 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .isEqualTo(createExpectedCheckStyleDetails());
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly reports a successful quality gate.
+     */
     @Test
     public void shouldConcludeChecksAsSuccessWhenQualityGateIsPassed() {
         FreeStyleProject project = createFreeStyleProjectWithWorkspaceFiles(NEW_CHECKSTYLE_REPORT);
@@ -80,16 +83,25 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .isEqualTo(ChecksConclusion.SUCCESS);
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly reports a failed quality gate.
+     */
     @Test
     public void shouldConcludeChecksAsFailureWhenQualityGateIsFailed() {
         assertChecksConclusionIsFailureWithQualityGateResult(QualityGateResult.FAILURE);
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly reports an unstable quality gate.
+     */
     @Test
     public void shouldConcludeChecksAsFailureWhenQualityGateResultIsUnstable() {
         assertChecksConclusionIsFailureWithQualityGateResult(QualityGateResult.UNSTABLE);
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly handles HTML tags in messages.
+     */
     @Test
     public void shouldParseHtmlMessage() {
         FreeStyleProject project = createFreeStyleProject();
@@ -112,6 +124,9 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                         .build());
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly handles the special case of zero issues.
+     */
     @Test
     public void shouldReportNoIssuesInTitle() {
         FreeStyleProject project = createFreeStyleProject();
@@ -129,6 +144,9 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasFieldOrPropertyWithValue("title", Optional.of("No issues."));
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly shows only the totals in the title if there are no new issues.
+     */
     @Test
     public void shouldReportOnlyTotalIssuesInTitleWhenNoNewIssues() {
         FreeStyleProject project = createFreeStyleProjectWithWorkspaceFiles(OLD_CHECKSTYLE_REPORT);
@@ -146,6 +164,9 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasFieldOrPropertyWithValue("title", Optional.of("No new issues, 4 total."));
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly shows the totals and the new issues in the title.
+     */
     @Test
     public void shouldReportOnlyNewIssuesInTitleWhenAllIssuesAreNew() {
         FreeStyleProject project = createFreeStyleProject();
@@ -169,6 +190,9 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                 .hasFieldOrPropertyWithValue("title", Optional.of("6 new issues."));
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} correctly ignores the columns if the issue refers to several lines.
+     */
     @Test
     public void shouldIgnoreColumnsWhenBuildMultipleLineAnnotation() {
         FreeStyleProject project = createFreeStyleProject();
@@ -197,14 +221,13 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
 
         ChecksOutput output = new ChecksOutputBuilder()
                 .withTitle("2 new issues, 6 total.")
-                .withSummary("## 6 issues in total:\n"
-                        + "- ### 2 new issues\n"
-                        + "- ### 4 outstanding issues\n"
-                        + "- ### 2 delta issues\n"
-                        + "- ### 0 fixed issues")
-                .withText("## Total Issue Statistics:\n* Error: 6\n* High: 0\n* Normal: 0\n* Low: 0\n"
-                        + "## New Issue Statistics:\n* Error: 2\n* High: 0\n* Normal: 0\n* Low: 0\n"
-                        + "## Delta Issue Statistics:\n* Error: 2\n* High: 0\n* Normal: 0\n* Low: 0\n")
+                .withSummary("|Total|New|Outstanding|Fixed|Trend\n"
+                        + "|:-:|:-:|:-:|:-:|:-:\n"
+                        + "|6|2|4|0|:-1:\n")
+                .withText("## Severity distribution of new issues\n"
+                        + "|Error|Warning High|Warning Normal|Warning Low\n"
+                        + "|:-:|:-:|:-:|:-:\n"
+                        + "|2|0|0|0\n")
                 .addAnnotation(new ChecksAnnotationBuilder()
                         .withPath("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins"
                                 + "/tasks/parser/CsharpNamespaceDetector.java")

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -40,8 +40,8 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
     private static final String NEW_CHECKSTYLE_REPORT = "checkstyle1.xml";
 
     /**
-     * Verifies that {@link WarningChecksPublisher} constructs the {@link ChecksDetails} correctly
-     * with only new issues.
+     * Verifies that {@link WarningChecksPublisher} constructs the {@link ChecksDetails} correctly with only new
+     * issues.
      */
     @Test
     public void shouldCreateChecksDetailsWithNewIssuesAsAnnotations() {
@@ -63,8 +63,16 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
         assertThat(publisher.extractChecksDetails())
                 .hasFieldOrPropertyWithValue("detailsURL", Optional.of(getResultAction(run).getAbsoluteUrl()))
                 .usingRecursiveComparison()
-                .ignoringFields("detailsURL")
+                .ignoringFields("detailsURL", "output.value.summary.value")
                 .isEqualTo(createExpectedCheckStyleDetails());
+        assertThat(publisher.extractChecksDetails().getOutput()).isPresent().get().satisfies(
+                output -> assertThat(output.getSummary()).isPresent().get().asString()
+                        .startsWith("|Total|New|Outstanding|Fixed|Trend\n"
+                                + "|:-:|:-:|:-:|:-:|:-:\n"
+                                + "|6|2|4|0|:-1:\n"
+                                + "Reference build: <a href=\"http://localhost:")
+                        .endsWith("#1</a>")
+        );
     }
 
     /**
@@ -145,7 +153,8 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
     }
 
     /**
-     * Verifies that {@link WarningChecksPublisher} correctly shows only the totals in the title if there are no new issues.
+     * Verifies that {@link WarningChecksPublisher} correctly shows only the totals in the title if there are no new
+     * issues.
      */
     @Test
     public void shouldReportOnlyTotalIssuesInTitleWhenNoNewIssues() {
@@ -221,9 +230,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
 
         ChecksOutput output = new ChecksOutputBuilder()
                 .withTitle("2 new issues, 6 total.")
-                .withSummary("|Total|New|Outstanding|Fixed|Trend\n"
-                        + "|:-:|:-:|:-:|:-:|:-:\n"
-                        + "|6|2|4|0|:-1:\n")
+                .withSummary("") // summary value is checked directly since it is using a random port
                 .withText("## Severity distribution of new issues\n"
                         + "|Error|Warning High|Warning Normal|Warning Low\n"
                         + "|:-:|:-:|:-:|:-:\n"

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
@@ -35,6 +35,7 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
     private final Control ignoreFailedBuilds = control("ignoreFailedBuilds");
     private final Control failOnError = control("failOnError");
     private final Control skipPublishingChecks = control("skipPublishingChecks");
+    private final Control publishAllIssues = control("publishAllIssues");
     private final Control reportFilePattern = control("/toolProxies/tool/pattern");
     private final Control trendChartType = control("trendChartType");
     private final Control healthyThreshold = control("healthy");
@@ -208,6 +209,10 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
         return isChecked(skipPublishingChecks);
     }
 
+    public boolean isPublishAllIssues() {
+        return isChecked(publishAllIssues);
+    }
+
     private boolean isChecked(final Control control) {
         return control.resolve().isSelected();
     }
@@ -365,6 +370,16 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
      */
     public void setSkipPublishingChecks(final boolean skipPublishingChecks) {
         this.skipPublishingChecks.check(skipPublishingChecks);
+    }
+
+    /**
+     * Sets whether all issues should be published using the Checks API. If set to {@code false} only new issues will
+     * be published.
+     *
+     * @param publishAllIssues {@code true} if all issues should be published, {@code false} if only new issues should be published
+     */
+    public void setPublishAllIssues(final boolean publishAllIssues) {
+        this.publishAllIssues.check(publishAllIssues);
     }
 
     /**

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/FreeStyleConfigurationUITest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/FreeStyleConfigurationUITest.java
@@ -43,6 +43,7 @@ public class FreeStyleConfigurationUITest extends AbstractJUnitTest {
         issuesRecorder.setIgnoreQualityGate(true);
         issuesRecorder.setIgnoreFailedBuilds(true);
         issuesRecorder.setSkipPublishingChecks(true);
+        issuesRecorder.setPublishAllIssues(true);
         issuesRecorder.setFailOnError(true);
         issuesRecorder.setHealthReport(1, 9, SEVERITY);
         issuesRecorder.setReportFilePattern(PATTERN);
@@ -62,6 +63,7 @@ public class FreeStyleConfigurationUITest extends AbstractJUnitTest {
         assertThat(issuesRecorder).isIgnoringQualityGate();
         assertThat(issuesRecorder).isIgnoringFailedBuilds();
         assertThat(issuesRecorder).isSkipPublishingChecks();
+        assertThat(issuesRecorder).isPublishAllIssues();
         assertThat(issuesRecorder).isFailingOnError();
         assertThat(issuesRecorder).hasHealthThreshold("1");
         assertThat(issuesRecorder).hasUnhealthyThreshold("9");
@@ -75,6 +77,7 @@ public class FreeStyleConfigurationUITest extends AbstractJUnitTest {
         // Now invert all booleans:
         issuesRecorder.setAggregatingResults(false);
         issuesRecorder.setSkipBlames(false);
+        issuesRecorder.setPublishAllIssues(false);
         issuesRecorder.setEnabledForFailure(false);
         issuesRecorder.setIgnoreQualityGate(false);
         issuesRecorder.setIgnoreFailedBuilds(false);
@@ -85,7 +88,7 @@ public class FreeStyleConfigurationUITest extends AbstractJUnitTest {
         issuesRecorder.openAdvancedOptions();
 
         assertThat(issuesRecorder).isNotAggregatingResults();
-        assertThat(issuesRecorder).isNotSkipBlames();
+        assertThat(issuesRecorder).isNotPublishAllIssues();
         assertThat(issuesRecorder).isNotEnabledForFailure();
         assertThat(issuesRecorder).isNotIgnoringQualityGate();
         assertThat(issuesRecorder).isNotIgnoringFailedBuilds();


### PR DESCRIPTION
Improves several aspects of the checks layout:

- Use a more compact layout for the summary and details pane using tables. 
- Add a trend emoji indicator that shows if the project is improving or not.
- Show the reference build that is used to compute the new warnings.
- Add an optional option to show all warnings as annotations (and not only the new ones)