### PR TITLE
Ensure that we use unique IDs in the UI

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/charts.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/charts.jelly
@@ -11,20 +11,20 @@
       </label>
     </div>
     <div class="mb-3">
-      <input class="form-check-input" type="radio" name="chartType" id="severity" checked="true"/>
-      <label class="form-check-label" for="severity">
+      <input class="form-check-input" type="radio" name="chartType-warnings" id="severity-warnings" checked="true"/>
+      <label class="form-check-label" for="severity-warnings">
         Issues by Severity
       </label>
     </div>
     <div class="mb-3">
-      <input class="form-check-input" type="radio" name="chartType" id="health"/>
-      <label class="form-check-label" for="health">
+      <input class="form-check-input" type="radio" name="chartType-warnings" id="health-warnings"/>
+      <label class="form-check-label" for="health-warnings">
         Issues and Health
       </label>
     </div>
     <div class="mb-3">
-      <input class="form-check-input" type="radio" name="chartType" id="new"/>
-      <label class="form-check-label" for="new">
+      <input class="form-check-input" type="radio" name="chartType-warnings" id="new-warnings"/>
+      <label class="form-check-label" for="new-warnings">
         New and fixed issues
       </label>
     </div>
@@ -39,13 +39,13 @@
     function fillWarnings(trendConfiguration, jsonConfiguration) {
       const type = jsonConfiguration['chartType'];
       if (type) {
-        trendConfiguration.find('#' + type).prop('checked', true);
+        trendConfiguration.find('#' + type + '-warnings').prop('checked', true);
       }
     }
 
     function saveWarnings(trendConfiguration) {
       return {
-        'chartType': trendConfiguration.find('input[name=chartType]:checked').attr('id')
+        'chartType': trendConfiguration.find('input[name=chartType-warnings]:checked').attr('id').replace('-warnings', '')
       };
     }
 


### PR DESCRIPTION
The `chartType` element used the same IDs as the other chart configuration dialogs (in the forensics API plugin).