### PR TITLE
Use inline elements on run summary page

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
@@ -234,7 +234,7 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
      */
     public ContainerTag getTitle(final AnalysisResult result, final boolean hasErrors) {
         String icon = hasErrors ? ERROR_ICON : INFO_ICON;
-        return div(join(getName() + ": ",
+        return span(join(getName() + ": ",
                 getWarningsCount(result),
                 a().withHref(getId() + "/info").with(
                         new UnescapedText(new SvgTag(icon, jenkins).withClasses("info-page-decorator").render())))).withId(

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/Summary.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/Summary.java
@@ -66,7 +66,7 @@ public class Summary {
      * @return the summary
      */
     public String create() {
-        return div(labelProvider.getTitle(analysisResult, !analysisResult.getErrorMessages().isEmpty()),
+        return span(labelProvider.getTitle(analysisResult, !analysisResult.getErrorMessages().isEmpty()),
                 createDescription())
                 .withId(labelProvider.getId() + "-summary")
                 .renderFormatted();

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryTest.java
@@ -83,7 +83,7 @@ class SummaryTest {
         AnalysisResult analysisResult = createAnalysisResult(EMPTY_ORIGINS, 0, 0,
                 EMPTY_ERRORS, 0);
         String createdHtml = createSummary(analysisResult).create();
-        assertThat(createdHtml).contains("<div id=\"test-summary\">");
+        assertThat(createdHtml).contains("<span id=\"test-summary\">");
         assertThat(createdHtml).contains("id=\"test-title\"");
     }
 


### PR DESCRIPTION
Preparation for fixing https://issues.jenkins.io/browse/JENKINS-65033

It's forwards and backwards compatible (no changes in the UI)

@uhafner 