### PR TITLE
[JENKINS-61834] Add a raw name for the results to be used as display name

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
@@ -94,7 +94,7 @@ public class JobAction implements Action, AsyncTrendChart {
 
     @Override
     public String getDisplayName() {
-        return labelProvider.getLinkName();
+        return labelProvider.getRawLinkName();
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
@@ -160,7 +160,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
     @Whitelisted
     @Override
     public String getDisplayName() {
-        return getLabelProvider().getLinkName();
+        return getLabelProvider().getRawLinkName();
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
@@ -45,6 +45,8 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
 
     private final String id;
     @CheckForNull
+    private String rawName;
+    @CheckForNull
     private String name;
     private final JenkinsFacade jenkins;
 
@@ -73,8 +75,16 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
     @VisibleForTesting
     StaticAnalysisLabelProvider(final String id, @CheckForNull final String name, final JenkinsFacade jenkins) {
         this.id = id;
-        this.name = SANITIZER.render(name);
         this.jenkins = jenkins;
+
+        setNameAndRawName(name);
+    }
+
+    private void setNameAndRawName(final String name) {
+        if (StringUtils.isNotBlank(name)) { // don't overwrite with empty
+            this.rawName = name;
+            this.name = SANITIZER.render(name);
+        }
     }
 
     /**
@@ -154,9 +164,7 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
      * @return the name
      */
     public StaticAnalysisLabelProvider setName(@CheckForNull final String name) {
-        if (StringUtils.isNotBlank(name)) { // don't overwrite with empty
-            this.name = name;
-        }
+        setNameAndRawName(name);
 
         return this;
     }
@@ -167,12 +175,24 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
     }
 
     /**
-     * Returns the name of the link to the results in Jenkins' side panel.
+     * Returns the name of the link to the results. The name will be sanitized and may contain HTML entities.
      *
      * @return the name of the side panel link
      */
     public String getLinkName() {
         return Messages.Tool_Link_Name(getName());
+    }
+
+    /**
+     * Returns the name of the link to the results in Jenkins' side panel.
+     *
+     * @return the name of the side panel link
+     */
+    public String getRawLinkName() {
+        if (StringUtils.isNotBlank(rawName)) {
+            return Messages.Tool_Link_Name(rawName);
+        }
+        return Messages.Tool_Link_Name(getDefaultName());
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
@@ -80,10 +80,10 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
         setNameAndRawName(name);
     }
 
-    private void setNameAndRawName(final String name) {
-        if (StringUtils.isNotBlank(name)) { // don't overwrite with empty
-            this.rawName = name;
-            this.name = SANITIZER.render(name);
+    private void setNameAndRawName(final String originalName) {
+        if (StringUtils.isNotBlank(originalName)) { // don't overwrite with empty
+            rawName = originalName;
+            name = SANITIZER.render(originalName);
         }
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
@@ -31,6 +31,7 @@ class JobActionTest {
     void shouldUseLabelProvider() {
         StaticAnalysisLabelProvider labelProvider = mock(StaticAnalysisLabelProvider.class);
         when(labelProvider.getLinkName()).thenReturn(LINK_NAME);
+        when(labelProvider.getRawLinkName()).thenReturn(LINK_NAME);
         when(labelProvider.getTrendName()).thenReturn(TREND_NAME);
         when(labelProvider.getId()).thenReturn(ID);
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProviderTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProviderTest.java
@@ -4,6 +4,7 @@ import java.util.Locale;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
 
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
@@ -19,6 +20,17 @@ class StaticAnalysisLabelProviderTest {
     private static final String ID = "id";
     private static final String NAME = "name";
     private static final String OTHER_NAME = "other";
+
+    @Test @Issue("JENKINS-61834")
+    void shouldNotEscapeHtmlEntities() {
+        StaticAnalysisLabelProvider labelProvider = new StaticAnalysisLabelProvider(ID, "C++");
+
+        assertThat(labelProvider).hasId(ID);
+        assertThat(labelProvider).hasName("C&#43;&#43;");
+        assertThat(labelProvider.getLinkName()).contains("C&#43;&#43;");
+        assertThat(labelProvider.getRawLinkName()).contains("C++");
+        assertThat(labelProvider.getTrendName()).contains("C&#43;&#43;");
+    }
 
     @Test
     void shouldReturnIdAndNameOfConstructorParametersInAllDisplayProperties() {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/util/SanitizerTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/util/SanitizerTest.java
@@ -1,0 +1,20 @@
+package io.jenkins.plugins.analysis.core.util;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests the class {@link Sanitizer}.
+ *
+ * @author Ullrich Hafner
+ */
+class SanitizerTest {
+    @Test @Issue("JENKINS-61834")
+    void shouldSkipPlus() {
+        Sanitizer sanitizer = new Sanitizer();
+
+        assertThat(sanitizer.render("C++")).isEqualTo("C&#43;&#43;");
+    }
+}


### PR DESCRIPTION
Since the `name` is user provided it needs to be sanitized in all HTML views.
But in the side panel links the name can be used in its raw form without escaping.

For details see [JENKINS-61834](https://issues.jenkins.io/browse/JENKINS-61834).