### PR TITLE
Update CSS of tooltips of issues column

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumn/column.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumn/column.jelly
@@ -12,33 +12,35 @@
       </j:when>
       <j:when test="${total.isPresent()}">
         ${total.asInt}
-        <div class="healthReportDetails">
-          <table border="0">
-            <thead>
-              <tr>
-                <th/>
-                <th align="left">${%Tool}</th>
-                <th align="right">${%Total}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <j:forEach var="result" items="${it.getDetails(job)}">
-                <tr>
-                  <td align="left">
-                    <img src="${resURL}/${result.icon}" style="width: 16px; height: 16px; " />
-                  </td>
-                  <td><a href="${rootURL}/${job.url}/${result.url}">${result.name}</a></td>
-                  <td align="right">${result.total}</td>
-                </tr>
-              </j:forEach>
-            </tbody>
-          </table>
-        </div>
       </j:when>
       <j:otherwise>
         -
       </j:otherwise>
     </j:choose>
+    <j:if test="${total.isPresent()}">
+      <div class="jenkins-tooltip healthReportDetails">
+        <table class="bigtable stripped-odd">
+          <thead>
+            <tr>
+              <th/>
+              <th align="left">${%Tool}</th>
+              <th align="right">${%Total}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <j:forEach var="result" items="${it.getDetails(job)}">
+              <tr>
+                <td align="left">
+                  <img src="${resURL}/${result.icon}" style="width: 16px; height: 16px; " />
+                </td>
+                <td><a href="${rootURL}/${job.url}/${result.url}">${result.name}</a></td>
+                <td align="right">${result.total}</td>
+              </tr>
+            </j:forEach>
+          </tbody>
+        </table>
+      </div>
+    </j:if>
   </td>
 
 </j:jelly>


### PR DESCRIPTION
Followup for jenkinsci/jenkins#5763 in Jenkins 2.318. Tooltips now should use a different CSS class.
