### PR TITLE
make no-issues-portlet more expressive

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
@@ -427,6 +427,16 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
     }
 
     /**
+     * Check if {@link AnalysisResult} issues does not have any new warnings.
+     *
+     * @return
+     *          true if {@link AnalysisResult} issues has no new warnings.
+     */
+    public boolean hasNoNewWarnings() {
+        return getTotals().getNewSize() == 0;
+    }
+
+    /**
      * Returns all outstanding issues of the associated static analysis run. I.e. all issues, that are part of the
      * current and previous report.
      *

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
@@ -9,6 +9,10 @@ import java.util.stream.Collectors;
 import com.google.gson.JsonObject;
 
 import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.echarts.JacksonFacade;
+import edu.hm.hafner.echarts.Palette;
+import edu.hm.hafner.echarts.PieChartModel;
+import edu.hm.hafner.echarts.PieData;
 
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 import hudson.Extension;
@@ -85,7 +89,7 @@ public class PullRequestMonitoringPortlet extends MonitorPortlet {
      * @return
      *          the data as json string.
      */
-    public String getResultIssuesAsJsonModel() {
+    public String getWarningsModel() {
         JsonObject sunburstData = new JsonObject();
         sunburstData.addProperty("fixed", action.getResult().getFixedIssues().getSize());
         sunburstData.addProperty("outstanding", action.getResult().getOutstandingIssues().getSize());
@@ -102,6 +106,13 @@ public class PullRequestMonitoringPortlet extends MonitorPortlet {
         return sunburstData.toString();
     }
 
+    public String getNoNewWarningsModel() {
+        PieChartModel model = new PieChartModel();
+        model.add(new PieData("outstanding", action.getResult().getOutstandingIssues().getSize()), Palette.YELLOW);
+        model.add(new PieData("fixed", action.getResult().getFixedIssues().getSize()), Palette.GREEN);
+        return new JacksonFacade().toJson(model);
+    }
+
     /**
      * Check if {@link AnalysisResult} issues are empty.
      *
@@ -110,6 +121,16 @@ public class PullRequestMonitoringPortlet extends MonitorPortlet {
      */
     public boolean isEmpty() {
         return action.getResult().isEmpty();
+    }
+
+    /**
+     * Check if {@link AnalysisResult} issues have no new warnings.
+     *
+     * @return
+     *          true if {@link AnalysisResult} issues have now new warnings.
+     */
+    public boolean hasNoNewWarnings() {
+        return action.getResult().hasNoNewWarnings();
     }
 
     /**

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
@@ -1,12 +1,13 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fa="/font-awesome">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fa="/font-awesome" xmlns:c="/charts">
 
   <st:adjunct includes="io.jenkins.plugins.echarts"/>
 
   <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/pull-request-portlet.css"/>
 
   <j:choose>
+
     <j:when test="${it.isEmpty()}">
       <div class="no-issues-body" style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px;">
         <h1>${%zeroIssues.title}</h1>
@@ -14,18 +15,28 @@
         <fa:svg-icon name="check-double" class="no-issues-banner"/>
       </div>
     </j:when>
+
+    <j:when test="${it.hasNoNewWarnings()}">
+      <div class="no-issues-body" style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px;">
+        <h3>${%zeroNewIssues.title} <fa:svg-icon name="check-double" class="no-new-issues-banner"/></h3>
+        <p>${%zeroNewIssues.description}</p>
+
+        <c:pie-chart id="${it.id}" height="${it.preferredHeight - 200}" model="${it.getNoNewWarningsModel()}"/>
+      </div>
+    </j:when>
+
     <j:otherwise>
-      <div id="${it.id}" data="${it.getResultIssuesAsJsonModel()}"
+      <div id="${it.id}" data="${it.getWarningsModel()}"
            style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px;"/>
     </j:otherwise>
 
-    <j:if test="${it.hasQualityGate()}">
-      <p class="portlet-quality-gate-label">${%qualityGate.Name}
-        <img src="${it.getQualityGateResultIconUrl()}"/>
-        ${it.getQualityGateResultDescription()}</p>
-    </j:if>
-
   </j:choose>
+
+  <j:if test="${it.hasQualityGate()}">
+    <p class="portlet-quality-gate-label">${%qualityGate.Name}
+      <img src="${it.getQualityGateResultIconUrl()}"/>
+      ${it.getQualityGateResultDescription()}</p>
+  </j:if>
 
   <script>var portlet = <st:bind value="${it}"/></script>
   <script type="text/javascript" src="${resURL}/plugin/warnings-ng/js/issues-sunburst.js"/>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
@@ -1,14 +1,17 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fa="/font-awesome">
 
   <st:adjunct includes="io.jenkins.plugins.echarts"/>
 
+  <link rel="stylesheet" href="${resURL}/plugin/warnings-ng/css/pull-request-portlet.css"/>
+
   <j:choose>
     <j:when test="${it.isEmpty()}">
-      <div style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px; transform: translateY(40%);">
+      <div class="no-issues-body" style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 40}px;">
         <h1>${%zeroIssues.title}</h1>
         <p>${%zeroIssues.description}</p>
+        <fa:svg-icon name="check-double" class="no-issues-banner"/>
       </div>
     </j:when>
     <j:otherwise>
@@ -17,7 +20,7 @@
     </j:otherwise>
 
     <j:if test="${it.hasQualityGate()}">
-      <p style="text-align: right; margin: 5px;">${%qualityGate.Name}
+      <p class="portlet-quality-gate-label">${%qualityGate.Name}
         <img src="${it.getQualityGateResultIconUrl()}"/>
         ${it.getQualityGateResultDescription()}</p>
     </j:if>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.properties
@@ -1,3 +1,5 @@
 zeroIssues.title=Congratulations
-zeroIssues.description=No new issues have been reported!
+zeroNewIssues.title=Good Job
+zeroIssues.description=No issues have been reported!
+zeroNewIssues.description=No new issues have been reported, but there are still some outstanding ones!
 qualityGate.Name=Quality gate:

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.properties
@@ -1,3 +1,3 @@
 zeroIssues.title=Congratulations
-zeroIssues.description=There are no issues for the current build!
+zeroIssues.description=No new issues have been reported!
 qualityGate.Name=Quality gate:

--- a/plugin/src/main/webapp/css/pull-request-portlet.css
+++ b/plugin/src/main/webapp/css/pull-request-portlet.css
@@ -8,6 +8,12 @@
     fill: #009688;
 }
 
+.no-new-issues-banner {
+    fill: #009688;
+    width: 30px;
+    height: 30px;
+}
+
 .no-issues-body {
     transform: translateY(10%);
 }

--- a/plugin/src/main/webapp/css/pull-request-portlet.css
+++ b/plugin/src/main/webapp/css/pull-request-portlet.css
@@ -1,0 +1,13 @@
+.portlet-quality-gate-label {
+    text-align: right;
+    margin: 5px;
+}
+
+.no-issues-banner {
+    padding: 20px;
+    fill: #009688;
+}
+
+.no-issues-body {
+    transform: translateY(10%);
+}

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -1024,13 +1024,13 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         ResultAction action = baseline.getAction(ResultAction.class);
         PullRequestMonitoringPortlet portlet = new PullRequestMonitoringPortlet(action);
 
-        assertThatJson(portlet.getResultIssuesAsJsonModel()).node("fixed").isEqualTo(0);
-        assertThatJson(portlet.getResultIssuesAsJsonModel()).node("outstanding").isEqualTo(3);
-        assertThatJson(portlet.getResultIssuesAsJsonModel()).node("new").node("total").isEqualTo(0);
-        assertThatJson(portlet.getResultIssuesAsJsonModel()).node("new").node("low").isEqualTo(0);
-        assertThatJson(portlet.getResultIssuesAsJsonModel()).node("new").node("normal").isEqualTo(0);
-        assertThatJson(portlet.getResultIssuesAsJsonModel()).node("new").node("high").isEqualTo(0);
-        assertThatJson(portlet.getResultIssuesAsJsonModel()).node("new").node("error").isEqualTo(0);
+        assertThatJson(portlet.getWarningsModel()).node("fixed").isEqualTo(0);
+        assertThatJson(portlet.getWarningsModel()).node("outstanding").isEqualTo(3);
+        assertThatJson(portlet.getWarningsModel()).node("new").node("total").isEqualTo(0);
+        assertThatJson(portlet.getWarningsModel()).node("new").node("low").isEqualTo(0);
+        assertThatJson(portlet.getWarningsModel()).node("new").node("normal").isEqualTo(0);
+        assertThatJson(portlet.getWarningsModel()).node("new").node("high").isEqualTo(0);
+        assertThatJson(portlet.getWarningsModel()).node("new").node("error").isEqualTo(0);
     }
 
     private void write(final String adaptedOobFileContent) {


### PR DESCRIPTION
Improved the display of portlets when no issues are present.

Before:
![Bildschirmfoto 2021-06-11 um 17 22 53](https://user-images.githubusercontent.com/26878018/121710272-bc40a800-cad9-11eb-9503-cc1c8bd8e168.png)

After:

1. No warnings at all
![Bildschirmfoto 2021-06-13 um 15 07 22](https://user-images.githubusercontent.com/26878018/121808663-e4efab80-cc59-11eb-8a79-0b8bd656b695.png)

2. No new warnings but outstanding and probably some fixed: 
A sunburst diagram does not make any sense, because the sunburst diagram only shows the severity of the new issues as an interactive diagram together with the static outstanding and fixed ones (without severity clustering). So I decide to use the normal pie-chart for this use case.

![Bildschirmfoto 2021-06-13 um 15 07 18](https://user-images.githubusercontent.com/26878018/121808672-f33dc780-cc59-11eb-92bc-688c617056a4.png)

3. New warnings, outstanding and fixed
Portlet remains the same as in #935 with the interactive sunburst diagram together with the severity cluster for new warnings.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

