### PR TITLE
Upgrade commons-beanutils 1.9.4

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -167,6 +167,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
       <version>${commons.text.version}</version>


### PR DESCRIPTION
Use last version of commons-beanutils as current one is subject to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0114

Signed-off-by: olivier lamy <olamy@apache.org>
