### PR TITLE
[JENKINS-64830] Add `AGGREGATION_ONLY` option in UI

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -21,7 +21,7 @@
   <url>https://github.com/jenkinsci/warnings-ng-plugin</url>
 
   <properties>
-    <revision>8.10.0</revision>
+    <revision>8.9.1</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.warnings.ng</module.name>
@@ -691,6 +691,11 @@
                 <code>java.field.enumConstantOrderChanged</code>
                 <classQualifiedName>io.jenkins.plugins.analysis.core.util.TrendChartType</classQualifiedName>
                 <justification>Internal API to render the available trends.</justification>
+              </item>
+              <item>
+                <code>java.method.added</code>
+                <classSimpleName>Messages</classSimpleName>
+                <justification>Messages are now external API.</justification>
               </item>
             </revapi.ignore>
           </analysisConfiguration>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/ModelValidation.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/ModelValidation.java
@@ -158,6 +158,7 @@ public class ModelValidation {
         options.add(Messages.AggregationChart_AGGREGATION_TOOLS(), TrendChartType.AGGREGATION_TOOLS.name());
         options.add(Messages.AggregationChart_TOOLS_AGGREGATION(), TrendChartType.TOOLS_AGGREGATION.name());
         options.add(Messages.AggregationChart_TOOLS_ONLY(), TrendChartType.TOOLS_ONLY.name());
+        options.add(Messages.AggregationChart_AGGREGATION_ONLY(), TrendChartType.AGGREGATION_ONLY.name());
         options.add(Messages.AggregationChart_NONE(), TrendChartType.NONE.name());
         return options;
     }

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-trendChartType.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/IssuesRecorder/help-trendChartType.html
@@ -9,6 +9,8 @@
         <dd>The aggregation trend is shown <b>after</b> all other analysis tool trend charts.</dd>
         <dt>TOOLS_ONLY</dt>
         <dd>The aggregation trend is not shown, only the analysis tool trend charts are shown.</dd>
+        <dt>AGGREGATION_ONLY</dt>
+        <dd>The aggregation trend is only shown, no other analysis tool trend charts are shown.</dd>
         <dt>NONE</dt>
         <dd>Neither the aggregation trend nor analysis tool trend charts are shown.</dd>
     </dl>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-trendChartType.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep/help-trendChartType.html
@@ -9,6 +9,8 @@
         <dd>The aggregation trend is shown <b>after</b> all other analysis tool trend charts.</dd>
         <dt>TOOLS_ONLY</dt>
         <dd>The aggregation trend is not shown, only the analysis tool trend charts are shown.</dd>
+        <dt>AGGREGATION_ONLY</dt>
+        <dd>The aggregation trend is only shown, no other analysis tool trend charts are shown.</dd>
         <dt>NONE</dt>
         <dd>Neither the aggregation trend nor analysis tool trend charts are shown.</dd>
     </dl>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-trendChartType.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-trendChartType.html
@@ -9,6 +9,8 @@
         <dd>The aggregation trend is shown <b>after</b> all other analysis tool trend charts.</dd>
         <dt>TOOLS_ONLY</dt>
         <dd>The aggregation trend is not shown, only the analysis tool trend charts are shown.</dd>
+        <dt>AGGREGATION_ONLY</dt>
+        <dd>The aggregation trend is only shown, no other analysis tool trend charts are shown.</dd>
         <dt>NONE</dt>
         <dd>Neither the aggregation trend nor analysis tool trend charts are shown.</dd>
     </dl>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-trendChartType.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep/help-trendChartType.html
@@ -9,6 +9,8 @@
         <dd>The aggregation trend is shown <b>after</b> all other analysis tool trend charts.</dd>
         <dt>TOOLS_ONLY</dt>
         <dd>The aggregation trend is not shown, only the analysis tool trend charts are shown.</dd>
+        <dt>AGGREGATION_ONLY</dt>
+        <dd>The aggregation trend is only shown, no other analysis tool trend charts are shown.</dd>
         <dt>NONE</dt>
         <dd>Neither the aggregation trend nor analysis tool trend charts are shown.</dd>
     </dl>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/util/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/util/Messages.properties
@@ -17,9 +17,10 @@ SeverityFilter.High=Error and High
 SeverityFilter.Normal=Error, High and Normal
 SeverityFilter.Low=All Severities
 
-AggregationChart.AGGREGATION_TOOLS=Aggregation (top) and tools
-AggregationChart.TOOLS_AGGREGATION=Tools and aggregation (bottom)
-AggregationChart.TOOLS_ONLY=No aggregation, only tools
+AggregationChart.AGGREGATION_TOOLS=Aggregation on top - tools at the bottom
+AggregationChart.TOOLS_AGGREGATION=Tools on top - aggregation at the bottom
+AggregationChart.TOOLS_ONLY=No aggregation - only tools
+AggregationChart.AGGREGATION_ONLY=Only aggregation - no tools
 AggregationChart.NONE=No trend charts
 
 FieldValidator.Error.WrongIdFormat=An ID must be a valid URL.

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/util/ModelValidationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/util/ModelValidationTest.java
@@ -102,6 +102,14 @@ class ModelValidationTest {
     }
 
     @Test
+    void doFillTrendChartOptions() {
+        ModelValidation model = new ModelValidation();
+        ListBoxModel allFilters = model.getAllTrendChartTypes();
+
+        assertThat(allFilters).hasSize(TrendChartType.values().length);
+    }
+
+    @Test
     void doFillReferenceJobItemsShouldBeNotEmpty() {
         JenkinsFacade jenkins = mock(JenkinsFacade.class);
         when(jenkins.getAllJobNames()).thenReturn(new HashSet<>());

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PyLintTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PyLintTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import io.jenkins.plugins.analysis.warnings.PyLint.PyLintDescriptions;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests the class {@link PyLintDescriptions}.


### PR DESCRIPTION
While the steps support this new type the UI and help still lists only the old types. For details see [JENKINS-64830](https://issues.jenkins.io/browse/JENKINS-64830).