### PR TITLE
Fix Stapler "ERROR" for Groovy Parser job-configuration web-form

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/groovy/GroovyScript/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/groovy/GroovyScript/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:i="/issues" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:i="/issues" xmlns:f="/lib/form" xmlns:c="/controls">
 
   <f:entry title="${%title.tool}" description="${%description.tool(rootURL)}" field="parserId">
     <f:select/>
@@ -7,12 +7,12 @@
 
   <f:entry title="${%title.pattern}" field="pattern"
            description="${%description.pattern('http://ant.apache.org/manual/Types/fileset.html')}">
-    <f:textbox/>
+    <c:safe-textbox/>
   </f:entry>
 
   <f:entry title="${%title.reportEncoding}" field="reportEncoding"
            description="${%description.reportEncoding}">
-    <f:combobox/>
+    <c:safe-combobox/>
   </f:entry>
 
   <i:tool-defaults/>


### PR DESCRIPTION
In the (freestyle) job configuration web form, the "Groovy Parser" form has two fields reporting jelly binding errors (highlighted in red boxes in the image below).
![image](https://user-images.githubusercontent.com/984537/122961941-d05b9380-d37c-11eb-9c19-b5b02909fb31.png)

This seems to be caused by the underlying `Descriptor` class (`ReportScanningTool.ReportScanningToolDescriptor`) having the `@POST` annotation on the `doCheckReportEncoding` and `doCheckPattern` methods but the `config.jelly` file _for the Groovy Parser_ is missing the corresponding "use POST when calling Jenkins" notation for those two fields.
This change makes the "Groovy Parser" form use the same constructs used on the ReportScanningTool's form.