### PR TITLE
implement MonitorPortlet for pull-request-monitoring plugin

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -39,7 +39,7 @@
     <bootstrap4-api.version>4.6.0-3</bootstrap4-api.version>
     <popper-api.version>1.16.1-2</popper-api.version>
     <error_prone_annotations.version>2.7.1</error_prone_annotations.version>
-    <pull-request-monitoring.version>1.7.0</pull-request-monitoring.version>
+    <pull-request-monitoring.version>1.7.1</pull-request-monitoring.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
     <j2html.version>1.4.0</j2html.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -39,7 +39,7 @@
     <bootstrap4-api.version>4.6.0-3</bootstrap4-api.version>
     <popper-api.version>1.16.1-2</popper-api.version>
     <error_prone_annotations.version>2.7.1</error_prone_annotations.version>
-    <pull-request-monitoring.version>1.6.0</pull-request-monitoring.version>
+    <pull-request-monitoring.version>1.6.1</pull-request-monitoring.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
     <j2html.version>1.4.0</j2html.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -39,7 +39,7 @@
     <bootstrap4-api.version>4.6.0-3</bootstrap4-api.version>
     <popper-api.version>1.16.1-2</popper-api.version>
     <error_prone_annotations.version>2.7.1</error_prone_annotations.version>
-    <pull-request-monitoring.version>1.6.1</pull-request-monitoring.version>
+    <pull-request-monitoring.version>1.7.0</pull-request-monitoring.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
     <j2html.version>1.4.0</j2html.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -39,6 +39,7 @@
     <bootstrap4-api.version>4.6.0-3</bootstrap4-api.version>
     <popper-api.version>1.16.1-2</popper-api.version>
     <error_prone_annotations.version>2.7.1</error_prone_annotations.version>
+    <pull-request-monitoring.version>1.5.3</pull-request-monitoring.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
     <j2html.version>1.4.0</j2html.version>
@@ -257,6 +258,13 @@
       <version>${token-macro.version}</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>pull-request-monitoring</artifactId>
+      <version>${pull-request-monitoring.version}</version>
+      <optional>true</optional>
+    </dependency>
+
     <!-- ASM is required by token-macro but does not declare its dependency -->
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -39,7 +39,7 @@
     <bootstrap4-api.version>4.6.0-3</bootstrap4-api.version>
     <popper-api.version>1.16.1-2</popper-api.version>
     <error_prone_annotations.version>2.7.1</error_prone_annotations.version>
-    <pull-request-monitoring.version>1.5.3</pull-request-monitoring.version>
+    <pull-request-monitoring.version>1.6.0</pull-request-monitoring.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
     <j2html.version>1.4.0</j2html.version>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
@@ -417,6 +417,16 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
     }
 
     /**
+     * Check if {@link AnalysisResult} issues are empty (including new, outstanding and fixed).
+     *
+     * @return
+     *          true if {@link AnalysisResult} issues are empty, else false.
+     */
+    public boolean isEmpty() {
+        return getTotals().getTotalSize() + getTotals().getFixedSize() == 0;
+    }
+
+    /**
      * Returns all outstanding issues of the associated static analysis run. I.e. all issues, that are part of the
      * current and previous report.
      *

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
@@ -39,6 +39,7 @@ public class PullRequestMonitoringPortlet extends MonitorPortlet {
      *              the corresponding {@link ResultAction}.
      */
     public PullRequestMonitoringPortlet(final ResultAction action) {
+        super();
         this.action = action;
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
@@ -1,0 +1,159 @@
+package io.jenkins.plugins.analysis.core.portlets;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.gson.JsonObject;
+
+import edu.hm.hafner.analysis.Severity;
+
+import org.kohsuke.stapler.bind.JavaScriptMethod;
+import hudson.Extension;
+import hudson.model.Run;
+
+import io.jenkins.plugins.analysis.core.model.AnalysisResult;
+import io.jenkins.plugins.analysis.core.model.ResultAction;
+import io.jenkins.plugins.analysis.core.util.QualityGateStatus;
+import io.jenkins.plugins.monitoring.MonitorPortlet;
+import io.jenkins.plugins.monitoring.MonitorPortletFactory;
+
+/**
+ * A portlet that can be used for the
+ * <a href="https://github.com/jenkinsci/pull-request-monitoring-plugin">pull-request-monitoring</a> dashboard.
+ * It renders an interactive sunburst diagram for each {@link ResultAction},
+ * which is registered at the current users {@link Run}.
+ *
+ * @author Simon Symhoven
+ */
+public class PullRequestMonitoringPortlet implements MonitorPortlet {
+
+    private final ResultAction action;
+
+    /**
+     * Creates a new {@link PullRequestMonitoringPortlet}.
+     *
+     * @param action
+     *              the corresponding {@link ResultAction}.
+     */
+    public PullRequestMonitoringPortlet(final ResultAction action) {
+        this.action = action;
+    }
+
+    @Override
+    public String getTitle() {
+        return action.getLabelProvider().getName();
+    }
+
+    @Override
+    @JavaScriptMethod
+    public String getId() {
+        return "warnings-ng-" + action.getResult().getId();
+    }
+
+    @Override
+    public int getPreferredWidth() {
+        return 350;
+    }
+
+    @Override
+    public int getPreferredHeight() {
+        return 350;
+    }
+
+    @Override
+    public Optional<String> getIconUrl() {
+        return Optional.ofNullable(action.getIconFileName());
+    }
+
+    @Override
+    public Optional<String> getDetailViewUrl() {
+        return Optional.ofNullable(action.getUrlName());
+    }
+
+    /**
+     * Get the json data for the sunburst diagram. (used by jelly view)
+     *
+     * @return
+     *          the data as json string.
+     */
+    public String getResultIssuesAsJsonModel() {
+        JsonObject sunburstData = new JsonObject();
+        sunburstData.addProperty("fixed", action.getResult().getFixedIssues().getSize());
+        sunburstData.addProperty("outstanding", action.getResult().getOutstandingIssues().getSize());
+
+        JsonObject newIssues = new JsonObject();
+        newIssues.addProperty("total", action.getResult().getNewIssues().getSize());
+        newIssues.addProperty("low", action.getResult().getNewIssues().getSizeOf(Severity.WARNING_LOW));
+        newIssues.addProperty("normal", action.getResult().getNewIssues().getSizeOf(Severity.WARNING_NORMAL));
+        newIssues.addProperty("high", action.getResult().getNewIssues().getSizeOf(Severity.WARNING_HIGH));
+        newIssues.addProperty("error", action.getResult().getNewIssues().getSizeOf(Severity.ERROR));
+
+        sunburstData.add("new", newIssues);
+
+        return sunburstData.toString();
+    }
+
+    /**
+     * Check if {@link AnalysisResult} issues are empty.
+     *
+     * @return
+     *          true if {@link AnalysisResult} issues are empty, else false.
+     */
+    public boolean isEmpty() {
+        return action.getResult().isEmpty();
+    }
+
+    /**
+     * Check if action has a quality gate.
+     *
+     * @return
+     *          true if action has a quality gate, else false.
+     */
+    public boolean hasQualityGate() {
+        return !action.getResult().getQualityGateStatus().equals(QualityGateStatus.INACTIVE);
+    }
+
+    /**
+     * Get the icon of the quality gate.
+     *
+     * @return
+     *          the image url of the icon.
+     */
+    public String getQualityGateResultIconUrl() {
+        return action.getResult().getQualityGateStatus().getResult().color.getImageOf("16x16");
+    }
+
+    /**
+     * Get the human readable description of quality gate.
+     *
+     * @return
+     *          the description.
+     */
+    public String getQualityGateResultDescription() {
+        return action.getResult().getQualityGateStatus().getResult().color.getDescription();
+    }
+
+    /**
+     * The factory for the {@link PullRequestMonitoringPortlet}.
+     */
+    @Extension(optional = true)
+    public static class PortletFactory implements MonitorPortletFactory {
+
+        @Override
+        public Collection<MonitorPortlet> getPortlets(final Run<?, ?> build) {
+            List<ResultAction> actions = build.getActions(ResultAction.class);
+
+            return actions.stream()
+                    .map(PullRequestMonitoringPortlet::new)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.PullRequestMonitoringPortlet_Name();
+        }
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
@@ -28,7 +28,7 @@ import io.jenkins.plugins.monitoring.MonitorPortletFactory;
  *
  * @author Simon Symhoven
  */
-public class PullRequestMonitoringPortlet implements MonitorPortlet {
+public class PullRequestMonitoringPortlet extends MonitorPortlet {
 
     private final ResultAction action;
 
@@ -51,6 +51,11 @@ public class PullRequestMonitoringPortlet implements MonitorPortlet {
     @JavaScriptMethod
     public String getId() {
         return "warnings-ng-" + action.getResult().getId();
+    }
+
+    @Override
+    public boolean isDefault() {
+        return true;
     }
 
     @Override
@@ -140,7 +145,7 @@ public class PullRequestMonitoringPortlet implements MonitorPortlet {
      * The factory for the {@link PullRequestMonitoringPortlet}.
      */
     @Extension(optional = true)
-    public static class PortletFactory implements MonitorPortletFactory {
+    public static class PortletFactory extends MonitorPortletFactory {
 
         @Override
         public Collection<MonitorPortlet> getPortlets(final Run<?, ?> build) {

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/Messages.properties
@@ -1,2 +1,3 @@
 IssuesTablePortlet.Name=Static analysis issues per tool and job
 IssuesChartPortlet.Name=Static analysis issues chart
+PullRequestMonitoringPortlet.Name=Warnings Next Generation

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
@@ -1,0 +1,27 @@
+<?jelly escape-by-default='true'?>
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+
+  <st:adjunct includes="io.jenkins.plugins.echarts"/>
+
+  <j:choose>
+    <j:when test="${it.isEmpty()}">
+      <h1>${%zeroIssues.title}</h1>
+      <p>${%zeroIssues.description}</p>
+    </j:when>
+    <j:otherwise>
+      <div id="${it.id}" data="${it.getResultIssuesAsJsonModel()}"
+           style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px;"/>
+
+      <j:if test="${it.hasQualityGate()}">
+        <p style="text-align: right; margin: 5px;">${%qualityGate.Name}
+          <img src="${it.getQualityGateResultIconUrl()}"/>
+          ${it.getQualityGateResultDescription()}</p>
+      </j:if>
+    </j:otherwise>
+  </j:choose>
+
+  <script>var portlet = <st:bind value="${it}"/></script>
+  <script type="text/javascript" src="${resURL}/plugin/warnings-ng/js/issues-sunburst.js"/>
+
+</j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
@@ -6,19 +6,22 @@
 
   <j:choose>
     <j:when test="${it.isEmpty()}">
-      <h1>${%zeroIssues.title}</h1>
-      <p>${%zeroIssues.description}</p>
+      <div style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px; transform: translateY(40%);">
+        <h1>${%zeroIssues.title}</h1>
+        <p>${%zeroIssues.description}</p>
+      </div>
     </j:when>
     <j:otherwise>
       <div id="${it.id}" data="${it.getResultIssuesAsJsonModel()}"
            style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px;"/>
-
-      <j:if test="${it.hasQualityGate()}">
-        <p style="text-align: right; margin: 5px;">${%qualityGate.Name}
-          <img src="${it.getQualityGateResultIconUrl()}"/>
-          ${it.getQualityGateResultDescription()}</p>
-      </j:if>
     </j:otherwise>
+
+    <j:if test="${it.hasQualityGate()}">
+      <p style="text-align: right; margin: 5px;">${%qualityGate.Name}
+        <img src="${it.getQualityGateResultIconUrl()}"/>
+        ${it.getQualityGateResultDescription()}</p>
+    </j:if>
+
   </j:choose>
 
   <script>var portlet = <st:bind value="${it}"/></script>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.properties
@@ -1,0 +1,3 @@
+zeroIssues.title=Congratulations
+zeroIssues.description=There are no issues for the current build!
+qualityGate.Name=Quality gate:

--- a/plugin/src/main/webapp/js/issues-sunburst.js
+++ b/plugin/src/main/webapp/js/issues-sunburst.js
@@ -1,0 +1,89 @@
+/* global jQuery3, echarts, portlet */
+(function($) {
+
+    portlet.getId(function(id) {
+        const chartDom = document.getElementById(id.responseObject());
+
+        if (chartDom == null) {
+            // portlet has no issues, skip generating the chart.
+            return;
+        }
+
+        const portletChart = echarts.init(chartDom);
+        const sunburstData = JSON.parse(chartDom.getAttribute('data'));
+
+        const data = [{
+            name: 'All\nIssues',
+            itemStyle: {
+                color:  '#70a1d7'
+            },
+            children: [{
+                name: 'New',
+                itemStyle: {
+                    color: '#EF9A9A'
+                },
+                value: sunburstData.new.total,
+                children: [{
+                    name: 'Low-Prio',
+                    value: sunburstData.new.low,
+                    itemStyle: {
+                        color: '#e9e2d0'
+                    }
+                }, {
+                    name: 'Normal-Prio',
+                    value: sunburstData.new.normal,
+                    itemStyle: {
+                        color: '#ffcda3'
+                    }
+                }, {
+                    name: 'High-Prio',
+                    value: sunburstData.new.high,
+                    itemStyle: {
+                        color: '#ee9595'
+                    }
+                },  {
+                    name: 'Error',
+                    value: sunburstData.new.error,
+                    itemStyle: {
+                        color: '#f05454'
+                    }
+                }]
+            }, {
+                name: 'Outstanding',
+                value: sunburstData.outstanding,
+                itemStyle: {
+                    color: '#FFF59D'
+                }
+            }, {
+                name: 'Fixed',
+                value: sunburstData.fixed,
+                itemStyle: {
+                    color: '#A5D6A7'
+                }
+            }]
+        }];
+
+        const option = {
+            series: {
+                sort: null,
+                type: 'sunburst',
+                data: data,
+                radius: ['15%', '80%'],
+                itemStyle: {
+                    color: '#ddd',
+                    borderWidth: 2
+                },
+                label: {
+                    rotate: 'horizontal',
+                },
+            },
+            tooltip: {
+                trigger: 'item',
+                formatter: '{b}: {c}'
+            }
+        };
+
+        option && portletChart.setOption(option);
+    });
+
+})(jQuery3);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -14,8 +14,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.TestExtension;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Report;


### PR DESCRIPTION
Implement portlets for the https://github.com/jenkinsci/pull-request-monitoring-plugin.

Add one portlet for each analysis result which is added by the warnings-ng plugin to the actual run. Each portlet contains a sunburst diagram of fixed, outstanding and new issues. The new issues are clustered by severities, os it looks like this:

![Bildschirmfoto 2021-05-23 um 15 53 23](https://user-images.githubusercontent.com/26878018/119263749-99a92680-bbe0-11eb-9f1a-da5febbea7db.png)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
