### PR TITLE
Let `getDescriptionProvider` return a `DescriptionProvider` instance

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -21,7 +21,7 @@
   <url>https://github.com/jenkinsci/warnings-ng-plugin</url>
 
   <properties>
-    <revision>9.1.0</revision>
+    <revision>9.0.1</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.warnings.ng</module.name>
@@ -670,9 +670,9 @@
               </item>
               <item>
                 <regex>true</regex>
-                <code>java.method.numberOfParametersChanged</code>
-                <methodName>do[A-Z].*</methodName>
-                <justification>Validation methods are internal API.</justification>
+                <code>java.method.returnTypeChanged</code>
+                <methodName>getDescriptionProvider</methodName>
+                <justification>Return type must be part of the API.</justification>
               </item>
               <item>
                 <code>java.method.added</code>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisModelParser.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisModelParser.java
@@ -84,7 +84,7 @@ public abstract class AnalysisModelParser extends ReportScanningTool {
          *
          * @return a description provider
          */
-        protected RegistryIssueDescriptionProvider getDescriptionProvider() {
+        protected DescriptionProvider getDescriptionProvider() {
             return descriptionProvider;
         }
 


### PR DESCRIPTION
Accidently this method returned the private implementation `RegistryIssueDescriptionProvider`.

