### PR TITLE
Use new status icons in quality gate of pull request portlet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,6 @@ Static Analysis Suite  is licensed under [MIT license](./LICENSE). We consider a
 explicitly stated otherwise. MIT-incompatible code contributions will be rejected.
 Contributions under MIT-compatible licenses may be also rejected if they are not ultimately necessary.
 
-We **Do NOT** require pull request submitters to sign the 
-[contributor agreement](https://wiki.jenkins.io/display/JENKINS/Copyright+on+source+code)
-as long as the code is licensed under MIT and merged by one of the contributors with the signed agreement.
-
 ## Continuous Integration
 
 The Jenkins project has a Continuous Integration server... powered by Jenkins, of course.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,8 @@ If you already have some experience with the plugin you can also fix one of the 
 
 If you are planning to provide your own parser, please also have a look at the project 
 [Static Analysis Model and Parsers](https://github.com/jenkinsci/analysis-model). Here, all parsers need to be 
-added first. The Jenkins Warnings Plug-in does not include the parsers anymore, it links the parsers using the 
-analysis-model library. You still need to add a reference to the new parser afterwards in order to get the parser
-represented in the UI. 
+added. The Jenkins Warnings Plug-in does not include the parsers anymore, it just links all parsers using the 
+analysis-model library. 
 
 ## Getting started
 
@@ -60,11 +59,11 @@ To submit a pull request:
 1. Commit changes and push them to your fork on GitHub.
 It is a good practice is to create branches instead of pushing to master.
 2. In GitHub Web UI click the **New Pull Request** button.
-3. Select `warnings-plugin` as **base fork** and `master` as **base**, then click **Create Pull Request**.
+3. Select `warnings-ng-plugin` as **base fork** and `master` as **base**, then click **Create Pull Request**.
 4. Fill in the Pull Request description. It should reflect the changes, the reason behind the changes, and if available a
 reference to the Jenkins ticket in our [issue tracker](https://issues.jenkins-ci.org/).
 5. Click **Create Pull Request**.
-6. Wait for CI results, reviews. 
+6. Wait for CI results and reviews. 
 7. Process the feedback (see previous step). If there are changes required, commit them in your local branch and push them
 again to GitHub. Your pull request will be updated automatically. Review comments for changed lines will become outdated.
 
@@ -85,12 +84,4 @@ as long as the code is licensed under MIT and merged by one of the contributors 
 
 The Jenkins project has a Continuous Integration server... powered by Jenkins, of course.
 The CI job for this project is located at [ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/warnings-plugin/).
-
-# Links
-
-* [Join the Gitter chat of the Warnings Plugin](https://gitter.im/jenkinsci/warnings-plugin)
-* [Jenkins Contribution Landing Page](https://jenkins.io/paricipate/)
-* [Jenkins IRC Channel](https://jenkins.io/chat/)
-* [Beginners Guide To Contributing](https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing)
-* [List of newbie-friendly issues in the core](https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly))
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ please share it and provide pull requests for the
 the [Analysis Parsers Library](https://github.com/jenkinsci/analysis-model/pulls). 
 
 For more details please refer to the [documentation](doc/Documentation.md) or to an 
-[introductory video](https://www.youtube.com/watch?v=0GcEqML8nys).
+[introductory video](https://www.youtube.com/watch?v=0GcEqML8nys). Contributions are welcome, please 
+refer to the separate [CONTRIBUTING](CONTRIBUTING.md) document
+for details on how to proceed!
+
 
 All source code is licensed under the MIT license.
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
@@ -155,14 +155,14 @@ public class PullRequestMonitoringPortlet extends MonitorPortlet {
     }
 
     /**
-     * Get the icon of the quality gate.
+     * Get the icon class of the quality gate.
      *
      * @return
-     *          the image url of the icon.
+     *          the image class of the Jenkins status icon.
      */
     @SuppressWarnings("unused") // used by jelly view
-    public String getQualityGateResultIconUrl() {
-        return result.getQualityGateStatus().getResult().color.getImageOf("16x16");
+    public String getQualityGateResultClass() {
+        return result.getQualityGateStatus().getIconClass();
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
@@ -155,6 +155,18 @@ public class PullRequestMonitoringPortlet extends MonitorPortlet {
     }
 
     /**
+     * Get the icon of the quality gate.
+     *
+     * @return
+     *          the image url of the icon.
+     * @deprecated replaced by {@link #getQualityGateResultClass()}
+     */
+    @Deprecated
+    public String getQualityGateResultIconUrl() {
+        return result.getQualityGateStatus().getResult().color.getImageOf("16x16");
+    }
+
+    /**
      * Get the icon class of the quality gate.
      *
      * @return

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
@@ -34,29 +34,18 @@ public enum QualityGateStatus {
      * Returns the associated {@link Result} color.
      *
      * @return Jenkins' {@link Result} color
-     * @deprecated
      */
-    @Deprecated
     public BallColor getColor() {
         return result.color;
     }
 
     /**
-     * Returns the associated {@link Result} color.
+     * Returns the associated {@link Result} icon class to be used in the UI.
      *
-     * @return Jenkins' {@link Result} color
+     * @return Jenkins' {@link Result} icon class
      */
     public String getIconClass() {
-        if (result == Result.SUCCESS) {
-            return "icon-blue";
-        }
-        if (result == Result.FAILURE) {
-            return "icon-red";
-        }
-        if (result == Result.UNSTABLE) {
-            return "icon-yellow";
-        }
-        return "icon-grey";
+        return getColor().getIconClassName();
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
@@ -34,9 +34,29 @@ public enum QualityGateStatus {
      * Returns the associated {@link Result} color.
      *
      * @return Jenkins' {@link Result} color
+     * @deprecated
      */
+    @Deprecated
     public BallColor getColor() {
         return result.color;
+    }
+
+    /**
+     * Returns the associated {@link Result} color.
+     *
+     * @return Jenkins' {@link Result} color
+     */
+    public String getIconClass() {
+        if (result == Result.SUCCESS) {
+            return "icon-blue";
+        }
+        if (result == Result.FAILURE) {
+            return "icon-red";
+        }
+        if (result == Result.UNSTABLE) {
+            return "icon-yellow";
+        }
+        return "icon-grey";
     }
 
     /**

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fa="/font-awesome" xmlns:c="/charts">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:fa="/font-awesome" xmlns:c="/charts">
 
   <st:adjunct includes="io.jenkins.plugins.echarts"/>
 
@@ -34,7 +34,7 @@
 
   <j:if test="${it.hasQualityGate()}">
     <p class="portlet-quality-gate-label">${%qualityGate.Name}
-      <img src="${it.getQualityGateResultIconUrl()}"/>
+      <l:icon class="${it.getQualityGateResultClass()} icon-sm"/>
       ${it.getQualityGateResultDescription()}</p>
   </j:if>
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/IntegrationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/IntegrationTest.java
@@ -64,6 +64,7 @@ import hudson.model.Action;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.Slave;
@@ -1013,6 +1014,25 @@ public abstract class IntegrationTest extends ResourceTest {
     protected ResultAction getResultAction(final Run<?, ?> build) {
         ResultAction action = build.getAction(ResultAction.class);
         assertThat(action).as("No ResultAction found in run %s", build).isNotNull();
+        return action;
+    }
+
+    /**
+     * Returns the {@link ResultAction} for the specified job. Note that this method does only return the first match,
+     * even if a test registered multiple actions.
+     *
+     * @param job
+     *         the job
+     *
+     * @return the action of the specified build
+     */
+    protected ResultAction getResultAction(final Job<?, ?> job) {
+        Run<?, ?> build = job.getLastCompletedBuild();
+        assertThat(build).as("No completed build found for job %s", job).isNotNull();
+
+        ResultAction action = build.getAction(ResultAction.class);
+        assertThat(action).as("No ResultAction found in run %s", build).isNotNull();
+
         return action;
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
@@ -26,6 +26,7 @@ import io.jenkins.plugins.analysis.core.model.IssuesDetail;
 import io.jenkins.plugins.analysis.core.model.IssuesModel.IssuesRow;
 import io.jenkins.plugins.analysis.core.model.ReportScanningTool;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
+import io.jenkins.plugins.analysis.core.portlets.PullRequestMonitoringPortlet;
 import io.jenkins.plugins.analysis.core.steps.IssuesRecorder;
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSuite;
 import io.jenkins.plugins.analysis.core.util.QualityGateStatus;
@@ -37,6 +38,7 @@ import io.jenkins.plugins.analysis.warnings.RegisteredParser;
 import io.jenkins.plugins.analysis.warnings.tasks.OpenTasks;
 
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 
 /**
  * Integration tests of the warnings plug-in in freestyle jobs. Tests the new recorder {@link IssuesRecorder}.
@@ -337,6 +339,41 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result.getTotalSize() - result.getNewSize()).isEqualTo(5); // Outstanding
         assertThat(result).hasTotalSize(5);
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
+
+        PullRequestMonitoringPortlet successPortlet = createPortlet(project);
+
+        String successfulModel = successPortlet.getWarningsModel();
+        assertThatJson(successfulModel).node("fixed").isEqualTo(3);
+        assertThatJson(successfulModel).node("outstanding").isEqualTo(5);
+        assertThatJson(successfulModel).node("new").node("total").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("low").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("normal").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("high").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("error").isEqualTo(0);
+
+        verifyNoNewWarningsPortletModel(successPortlet, 5, 3);
+    }
+
+    private void verifyNoNewWarningsPortletModel(final PullRequestMonitoringPortlet successPortlet,
+            final int expectedOutstandingWarnings, final int expectedFixedWarnings) {
+        String simpleModel = successPortlet.getNoNewWarningsModel();
+        assertThatJson(simpleModel).node("data").isArray().hasSize(2);
+        assertThatJson(simpleModel).node("data[0]").node("name").isEqualTo("outstanding");
+        assertThatJson(simpleModel).node("data[0]").node("value").isEqualTo(expectedOutstandingWarnings);
+        assertThatJson(simpleModel).node("data[1]").node("name").isEqualTo("fixed");
+        assertThatJson(simpleModel).node("data[1]").node("value").isEqualTo(expectedFixedWarnings);
+    }
+
+    private PullRequestMonitoringPortlet createPortlet(final FreeStyleProject project) {
+        PullRequestMonitoringPortlet portlet = new PullRequestMonitoringPortlet(getResultAction(project));
+
+        assertThat(portlet.hasQualityGate()).isFalse();
+        assertThat(portlet.getId()).endsWith("eclipse");
+        assertThat(portlet.getTitle()).endsWith("Eclipse ECJ");
+        assertThat(portlet.getIconUrl()).contains("/plugin/warnings-ng/icons/analysis-24x24.png");
+        assertThat(portlet.getDetailViewUrl()).contains("eclipse");
+
+        return portlet;
     }
 
     /**
@@ -362,6 +399,17 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result.getTotalSize() - result.getNewSize()).isEqualTo(5); // Outstanding
         assertThat(result).hasTotalSize(8);
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
+
+        PullRequestMonitoringPortlet successPortlet = createPortlet(project);
+
+        String successfulModel = successPortlet.getWarningsModel();
+        assertThatJson(successfulModel).node("fixed").isEqualTo(0);
+        assertThatJson(successfulModel).node("outstanding").isEqualTo(5);
+        assertThatJson(successfulModel).node("new").node("total").isEqualTo(3);
+        assertThatJson(successfulModel).node("new").node("low").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("normal").isEqualTo(3);
+        assertThatJson(successfulModel).node("new").node("high").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("error").isEqualTo(0);
     }
 
     /**
@@ -387,6 +435,19 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result.getTotalSize() - result.getNewSize()).isEqualTo(8); // Outstanding
         assertThat(result).hasTotalSize(8);
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
+
+        PullRequestMonitoringPortlet successPortlet = createPortlet(project);
+
+        String successfulModel = successPortlet.getWarningsModel();
+        assertThatJson(successfulModel).node("fixed").isEqualTo(0);
+        assertThatJson(successfulModel).node("outstanding").isEqualTo(8);
+        assertThatJson(successfulModel).node("new").node("total").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("low").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("normal").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("high").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("error").isEqualTo(0);
+
+        verifyNoNewWarningsPortletModel(successPortlet, 8, 0);
     }
 
     /**
@@ -413,6 +474,19 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result.getTotalSize() - result.getNewSize()).isEqualTo(2); // Outstanding
         assertThat(result).hasTotalSize(4);
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
+
+        PullRequestMonitoringPortlet successPortlet = createPortlet(project);
+
+        String successfulModel = successPortlet.getWarningsModel();
+        assertThatJson(successfulModel).node("fixed").isEqualTo(3);
+        assertThatJson(successfulModel).node("outstanding").isEqualTo(2);
+        assertThatJson(successfulModel).node("new").node("total").isEqualTo(2);
+        assertThatJson(successfulModel).node("new").node("low").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("normal").isEqualTo(2);
+        assertThatJson(successfulModel).node("new").node("high").isEqualTo(0);
+        assertThatJson(successfulModel).node("new").node("error").isEqualTo(0);
+
+        assertThat(successPortlet.hasQualityGate()).isFalse();
     }
 
     private ReportScanningTool createEclipse(final String pattern) {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
@@ -234,6 +234,15 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result.getSizePerOrigin()).containsExactly(entry("checkstyle", 0), entry("pmd", 0));
         assertThat(result).hasId("analysis");
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
+
+        PullRequestMonitoringPortlet portlet = new PullRequestMonitoringPortlet(getResultAction(project));
+
+        assertThat(portlet.hasQualityGate()).isFalse();
+        assertThat(portlet.isEmpty()).isTrue();
+        assertThat(portlet.getId()).endsWith("analysis");
+        assertThat(portlet.getTitle()).endsWith("Static Analysis");
+        assertThat(portlet.getIconUrl()).contains("/plugin/warnings-ng/icons/analysis-24x24.png");
+        assertThat(portlet.getDetailViewUrl()).contains("analysis");
     }
 
     /**
@@ -340,9 +349,9 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result).hasTotalSize(5);
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
 
-        PullRequestMonitoringPortlet successPortlet = createPortlet(project);
+        PullRequestMonitoringPortlet portlet = createPortlet(project);
 
-        String successfulModel = successPortlet.getWarningsModel();
+        String successfulModel = portlet.getWarningsModel();
         assertThatJson(successfulModel).node("fixed").isEqualTo(3);
         assertThatJson(successfulModel).node("outstanding").isEqualTo(5);
         assertThatJson(successfulModel).node("new").node("total").isEqualTo(0);
@@ -351,12 +360,14 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThatJson(successfulModel).node("new").node("high").isEqualTo(0);
         assertThatJson(successfulModel).node("new").node("error").isEqualTo(0);
 
-        verifyNoNewWarningsPortletModel(successPortlet, 5, 3);
+        verifyNoNewWarningsPortletModel(portlet, 5, 3);
     }
 
-    private void verifyNoNewWarningsPortletModel(final PullRequestMonitoringPortlet successPortlet,
+    private void verifyNoNewWarningsPortletModel(final PullRequestMonitoringPortlet portlet,
             final int expectedOutstandingWarnings, final int expectedFixedWarnings) {
-        String simpleModel = successPortlet.getNoNewWarningsModel();
+        assertThat(portlet.hasNoNewWarnings()).isTrue();
+
+        String simpleModel = portlet.getNoNewWarningsModel();
         assertThatJson(simpleModel).node("data").isArray().hasSize(2);
         assertThatJson(simpleModel).node("data[0]").node("name").isEqualTo("outstanding");
         assertThatJson(simpleModel).node("data[0]").node("value").isEqualTo(expectedOutstandingWarnings);
@@ -372,6 +383,7 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(portlet.getTitle()).endsWith("Eclipse ECJ");
         assertThat(portlet.getIconUrl()).contains("/plugin/warnings-ng/icons/analysis-24x24.png");
         assertThat(portlet.getDetailViewUrl()).contains("eclipse");
+        assertThat(portlet.isEmpty()).isFalse();
 
         return portlet;
     }
@@ -400,9 +412,10 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result).hasTotalSize(8);
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
 
-        PullRequestMonitoringPortlet successPortlet = createPortlet(project);
+        PullRequestMonitoringPortlet portlet = createPortlet(project);
+        assertThat(portlet.hasNoNewWarnings()).isFalse();
 
-        String successfulModel = successPortlet.getWarningsModel();
+        String successfulModel = portlet.getWarningsModel();
         assertThatJson(successfulModel).node("fixed").isEqualTo(0);
         assertThatJson(successfulModel).node("outstanding").isEqualTo(5);
         assertThatJson(successfulModel).node("new").node("total").isEqualTo(3);
@@ -436,9 +449,9 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThat(result).hasTotalSize(8);
         assertThat(result).hasQualityGateStatus(QualityGateStatus.INACTIVE);
 
-        PullRequestMonitoringPortlet successPortlet = createPortlet(project);
+        PullRequestMonitoringPortlet portlet = createPortlet(project);
 
-        String successfulModel = successPortlet.getWarningsModel();
+        String successfulModel = portlet.getWarningsModel();
         assertThatJson(successfulModel).node("fixed").isEqualTo(0);
         assertThatJson(successfulModel).node("outstanding").isEqualTo(8);
         assertThatJson(successfulModel).node("new").node("total").isEqualTo(0);
@@ -447,7 +460,7 @@ public class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite 
         assertThatJson(successfulModel).node("new").node("high").isEqualTo(0);
         assertThatJson(successfulModel).node("new").node("error").isEqualTo(0);
 
-        verifyNoNewWarningsPortletModel(successPortlet, 8, 0);
+        verifyNoNewWarningsPortletModel(portlet, 8, 0);
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/QualityGateITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/QualityGateITest.java
@@ -17,6 +17,7 @@ import hudson.model.Run;
 
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
+import io.jenkins.plugins.analysis.core.portlets.PullRequestMonitoringPortlet;
 import io.jenkins.plugins.analysis.core.steps.IssuesRecorder;
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSuite;
 import io.jenkins.plugins.analysis.core.util.QualityGate.QualityGateResult;
@@ -501,11 +502,15 @@ public class QualityGateITest extends IntegrationTestWithJenkinsPerSuite {
 
     @SuppressWarnings("illegalcatch")
     private void scheduleBuildAndAssertStatus(final AbstractProject<?, ?> job, final Result result,
-            final QualityGateStatus qualityGateStatus) {
+            final QualityGateStatus expectedQualityGateStatus) {
         try {
             Run<?, ?> build = getJenkins().assertBuildStatus(result, job.scheduleBuild2(0));
             ResultAction action = build.getAction(ResultAction.class);
-            assertThat(action.getResult()).hasQualityGateStatus(qualityGateStatus);
+            assertThat(action.getResult()).hasQualityGateStatus(expectedQualityGateStatus);
+
+            PullRequestMonitoringPortlet portlet = new PullRequestMonitoringPortlet(action);
+            assertThat(portlet.hasQualityGate()).isTrue();
+            assertThat(portlet.getQualityGateResultClass()).isEqualTo(expectedQualityGateStatus.getIconClass());
         }
         catch (Exception e) {
             throw new AssertionError(e);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -767,7 +767,7 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
      * configuration and runs this parser on the console that's showing an error log
      * with 8 issues ... but when we're configured not to allow groovy parsers to
      * scan the console at all so we expect it to fail.
-     * 
+     *
      * @throws IOException if the test fails unexpectedly
      */
     @Test
@@ -987,10 +987,8 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
 
         AnalysisResult result = scheduleSuccessfulBuild(job);
 
-        assertThat(not(result.getReferenceBuild().isPresent()));
-
-        assertThat(result.getNewIssues()).hasSize(0);
-        assertThat(result.getOutstandingIssues()).hasSize(2);
+        assertThat(result.getReferenceBuild()).isEmpty();
+        assertThat(result).hasNewSize(0).hasTotalSize(2);
         assertThat(result.getErrorMessages()).contains(
                 "Reference job 'reference' does not contain configured build '1'");
     }
@@ -1092,13 +1090,16 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         ResultAction action = baseline.getAction(ResultAction.class);
         PullRequestMonitoringPortlet portlet = new PullRequestMonitoringPortlet(action);
 
-        assertThatJson(portlet.getWarningsModel()).node("fixed").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("outstanding").isEqualTo(3);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("total").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("low").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("normal").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("high").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("error").isEqualTo(0);
+        String model = portlet.getWarningsModel();
+        assertThatJson(model).node("fixed").isEqualTo(0);
+        assertThatJson(model).node("outstanding").isEqualTo(3);
+        assertThatJson(model).node("new").node("total").isEqualTo(0);
+        assertThatJson(model).node("new").node("low").isEqualTo(0);
+        assertThatJson(model).node("new").node("normal").isEqualTo(0);
+        assertThatJson(model).node("new").node("high").isEqualTo(0);
+        assertThatJson(model).node("new").node("error").isEqualTo(0);
+
+        assertThat(portlet.hasQualityGate()).isFalse();
     }
 
     private void write(final String adaptedOobFileContent) {


### PR DESCRIPTION
Internally the quality gate still uses the `BallColor` class to visualize the quality gate status. This class has not been adapted to use the new Jenkins status icons so it is required to use a different way to show the correct icon of the quality gate.

- [x] Fix status icon in pull request portlet
- [ ]  Fix status icon in build summary (will be solved in another PR)

Screenshot

![Bildschirmfoto 2021-07-10 um 14 06 57](https://user-images.githubusercontent.com/503338/125162443-222b5880-e188-11eb-858d-fc91e1cb8fcc.png)


