### PR TITLE
Add documentation for filters

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-filters.html
@@ -1,6 +1,6 @@
 <div>
     The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
     filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
-    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    category or type. Include filters will be combined with <code>or</code>, exclude filters with <code>and</code>.
     If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-filters.html
@@ -1,5 +1,6 @@
 <div>
-    The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
-    another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
-    If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
+    The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
+    filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
+    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-id.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-id.html
@@ -2,6 +2,6 @@
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
     Allowed elements are characters, digits, dashes and underscores (more precisely,
-    the ID must match the regular expression `\p{Alnum}[\p{Alnum}-_]*`).
+    the ID must match the regular expression <code>\p{Alnum}[\p{Alnum}-_]*</code>).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-filters.html
@@ -1,6 +1,6 @@
 <div>
     The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
     filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
-    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    category or type. Include filters will be combined with <code>or</code>, exclude filters with <code>and</code>.
     If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-filters.html
@@ -1,5 +1,6 @@
 <div>
-    The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
-    another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
-    If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
+    The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
+    filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
+    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-id.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-id.html
@@ -2,6 +2,6 @@
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
     Allowed elements are characters, digits, dashes and underscores (more precisely,
-    the ID must match the regular expression `\p{Alnum}[\p{Alnum}-_]*`).
+    the ID must match the regular expression <code>\p{Alnum}[\p{Alnum}-_]*</code>).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-filters.html
@@ -1,6 +1,6 @@
 <div>
     The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
     filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
-    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    category or type. Include filters will be combined with <code>or</code>, exclude filters with <code>and</code>.
     If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-filters.html
@@ -1,5 +1,6 @@
 <div>
-    The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
-    another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
-    If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
+    The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
+    filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
+    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-id.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-id.html
@@ -2,6 +2,6 @@
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
     Allowed elements are characters, digits, dashes and underscores (more precisely,
-    the ID must match the regular expression `\p{Alnum}[\p{Alnum}-_]*`).
+    the ID must match the regular expression <code>\p{Alnum}[\p{Alnum}-_]*</code>).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-filters.html
@@ -1,6 +1,6 @@
 <div>
     The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
     filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
-    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    category or type. Include filters will be combined with <code>or</code>, exclude filters with <code>and</code>.
     If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-filters.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-filters.html
@@ -1,5 +1,6 @@
 <div>
-    The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
-    another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
-    If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
+    The created report of issues can be filtered afterwards. You can specify an arbitrary number of include or exclude
+    filters. Currently, there is support for filtering issues by module name, package or namespace name, file name,
+    category or type. Include filters will be combined with `or`, exclude filters with `and`.
+    If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-id.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-id.html
@@ -2,6 +2,6 @@
     The results of the selected tool are published using a unique ID (i.e. URL) which must not be already used by
     another tool in this job. This ID is used as link to the results, so choose a short and meaningful name.
     Allowed elements are characters, digits, dashes and underscores (more precisely,
-    the ID must match the regular expression `\p{Alnum}[\p{Alnum}-_]*`).
+    the ID must match the regular expression <code>\p{Alnum}[\p{Alnum}-_]*</code>).
     If you leave the ID field empty, then the built-in default ID of the registered tool will be used.
 </div>


### PR DESCRIPTION
Inline documentation for `filter` contains the help of the `id` property. See https://issues.jenkins.io/browse/JENKINS-64702.