### PR TITLE
"Number of static analysis issues" column should not be added by default

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumn.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumn.java
@@ -239,6 +239,11 @@ public class IssuesTotalColumn extends ListViewColumn {
             return Messages.IssuesTotalColumn_Name();
         }
 
+        @Override
+        public boolean shownByDefault() {
+        	return false;
+        }
+
         /**
          * Return the model for the select widget.
          *


### PR DESCRIPTION
The column should not be added to a new view by default, but rather if the user deliberately wants to add it.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

---
I've manually tested that the fix works as expected. Creating an automated test for this is not worth the effort IMHO.

Let me know if I need to create a corresponding GitHub or JIRA issue first.