### PR TITLE
Include keywords in plugin description

### DIFF
--- a/plugin/src/main/resources/index.jelly
+++ b/plugin/src/main/resources/index.jelly
@@ -2,7 +2,7 @@
 
 <div>
   This plugin collects compiler warnings or issues reported by static analysis tools and 
-  visualizes the results. It has built-in support for numerous static analysis tools 
-  (including several compilers), see the list of 
+  visualizes the results. It has built-in support for many compilers (cpp, clang, java, ...) and tools
+  (spotbugs, pmd, checkstyle, eslint, phpstan, ...), see the list of 
   <a href="https://github.com/jenkinsci/warnings-ng-plugin/blob/master/SUPPORTED-FORMATS.md">supported report formats</a>.
 </div>


### PR DESCRIPTION
Many searches on the plugin site now give no results because keywords like spotbugs or checkstyle are not included in description of any plugin. This PR aims to fix that, it should also improve search in plugin manager inside Jenkins.