### PR TITLE
[JENKINS-64376] add issue description as hidden column for search

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -34,7 +34,7 @@
     <font-awesome-api.version>5.15.2-1</font-awesome-api.version>
     <jquery3-api.version>3.5.1-2</jquery3-api.version>
     <bootstrap4-api.version>4.6.0-1</bootstrap4-api.version>
-    <data-tables-api.version>1.10.23-1</data-tables-api.version>
+    <data-tables-api.version>1.10.23-2-rc375.303aa4bbb87f</data-tables-api.version>
     <echarts-api.version>4.9.0-3</echarts-api.version>
 
     <commons.lang.version>3.11</commons.lang.version>
@@ -349,7 +349,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>git-forensics</artifactId>
-      <version>0.9.1</version>
+      <version>0.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -490,7 +490,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ansicolor</artifactId>
-      <version>0.7.5</version>
+      <version>0.7.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -34,7 +34,7 @@
     <font-awesome-api.version>5.15.2-1</font-awesome-api.version>
     <jquery3-api.version>3.5.1-2</jquery3-api.version>
     <bootstrap4-api.version>4.6.0-1</bootstrap4-api.version>
-    <data-tables-api.version>1.10.23-2-rc375.303aa4bbb87f</data-tables-api.version>
+    <data-tables-api.version>1.10.23-2-rc378.840ba07d8947</data-tables-api.version>
     <echarts-api.version>4.9.0-3</echarts-api.version>
 
     <commons.lang.version>3.11</commons.lang.version>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
@@ -72,6 +72,7 @@ public class BlamesModel extends DetailsTableModel {
         columns.add(new TableColumn(Messages.Table_Column_Commit(), "commit"));
         columns.add(new TableColumn(Messages.Table_Column_AddedAt(), "addedAt")
                 .setHeaderClass(ColumnCss.DATE));
+        columns.add(createHiddenDetailsColumn());
 
         return columns;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
@@ -107,7 +107,7 @@ public abstract class DetailsTableModel extends TableModel {
     }
 
     protected TableColumn createHiddenDetailsColumn() {
-        return new TableColumn("Hiddendetails", "descriptionContent")
+        return new TableColumn("Hiddendetails", "message")
             .setHeaderClass(ColumnCss.HIDDEN)
             .setWidth(0);
     }
@@ -142,7 +142,7 @@ public abstract class DetailsTableModel extends TableModel {
         private static final Sanitizer SANITIZER = new Sanitizer();
 
         private final String description;
-        private final String descriptionContent;
+        private final String message;
         private final DetailedColumnDefinition fileName;
         private final String age;
         private final JenkinsFacade jenkinsFacade;
@@ -167,8 +167,8 @@ public abstract class DetailsTableModel extends TableModel {
                 final Issue issue,
                 final JenkinsFacade jenkinsFacade) {
             this.jenkinsFacade = jenkinsFacade;
-            descriptionContent = getDetailsContent(issue, descriptionProvider.getDescription(issue));
-            description = formatDetails(descriptionContent);
+            message = render(issue.getMessage());
+            description = formatDetails(issue, descriptionProvider.getDescription(issue));
             age = ageBuilder.apply(parseInt(issue.getReference()));
             fileName = createFileName(fileNameRenderer, issue);
         }
@@ -179,18 +179,18 @@ public abstract class DetailsTableModel extends TableModel {
         }
 
         /**
-         * Get the raw content of the details column. This is used to add to a hidden column that is never visible,
-         * but is used for searching.
-         * See {@link #formatDetails(String) formatDetails} for the visible column.
+         * Formats the text of the details column. The details column is not directly shown, it rather is a hidden
+         * element that is expanded if the corresponding button is selected. The actual text value is stored in the
+         * {@code data-description} attribute.
          *
          * @param issue
          *         the issue in a table row
          * @param additionalDescription
          *         additional description of the issue
          *
-         * @return the raw details content.
+         * @return the formatted column
          */
-        private String getDetailsContent(final Issue issue, final String additionalDescription) {
+        private String formatDetails(final Issue issue, final String additionalDescription) {
             UnescapedText details;
             if (StringUtils.isBlank(issue.getMessage())) {
                 details = new UnescapedText(additionalDescription);
@@ -199,21 +199,7 @@ public abstract class DetailsTableModel extends TableModel {
                 details = DomContentJoiner.join(" ", false,
                         p(strong().with(new UnescapedText(issue.getMessage()))), additionalDescription);
             }
-            return render(details);
-        }
-
-        /**
-         * Formats the text of the details column. The details column is not directly shown, it rather is a hidden
-         * element that is expanded if the corresponding button is selected. The actual text value is stored in the
-         * {@code data-description} attribute.
-         *
-         * @param detailsContent
-         *         The actual text value to put in the details column
-         *
-         * @return the formatted column
-         */
-        private String formatDetails(final String detailsContent) {
-            return TableColumn.renderDetailsColumn(detailsContent, jenkinsFacade);
+            return TableColumn.renderDetailsColumn(render(details), jenkinsFacade);
         }
 
         /**
@@ -272,8 +258,8 @@ public abstract class DetailsTableModel extends TableModel {
             return description;
         }
 
-        public String getDescriptionContent() {
-            return descriptionContent;
+        public String getMessage() {
+            return message;
         }
 
         public DetailedColumnDefinition getFileName() {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ForensicsModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ForensicsModel.java
@@ -80,6 +80,7 @@ public class ForensicsModel extends DetailsTableModel {
                 .setHeaderClass(ColumnCss.NUMBER));
         columns.add(new TableColumn(Messages.Table_Column_Churn(), "churn")
                 .setHeaderClass(ColumnCss.NUMBER));
+        columns.add(createHiddenDetailsColumn());
 
         return columns;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesModel.java
@@ -63,6 +63,7 @@ public class IssuesModel extends DetailsTableModel {
         }
         columns.add(createSeverityColumn());
         columns.add(createAgeColumn());
+        columns.add(createHiddenDetailsColumn());
         return columns;
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/BlamesModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/BlamesModelTest.java
@@ -35,18 +35,18 @@ class BlamesModelTest extends AbstractDetailsModelTest {
         BlamesModel model = createModel(report, blames);
 
         String columnDefinitions = model.getColumnsDefinition();
-        assertThatJson(columnDefinitions).isArray().hasSize(7);
+        assertThatJson(columnDefinitions).isArray().hasSize(8);
 
-        String[] columns = {"description", "fileName", "age", "author", "email", "commit", "addedAt"};
+        String[] columns = {"description", "fileName", "age", "author", "email", "commit", "addedAt", "descriptionContent"};
         for (int column = 0; column < columns.length; column++) {
             verifyColumnProperty(model, column, columns[column]);
         }
         verifyFileNameColumn(columnDefinitions);
 
         assertThat(getLabels(model))
-                .containsExactly("Details", "File", "Age", "Author", "Email", "Commit", "Added");
+                .containsExactly("Details", "File", "Age", "Author", "Email", "Commit", "Added", "Hiddendetails");
         assertThat(getWidths(model))
-                .containsExactly(1, 1, 1, 1, 1, 1, 1);
+                .containsExactly(1, 1, 1, 1, 1, 1, 1, 0);
 
         assertThat(model.getRows()).hasSize(2);
     }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/BlamesModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/BlamesModelTest.java
@@ -37,7 +37,7 @@ class BlamesModelTest extends AbstractDetailsModelTest {
         String columnDefinitions = model.getColumnsDefinition();
         assertThatJson(columnDefinitions).isArray().hasSize(8);
 
-        String[] columns = {"description", "fileName", "age", "author", "email", "commit", "addedAt", "descriptionContent"};
+        String[] columns = {"description", "fileName", "age", "author", "email", "commit", "addedAt", "message"};
         for (int column = 0; column < columns.length; column++) {
             verifyColumnProperty(model, column, columns[column]);
         }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ForensicsModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ForensicsModelTest.java
@@ -31,10 +31,10 @@ class ForensicsModelTest extends AbstractDetailsModelTest {
         ForensicsModel model = createModel(report, statistics);
 
         String columnDefinitions = model.getColumnsDefinition();
-        assertThatJson(columnDefinitions).isArray().hasSize(9);
+        assertThatJson(columnDefinitions).isArray().hasSize(10);
 
         String[] columns = {"description", "fileName", "age", "authorsSize",
-                "commitsSize", "modifiedAt", "addedAt", "linesOfCode", "churn"};
+                "commitsSize", "modifiedAt", "addedAt", "linesOfCode", "churn", "descriptionContent"};
         for (int column = 0; column < columns.length; column++) {
             verifyColumnProperty(model, column, columns[column]);
         }
@@ -42,9 +42,9 @@ class ForensicsModelTest extends AbstractDetailsModelTest {
 
         assertThat(getLabels(model))
                 .containsExactly("Details", "File", "Age", "#Authors",
-                        "#Commits", "Last Commit", "Added", "#LoC", "Code Churn");
+                        "#Commits", "Last Commit", "Added", "#LoC", "Code Churn", "Hiddendetails");
         assertThat(getWidths(model))
-                .containsExactly(1, 2, 1, 1, 1, 2, 2, 1, 1);
+                .containsExactly(1, 2, 1, 1, 1, 2, 2, 1, 1, 0);
 
         assertThat(model.getRows()).hasSize(2);
     }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ForensicsModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ForensicsModelTest.java
@@ -34,7 +34,7 @@ class ForensicsModelTest extends AbstractDetailsModelTest {
         assertThatJson(columnDefinitions).isArray().hasSize(10);
 
         String[] columns = {"description", "fileName", "age", "authorsSize",
-                "commitsSize", "modifiedAt", "addedAt", "linesOfCode", "churn", "descriptionContent"};
+                "commitsSize", "modifiedAt", "addedAt", "linesOfCode", "churn", "message"};
         for (int column = 0; column < columns.length; column++) {
             verifyColumnProperty(model, column, columns[column]);
         }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IssuesModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IssuesModelTest.java
@@ -32,9 +32,9 @@ class IssuesModelTest extends AbstractDetailsModelTest {
         IssuesModel model = createModel(report);
 
         String columnDefinitions = model.getColumnsDefinition();
-        assertThatJson(columnDefinitions).isArray().hasSize(7);
+        assertThatJson(columnDefinitions).isArray().hasSize(8);
 
-        String[] columns = {"description", "fileName", "packageName", "category", "type", "severity", "age"};
+        String[] columns = {"description", "fileName", "packageName", "category", "type", "severity", "age", "descriptionContent" };
         for (int column = 0; column < columns.length; column++) {
             verifyColumnProperty(model, column, columns[column]);
         }
@@ -61,28 +61,28 @@ class IssuesModelTest extends AbstractDetailsModelTest {
 
         DetailsTableModel model = createModel(report);
         assertThat(getLabels(model))
-                .containsExactly("Details", "File", "Severity", "Age");
+                .containsExactly("Details", "File", "Severity", "Age", "Hiddendetails");
         assertThat(getWidths(model))
-                .containsExactly(1, 1, 1, 1);
+                .containsExactly(1, 1, 1, 1, 0);
         assertThat(model.getRows()).hasSize(1);
 
         when(report.hasPackages()).thenReturn(true);
         assertThat(getLabels(model))
-                .containsExactly("Details", "File", "Package", "Severity", "Age");
+                .containsExactly("Details", "File", "Package", "Severity", "Age", "Hiddendetails");
         assertThat(getWidths(model))
-                .containsExactly(1, 1, 2, 1, 1);
+                .containsExactly(1, 1, 2, 1, 1, 0);
 
         when(report.hasCategories()).thenReturn(true);
         assertThat(getLabels(model))
-                .containsExactly("Details", "File", "Package", "Category", "Severity", "Age");
+                .containsExactly("Details", "File", "Package", "Category", "Severity", "Age", "Hiddendetails");
         assertThat(getWidths(model))
-                .containsExactly(1, 1, 2, 1, 1, 1);
+                .containsExactly(1, 1, 2, 1, 1, 1, 0);
 
         when(report.hasTypes()).thenReturn(true);
         assertThat(getLabels(model))
-                .containsExactly("Details", "File", "Package", "Category", "Type", "Severity", "Age");
+                .containsExactly("Details", "File", "Package", "Category", "Type", "Severity", "Age", "Hiddendetails");
         assertThat(getWidths(model))
-                .containsExactly(1, 1, 2, 1, 1, 1, 1);
+                .containsExactly(1, 1, 2, 1, 1, 1, 1, 0);
     }
 
     private IssuesModel createModel(final Report report) {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IssuesModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IssuesModelTest.java
@@ -34,7 +34,7 @@ class IssuesModelTest extends AbstractDetailsModelTest {
         String columnDefinitions = model.getColumnsDefinition();
         assertThatJson(columnDefinitions).isArray().hasSize(8);
 
-        String[] columns = {"description", "fileName", "packageName", "category", "type", "severity", "age", "descriptionContent" };
+        String[] columns = {"description", "fileName", "packageName", "category", "type", "severity", "age", "message" };
         for (int column = 0; column < columns.length; column++) {
             verifyColumnProperty(model, column, columns[column]);
         }


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-64376

Description is added as a hidden column, so it can be searched, but doesn't clutter the view.

Downstream PR for https://github.com/jenkinsci/data-tables-api-plugin/pull/146
