### PR TITLE
[JENKINS-64657] Use new DoxygenParser for Doxygen

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -26,7 +26,7 @@
 
     <module.name>${project.groupId}.warnings.ng</module.name>
 
-    <analysis-model-api.version>9.7.0</analysis-model-api.version>
+    <analysis-model-api.version>9.8.0</analysis-model-api.version>
     <analysis-model-tests.version>${analysis-model-api.version}</analysis-model-tests.version>
     <forensics-api-plugin.version>0.9.3</forensics-api-plugin.version>
     <plugin-util-api.version>1.6.1</plugin-util-api.version>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/Doxygen.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/Doxygen.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.analysis.warnings;
 
 import edu.hm.hafner.analysis.IssueParser;
-import edu.hm.hafner.analysis.parser.Gcc4CompilerParser;
+import edu.hm.hafner.analysis.parser.DoxygenParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -18,8 +18,6 @@ import io.jenkins.plugins.analysis.core.model.ReportScanningTool;
 public class Doxygen extends ReportScanningTool {
     private static final long serialVersionUID = -958188599615335136L;
     private static final String ID = "doxygen";
-    private static final String DOXYGEN_WARNING_PATTERN =
-        "(?:(.+?):(\\d+):(?:(\\d+):)?)? ?([wW]arning|.*[Ee]rror): (.*)$";
 
     /** Creates a new instance of {@link Doxygen}. */
     @DataBoundConstructor
@@ -30,7 +28,7 @@ public class Doxygen extends ReportScanningTool {
 
     @Override
     public IssueParser createParser() {
-        return new Gcc4CompilerParser(DOXYGEN_WARNING_PATTERN);
+        return new DoxygenParser();
     }
 
     /** Descriptor for this static analysis tool. */

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/Doxygen.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/Doxygen.java
@@ -18,6 +18,8 @@ import io.jenkins.plugins.analysis.core.model.ReportScanningTool;
 public class Doxygen extends ReportScanningTool {
     private static final long serialVersionUID = -958188599615335136L;
     private static final String ID = "doxygen";
+    private static final String DOXYGEN_WARNING_PATTERN =
+        "(?:(.+?):(\\d+):(?:(\\d+):)?)? ?([wW]arning|.*[Ee]rror): (.*)$";
 
     /** Creates a new instance of {@link Doxygen}. */
     @DataBoundConstructor
@@ -28,7 +30,7 @@ public class Doxygen extends ReportScanningTool {
 
     @Override
     public IssueParser createParser() {
-        return new Gcc4CompilerParser();
+        return new Gcc4CompilerParser(DOXYGEN_WARNING_PATTERN);
     }
 
     /** Descriptor for this static analysis tool. */

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
@@ -855,7 +855,7 @@ public class ParsersITest extends IntegrationTestWithJenkinsPerSuite {
     /** Runs the Doxygen parser on an output file that contains 18 issues. */
     @Test
     public void shouldFindAllDoxygenIssues() {
-        shouldFindIssuesOfTool(18, new Doxygen(), "doxygen.txt");
+        shouldFindIssuesOfTool(19, new Doxygen(), "doxygen.txt");
     }
 
     /** Runs the Dr. Memory parser on an output file that contains 8 issues. */


### PR DESCRIPTION
This is supposed to solve (at least partially) the issues described here: https://issues.jenkins.io/browse/JENKINS-64657.

The warnings that were not parsed were of this type:
```
Warning: doxygen no longer ships with the FreeSans font.
         You may want to clear or change DOT_FONTNAME.
         Otherwise you run the risk that the wrong font is being used for dot generated graphs.
Warning: source ../path/to/file is not a readable file or directory... skipping.
```

This modified Gcc4CompilerParser pattern catches these types.

This commit is related to jenkinsci/analysis-model#559