### PR TITLE
[JENKINS-61484] tooltip will not cover link when placed right

### DIFF
--- a/plugin/src/main/resources/issues/property.jelly
+++ b/plugin/src/main/resources/issues/property.jelly
@@ -41,7 +41,7 @@
               <tr>
                 <td>
                   <a href="${t.property}.${key.hashCode()}/"
-                     data-toggle="tooltip" data-placement="bottom" title="${t.getToolTip(key)}">
+                     data-toggle="tooltip" data-placement="right" title="${t.getToolTip(key)}">
                     ${t.getDisplayName(key)}</a>
                 </td>
                 <td>${count}</td>


### PR DESCRIPTION
If a tooltip is too big, and when it's positioned above the link, it can cover the link when there's not enough space. The link can't be clicked anymore at that point, since it's covered by the tooltip
Also, the tooltip will start to flicker.

Similar behavior is described [here](https://stackoverflow.com/questions/11979837/twitter-bootstrap-tooltip-not-aligning-correctly-when-it-is-going-to-go-outside).

Given the layout of the webpage, I think it's reasonable to always put the tooltip on the right, to avoid these issues.

I don't know how to add a test for this though. My experience with testing bootstrap and jelly files is limited...