### PR TITLE
[JENKINS-64051] Do not reformat punctuation when building the description 

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
@@ -9,6 +9,7 @@ import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 
+import j2html.tags.DomContentJoiner;
 import j2html.tags.UnescapedText;
 
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
@@ -187,7 +188,8 @@ public abstract class DetailsTableModel extends TableModel {
                 details = new UnescapedText(additionalDescription);
             }
             else {
-                details = join(p(strong().with(new UnescapedText(issue.getMessage()))), additionalDescription);
+                details = DomContentJoiner.join(" ", false,
+                        p(strong().with(new UnescapedText(issue.getMessage()))), additionalDescription);
             }
             return TableColumn.renderDetailsColumn(render(details), jenkinsFacade);
         }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailsTableModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailsTableModelTest.java
@@ -3,8 +3,11 @@ package io.jenkins.plugins.analysis.core.model;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
 
 import io.jenkins.plugins.analysis.core.model.DetailsTableModel.TableRow;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests the class {@link DetailsTableModel}.
@@ -12,6 +15,16 @@ import io.jenkins.plugins.analysis.core.model.DetailsTableModel.TableRow;
  * @author Ullrich Hafner
  */
 class DetailsTableModelTest extends AbstractDetailsModelTest {
+    @Test @org.jvnet.hudson.test.Issue("JENKINS-64051")
+    void shouldNotRemoveWhitespace() {
+        IssueBuilder builder = new IssueBuilder();
+        builder.setMessage("project: Defaults to NumberGroupSeparator on .NET Core except on Windows.");
+        TableRow model = createRow(builder.build());
+
+        String actualColumn = model.getDescription();
+        assertThat(actualColumn).contains("NumberGroupSeparator on .NET Core except");
+    }
+
     @Test
     void shouldCreateSortableFileName() {
         Issue issue = createIssue(1);


### PR DESCRIPTION
See [JENKINS-64051](https://issues.jenkins.io/browse/JENKINS-64051) for details.