### PR TITLE
Add required repository sections to example pom

### DIFF
--- a/doc/Custom-Plugin.md
+++ b/doc/Custom-Plugin.md
@@ -32,6 +32,20 @@ The plugin should depend on Jenkins plugin parent pom and on the Warnings Next G
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories> 
+ 
 </project>
 ```
 

--- a/doc/Custom-Plugin.md
+++ b/doc/Custom-Plugin.md
@@ -42,7 +42,7 @@ The plugin should depend on Jenkins plugin parent pom and on the Warnings Next G
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories> 
  

--- a/doc/Custom-Plugin.md
+++ b/doc/Custom-Plugin.md
@@ -35,7 +35,7 @@ The plugin should depend on Jenkins plugin parent pom and on the Warnings Next G
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Without these, maven cannot find the parent pom. Thought I'd offer an update to the documentation to fix that problem.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
  - I have no desired changelog entry. I don't really care, just thought I'd help.
- [x] Please describe what you did
  - I added the `<repository>` and `<pluginRepository>` sections required to get the provided pom to work.
- [x] Link to relevant issues in GitHub or Jira
  - No issue, I just found it and fixed it.
- [x] Link to relevant pull requests, esp. upstream and downstream changes
  - N/A
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
  - Tests for a documentation change?