### PR TITLE
Rename "C++ Lint" to Cpplint

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -27,7 +27,7 @@ the [Analysis Parsers Library](https://github.com/jenkinsci/analysis-model/).
 | 7 | axivion-suite | axivionSuite() | ![Axivion Suite](plugin/src/main/webapp/icons/axivion-24x24.png) ![Axivion Suite](plugin/src/main/webapp/icons/axivion-48x48.png) | Axivion Suite | - |
 | 8 | brakeman | brakeman() | ![Brakeman](plugin/src/main/webapp/icons/brakeman-24x24.png) ![Brakeman](plugin/src/main/webapp/icons/brakeman-48x48.png) | [Brakeman](https://brakemanscanner.org) | **/brakeman-output.json |
 | 9 | buckminster | buckminster() | - - | Buckminster |  |
-| 10 | cpplint | cppLint() | - - | C&#43;&#43; Lint |  |
+| 10 | cpplint | cppLint() | - - | Cpplint |  |
 | 11 | cadence | cadence() | - - | Cadence Incisive |  |
 | 12 | cargo | cargo() | - - | Cargo Check |  |
 | 13 | ccm | ccm() | - - | CCM |  |

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CppLint.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/CppLint.java
@@ -7,7 +7,7 @@ import hudson.Extension;
 import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
 
 /**
- * Provides a parser and customized messages for C++ Lint.
+ * Provides a parser and customized messages for Cpplint.
  *
  * @author Ullrich Hafner
  */


### PR DESCRIPTION
Switch all occurrences of "C++ Lint" to Cpplint.

In the documentation, the tool is only mentioned by the name cpplint.

Source:
https://github.com/google/styleguide/tree/gh-pages/cpplint
https://pypi.org/project/cpplint

The corresponding PR in Ananlysis-model: [ PR #707](https://github.com/jenkinsci/analysis-model/pull/707)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
