### PR TITLE
[JENKINS-63109] Add a return value for the step `recordIssues`

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
@@ -352,6 +352,7 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
         return statistics;
     }
 
+    @Whitelisted
     @Override
     public String getId() {
         return id;
@@ -408,6 +409,7 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
      *
      * @return all issues
      */
+    @Whitelisted
     public Report getIssues() {
         Report merged = new Report();
         merged.addAll(getNewIssues(), getOutstandingIssues());
@@ -420,6 +422,7 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
      *
      * @return all outstanding issues
      */
+    @Whitelisted
     public Report getOutstandingIssues() {
         return getIssues(AnalysisResult::getOutstandingIssuesReference, AnalysisResult::setOutstandingIssuesReference,
                 "outstanding");
@@ -431,6 +434,7 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
      *
      * @return all new issues
      */
+    @Whitelisted
     public Report getNewIssues() {
         return getIssues(AnalysisResult::getNewIssuesReference, AnalysisResult::setNewIssuesReference,
                 "new");
@@ -442,6 +446,7 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
      *
      * @return all fixed issues
      */
+    @Whitelisted
     public Report getFixedIssues() {
         return getIssues(AnalysisResult::getFixedIssuesReference, AnalysisResult::setFixedIssuesReference,
                 "fixed");
@@ -517,6 +522,7 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
         return qualityGateStatus.isSuccessful();
     }
 
+    @Whitelisted
     @Override
     public QualityGateStatus getQualityGateStatus() {
         return qualityGateStatus;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
@@ -1064,7 +1064,7 @@ public class RecordIssuesStep extends Step implements Serializable {
     /**
      * Actually performs the execution of the associated step.
      */
-    static class Execution extends AnalysisExecution<Void> {
+    static class Execution extends AnalysisExecution<List<AnalysisResult>> {
         private static final long serialVersionUID = -2840020502160375407L;
 
         private final RecordIssuesStep step;
@@ -1075,7 +1075,7 @@ public class RecordIssuesStep extends Step implements Serializable {
         }
 
         @Override
-        protected Void run() throws IOException, InterruptedException {
+        protected List<AnalysisResult> run() throws IOException, InterruptedException {
             IssuesRecorder recorder = new IssuesRecorder();
             recorder.setTools(step.getTools());
             recorder.setSourceCodeEncoding(step.getSourceCodeEncoding());
@@ -1105,8 +1105,8 @@ public class RecordIssuesStep extends Step implements Serializable {
 
             FilePath workspace = getWorkspace();
             workspace.mkdirs();
-            recorder.perform(getRun(), workspace, getTaskListener(), statusHandler);
-            return null;
+
+            return recorder.perform(getRun(), workspace, getTaskListener(), statusHandler);
         }
 
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/StaticAnalysisRun.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/StaticAnalysisRun.java
@@ -16,6 +16,7 @@ public interface StaticAnalysisRun extends AnalysisBuildResult {
      *
      * @return the ID
      */
+    @Whitelisted
     String getId();
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -101,9 +101,12 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         assertThat(getConsoleLog(baseline)).contains("[fixedSize=" + 0 + "]");
         assertThat(getConsoleLog(baseline)).contains("[qualityGate=" + "PASSED" + "]");
         assertThat(getConsoleLog(baseline)).contains("[id=checkstyle]");
-        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(17,5): DesignForExtensionCheck: Design: Die Methode 'accepts' ist nicht für Vererbung entworfen - muss abstract, final oder leer sein.");
-        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(42,0): LineLengthCheck: Sizes: Zeile länger als 80 Zeichen");
-        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(22,5): DesignForExtensionCheck: Design: Die Methode 'detectPackageName' ist nicht fr Vererbung entworfen - muss abstract, final oder leer sein.");
+        assertThat(getConsoleLog(baseline)).contains(
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(17,5): DesignForExtensionCheck: Design: Die Methode 'accepts' ",
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(17,5): DesignForExtensionCheck: Design: Die Methode 'accepts' ",
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(17,5): DesignForExtensionCheck: Design: Die Methode 'accepts' ");
+        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(42,0): LineLengthCheck: Sizes: Zeile ");
+        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(22,5): DesignForExtensionCheck: Design: Die Methode 'detectPackageName' ");
 
         configureRecorder(job, "checkstyle2");
         Run<?, ?> build = buildWithResult(job, Result.UNSTABLE);
@@ -113,10 +116,10 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         assertThat(getConsoleLog(build)).contains("[fixedSize=" + 2 + "]");
         assertThat(getConsoleLog(build)).contains("[qualityGate=" + "WARNING" + "]");
         assertThat(getConsoleLog(build)).contains("[id=checkstyle]");
-        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(29,0): LineLengthCheck: Sizes: Zeile länger als 80 Zeichen");
+        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(29,0): LineLengthCheck: Sizes: Zeile ");
         assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(30,21): RightCurlyCheck: Blocks: '}' sollte in derselben Zeile stehen.");
         assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(37,9): RightCurlyCheck: Blocks: '}' sollte in derselben Zeile stehen.");
-        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(22,5): DesignForExtensionCheck: Design: Die Methode 'detectPackageName' ist nicht fr Vererbung entworfen - muss abstract, final oder leer sein.");
+        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(22,5): DesignForExtensionCheck: Design: Die Methode 'detectPackageName' ");
     }
 
     private void configureRecorder(final WorkflowJob job, final String fileName) {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -85,6 +85,58 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         assertThat(getConsoleLog(build)).contains("[id=checkstyle]");
     }
 
+    /**
+     * Runs a pipeline and verifies the {@code recordIssues} step has some whitelisted methods.
+     */
+    @Test @org.jvnet.hudson.test.Issue("JENKINS-63109")
+    public void shouldWhitelistRecorderApi() {
+        WorkflowJob job = createPipelineWithWorkspaceFiles("checkstyle1.xml", "checkstyle2.xml");
+
+        configureRecorder(job, "checkstyle1");
+        Run<?, ?> baseline = buildSuccessfully(job);
+
+        assertThat(getConsoleLog(baseline)).contains("[reportsSize=" + 1 + "]");
+        assertThat(getConsoleLog(baseline)).contains("[totalSize=" + 3 + "]");
+        assertThat(getConsoleLog(baseline)).contains("[newSize=" + 0 + "]");
+        assertThat(getConsoleLog(baseline)).contains("[fixedSize=" + 0 + "]");
+        assertThat(getConsoleLog(baseline)).contains("[qualityGate=" + "PASSED" + "]");
+        assertThat(getConsoleLog(baseline)).contains("[id=checkstyle]");
+        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(17,5): DesignForExtensionCheck: Design: Die Methode 'accepts' ist nicht für Vererbung entworfen - muss abstract, final oder leer sein.");
+        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(42,0): LineLengthCheck: Sizes: Zeile länger als 80 Zeichen");
+        assertThat(getConsoleLog(baseline)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(22,5): DesignForExtensionCheck: Design: Die Methode 'detectPackageName' ist nicht fr Vererbung entworfen - muss abstract, final oder leer sein.");
+
+        configureRecorder(job, "checkstyle2");
+        Run<?, ?> build = buildWithResult(job, Result.UNSTABLE);
+        assertThat(getConsoleLog(build)).contains("[reportsSize=" + 1 + "]");
+        assertThat(getConsoleLog(build)).contains("[totalSize=" + 4 + "]");
+        assertThat(getConsoleLog(build)).contains("[newSize=" + 3 + "]");
+        assertThat(getConsoleLog(build)).contains("[fixedSize=" + 2 + "]");
+        assertThat(getConsoleLog(build)).contains("[qualityGate=" + "WARNING" + "]");
+        assertThat(getConsoleLog(build)).contains("[id=checkstyle]");
+        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(29,0): LineLengthCheck: Sizes: Zeile länger als 80 Zeichen");
+        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(30,21): RightCurlyCheck: Blocks: '}' sollte in derselben Zeile stehen.");
+        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(37,9): RightCurlyCheck: Blocks: '}' sollte in derselben Zeile stehen.");
+        assertThat(getConsoleLog(build)).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java(22,5): DesignForExtensionCheck: Design: Die Methode 'detectPackageName' ist nicht fr Vererbung entworfen - muss abstract, final oder leer sein.");
+    }
+
+    private void configureRecorder(final WorkflowJob job, final String fileName) {
+        job.setDefinition(new CpsFlowDefinition("node {\n"
+                + "  stage ('Integration Test') {\n"
+                + "         def reports = recordIssues tool: checkStyle(pattern: '**/" + fileName + "*'), qualityGates: [[threshold: 4, type: 'TOTAL', unstable: true]]\n"
+                + "         echo '[reportsSize=' + reports.size() + ']' \n"
+                + "         def result = reports.get(0) \n"
+                + "         echo '[totalSize=' + result.getTotals().getTotalSize() + ']' \n"
+                + "         echo '[newSize=' + result.getTotals().getNewSize() + ']' \n"
+                + "         echo '[fixedSize=' + result.getTotals().getFixedSize() + ']' \n"
+                + "         echo '[qualityGate=' + result.getQualityGateStatus() + ']' \n"
+                + "         echo '[id=' + result.getId() + ']' \n"
+                + "         result.getIssues().each { issue ->\n"
+                + "             echo issue.toString()\n"
+                + "         }"
+                + "  }\n"
+                + "}", true));
+    }
+
     private void configureScanner(final WorkflowJob job, final String fileName) {
         job.setDefinition(new CpsFlowDefinition("node {\n"
                 + "  stage ('Integration Test') {\n"


### PR DESCRIPTION
The step now returns a list of `AnalysisResult` instances.

See https://issues.jenkins.io/browse/JENKINS-63109 for details.