### PR TITLE
Use new status icons in quality gate of pull request portlet

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet.java
@@ -159,10 +159,22 @@ public class PullRequestMonitoringPortlet extends MonitorPortlet {
      *
      * @return
      *          the image url of the icon.
+     * @deprecated replaced by {@link #getQualityGateResultClass()}
      */
-    @SuppressWarnings("unused") // used by jelly view
+    @Deprecated
     public String getQualityGateResultIconUrl() {
         return result.getQualityGateStatus().getResult().color.getImageOf("16x16");
+    }
+
+    /**
+     * Get the icon class of the quality gate.
+     *
+     * @return
+     *          the image class of the Jenkins status icon.
+     */
+    @SuppressWarnings("unused") // used by jelly view
+    public String getQualityGateResultClass() {
+        return result.getQualityGateStatus().getIconClass();
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/QualityGateStatus.java
@@ -40,6 +40,15 @@ public enum QualityGateStatus {
     }
 
     /**
+     * Returns the associated {@link Result} icon class to be used in the UI.
+     *
+     * @return Jenkins' {@link Result} icon class
+     */
+    public String getIconClass() {
+        return getColor().getIconClassName();
+    }
+
+    /**
      * Returns whether the quality gate has been passed (or has not been activated at all).
      *
      * @return {@code true} if the quality gate has been passed, {@code false}  otherwise

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/PullRequestMonitoringPortlet/monitor.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fa="/font-awesome" xmlns:c="/charts">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:fa="/font-awesome" xmlns:c="/charts">
 
   <st:adjunct includes="io.jenkins.plugins.echarts"/>
 
@@ -34,7 +34,7 @@
 
   <j:if test="${it.hasQualityGate()}">
     <p class="portlet-quality-gate-label">${%qualityGate.Name}
-      <img src="${it.getQualityGateResultIconUrl()}"/>
+      <l:icon class="${it.getQualityGateResultClass()} icon-sm"/>
       ${it.getQualityGateResultDescription()}</p>
   </j:if>
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/IntegrationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/IntegrationTest.java
@@ -64,6 +64,7 @@ import hudson.model.Action;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.Slave;
@@ -1013,6 +1014,25 @@ public abstract class IntegrationTest extends ResourceTest {
     protected ResultAction getResultAction(final Run<?, ?> build) {
         ResultAction action = build.getAction(ResultAction.class);
         assertThat(action).as("No ResultAction found in run %s", build).isNotNull();
+        return action;
+    }
+
+    /**
+     * Returns the {@link ResultAction} for the specified job. Note that this method does only return the first match,
+     * even if a test registered multiple actions.
+     *
+     * @param job
+     *         the job
+     *
+     * @return the action of the specified build
+     */
+    protected ResultAction getResultAction(final Job<?, ?> job) {
+        Run<?, ?> build = job.getLastCompletedBuild();
+        assertThat(build).as("No completed build found for job %s", job).isNotNull();
+
+        ResultAction action = build.getAction(ResultAction.class);
+        assertThat(action).as("No ResultAction found in run %s", build).isNotNull();
+
         return action;
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/QualityGateITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/QualityGateITest.java
@@ -17,6 +17,7 @@ import hudson.model.Run;
 
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
+import io.jenkins.plugins.analysis.core.portlets.PullRequestMonitoringPortlet;
 import io.jenkins.plugins.analysis.core.steps.IssuesRecorder;
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSuite;
 import io.jenkins.plugins.analysis.core.util.QualityGate.QualityGateResult;
@@ -501,11 +502,15 @@ public class QualityGateITest extends IntegrationTestWithJenkinsPerSuite {
 
     @SuppressWarnings("illegalcatch")
     private void scheduleBuildAndAssertStatus(final AbstractProject<?, ?> job, final Result result,
-            final QualityGateStatus qualityGateStatus) {
+            final QualityGateStatus expectedQualityGateStatus) {
         try {
             Run<?, ?> build = getJenkins().assertBuildStatus(result, job.scheduleBuild2(0));
             ResultAction action = build.getAction(ResultAction.class);
-            assertThat(action.getResult()).hasQualityGateStatus(qualityGateStatus);
+            assertThat(action.getResult()).hasQualityGateStatus(expectedQualityGateStatus);
+
+            PullRequestMonitoringPortlet portlet = new PullRequestMonitoringPortlet(action);
+            assertThat(portlet.hasQualityGate()).isTrue();
+            assertThat(portlet.getQualityGateResultClass()).isEqualTo(expectedQualityGateStatus.getIconClass());
         }
         catch (Exception e) {
             throw new AssertionError(e);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -767,7 +767,7 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
      * configuration and runs this parser on the console that's showing an error log
      * with 8 issues ... but when we're configured not to allow groovy parsers to
      * scan the console at all so we expect it to fail.
-     * 
+     *
      * @throws IOException if the test fails unexpectedly
      */
     @Test
@@ -987,10 +987,8 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
 
         AnalysisResult result = scheduleSuccessfulBuild(job);
 
-        assertThat(not(result.getReferenceBuild().isPresent()));
-
-        assertThat(result.getNewIssues()).hasSize(0);
-        assertThat(result.getOutstandingIssues()).hasSize(2);
+        assertThat(result.getReferenceBuild()).isEmpty();
+        assertThat(result).hasNewSize(0).hasTotalSize(2);
         assertThat(result.getErrorMessages()).contains(
                 "Reference job 'reference' does not contain configured build '1'");
     }
@@ -1092,13 +1090,16 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         ResultAction action = baseline.getAction(ResultAction.class);
         PullRequestMonitoringPortlet portlet = new PullRequestMonitoringPortlet(action);
 
-        assertThatJson(portlet.getWarningsModel()).node("fixed").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("outstanding").isEqualTo(3);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("total").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("low").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("normal").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("high").isEqualTo(0);
-        assertThatJson(portlet.getWarningsModel()).node("new").node("error").isEqualTo(0);
+        String model = portlet.getWarningsModel();
+        assertThatJson(model).node("fixed").isEqualTo(0);
+        assertThatJson(model).node("outstanding").isEqualTo(3);
+        assertThatJson(model).node("new").node("total").isEqualTo(0);
+        assertThatJson(model).node("new").node("low").isEqualTo(0);
+        assertThatJson(model).node("new").node("normal").isEqualTo(0);
+        assertThatJson(model).node("new").node("high").isEqualTo(0);
+        assertThatJson(model).node("new").node("error").isEqualTo(0);
+
+        assertThat(portlet.hasQualityGate()).isFalse();
     }
 
     private void write(final String adaptedOobFileContent) {


### PR DESCRIPTION
Internally the quality gate still uses the `BallColor` class to visualize the quality gate status. This class has not been adapted to use the new Jenkins status icons so it is required to use a different way to show the correct icon of the quality gate.

- [x] Fix status icon in pull request portlet
- [ ]  Fix status icon in build summary (will be solved in another PR)

Screenshot

![Bildschirmfoto 2021-07-10 um 14 06 57](https://user-images.githubusercontent.com/503338/125162443-222b5880-e188-11eb-858d-fc91e1cb8fcc.png)
