### PR TITLE
Add missing newline after GitHub checks details table

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -83,7 +83,7 @@ class WarningChecksPublisher {
                 .filter(StringUtils::isNotEmpty)
                 .orElse(labelProvider.getName());
 
-        String summary = extractChecksSummary(totals) + extractReferenceBuild(result, labelProvider);
+        String summary = extractChecksSummary(totals) + "\n" + extractReferenceBuild(result, labelProvider);
         Report issues = annotationScope == AnnotationScope.PUBLISH_NEW_ISSUES ? result.getNewIssues() : result.getIssues();
         return new ChecksDetailsBuilder()
                 .withName(checksName)

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -93,7 +93,7 @@ public class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSu
                             assertThat(output.getSummary()).isPresent().get().asString()
                                     .startsWith("|Total|New|Outstanding|Fixed|Trend\n"
                                             + "|:-:|:-:|:-:|:-:|:-:\n"
-                                            + "|6|2|4|0|:-1:\n"
+                                            + "|6|2|4|0|:-1:\n\n"
                                             + "Reference build: <a href=\"http://localhost:")
                                     .endsWith("#1</a>");
                             assertThat(output.getChecksAnnotations()).hasSize(2);


### PR DESCRIPTION
Otherwise the reference build will be shown inside the table, see https://github.com/jenkinsci/git-forensics-plugin/pull/213/checks?check_run_id=1717460354 for an example.