### PR TITLE
Simplify structure of reports generated by open task scanner

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/tasks/AgentScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/tasks/AgentScanner.java
@@ -86,7 +86,7 @@ class AgentScanner extends MasterToSlaveFileCallable<Report> {
         report.logInfo(scanner.getTaskTags());
         report.logInfo("Scanning all %d files for open tasks", fileNames.length);
         for (String fileName : fileNames) {
-            report.addAll(scanner.scan(root.resolve(fileName), getCharset()));
+            report.addAll(scanner.scan(root.resolve(fileName), getCharset()).get());
 
             if (Thread.interrupted()) {
                 throw new ParsingCanceledException();


### PR DESCRIPTION
Extract issues from file reports before attaching them to the aggregated report. Storing issues per file in a new report seems to be wasted memory.
