### PR TITLE
add parser for CodeChecker files

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
@@ -7,7 +7,7 @@ import hudson.Extension;
 import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
 
 /**
- * Provides a parser and customized messages for CodeChecker
+ * Provides a parser and customized messages for CodeChecker.
  *
  */
 public class CodeChecker extends AnalysisModelParser {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.jenkinsci.Symbol;
+import hudson.Extension;
+
+import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
+
+/**
+ * Provides a parser and customized messages for the clang-analyzer.
+ *
+ */
+public class CodeChecker extends AnalysisModelParser {
+    private static final long serialVersionUID = -171355177448403202L;
+    private static final String ID = "code-checker";
+
+    /** Creates a new instance of {@link CodeChecker}. */
+    @DataBoundConstructor
+    public CodeChecker() {
+        super();
+        // empty constructor required for stapler
+    }
+
+    /** Descriptor for this static analysis tool. */
+    @Symbol("codeChecker")
+    @Extension
+    public static class Descriptor extends AnalysisModelParserDescriptor {
+        /** Creates the descriptor instance. */
+        public Descriptor() {
+            super(ID);
+        }
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
@@ -7,7 +7,7 @@ import hudson.Extension;
 import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
 
 /**
- * Provides a parser and customized messages CodeChecker
+ * Provides a parser and customized messages for CodeChecker
  *
  */
 public class CodeChecker extends AnalysisModelParser {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
@@ -7,7 +7,8 @@ import hudson.Extension;
 import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
 
 /**
- * Provides a parser and customized messages for the clang-analyzer.
+ * Provides a parser and customized messages for out put of
+ * `CodeChecker parse folder_with_plist_files > textoutput`
  *
  */
 public class CodeChecker extends AnalysisModelParser {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CodeChecker.java
@@ -7,8 +7,7 @@ import hudson.Extension;
 import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
 
 /**
- * Provides a parser and customized messages for out put of
- * `CodeChecker parse folder_with_plist_files > textoutput`
+ * Provides a parser and customized messages CodeChecker
  *
  */
 public class CodeChecker extends AnalysisModelParser {


### PR DESCRIPTION
Codechecker is a wrapper for clang-tidy and clang static analysis.
`Codechecker analyze` creates *.plist files. These can be parsed with the already existing parsers.
In a second step Codechecker convert the contents of the *.plist files into one, human readable text file.
`Codechecker parse folder_with_plist_files > textfile.txt`.
And the new parser parses this text file.

the line in a Jenkinsfile could look like
~~~~
recordIssues tool:codeChecker( pattern: 'b/static_analysis_report.txt')
~~~~
The pull request for `analysis-model` is
https://github.com/jenkinsci/analysis-model/pull/706

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
