### PR TITLE
Use new messages dialog and improve associated icon link 

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -33,7 +33,8 @@
 
     <data-tables-api.version>1.11.3-4</data-tables-api.version>
     <echarts-api.version>5.2.2-1</echarts-api.version>
-    <bootstrap5-api.version>5.1.3-1</bootstrap5-api.version>
+    <bootstrap5-api.version>5.1.3-2</bootstrap5-api.version>
+    <font-awesome-api.version>5.15.4-2</font-awesome-api.version>
     <error_prone_annotations.version>2.9.0</error_prone_annotations.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
 
@@ -120,6 +121,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>font-awesome-api</artifactId>
+      <version>${font-awesome-api.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -33,8 +33,8 @@
 
     <data-tables-api.version>1.11.3-4</data-tables-api.version>
     <echarts-api.version>5.2.2-1</echarts-api.version>
-    <bootstrap5-api.version>5.1.3-2</bootstrap5-api.version>
-    <font-awesome-api.version>5.15.4-2</font-awesome-api.version>
+    <bootstrap5-api.version>5.1.3-3</bootstrap5-api.version>
+    <font-awesome-api.version>5.15.4-3</font-awesome-api.version>
     <error_prone_annotations.version>2.9.0</error_prone_annotations.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
@@ -25,6 +25,7 @@ import hudson.model.Run;
 import io.jenkins.plugins.analysis.core.util.BuildFolderFacade;
 import io.jenkins.plugins.analysis.core.util.ConsoleLogHandler;
 import io.jenkins.plugins.analysis.core.util.LocalizedSeverity;
+import io.jenkins.plugins.bootstrap5.MessagesViewModel;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
@@ -157,8 +158,9 @@ public class DetailFactory {
                     EMPTY, Messages.Outstanding_Warnings_Header(), url, labelProvider, sourceEncoding);
         }
         if ("info".equalsIgnoreCase(link)) {
-            return new InfoErrorDetail(owner, result.getErrorMessages(), result.getInfoMessages(),
-                    labelProvider.getName());
+            return new MessagesViewModel(owner, labelProvider.getName(),
+                    result.getInfoMessages().castToList(),
+                    result.getErrorMessages().castToList());
         }
         for (Severity severity : Severity.getPredefinedValues()) {
             if (severity.getName().equalsIgnoreCase(link)) {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/InfoErrorDetail.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/InfoErrorDetail.java
@@ -11,8 +11,10 @@ import hudson.model.Run;
  * Result object to visualize the logging messages and errors during a static analysis run.
  *
  * @author Ullrich Hafner
+ * @deprecated moved to Bootstrap 5 API plugin
  */
 @SuppressWarnings("PMD.DataClass")
+@Deprecated
 public class InfoErrorDetail implements ModelObject {
     private final Run<?, ?> owner;
     private final ImmutableList<String> errorMessages;

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.jelly
@@ -25,18 +25,15 @@
           </j:if>
         </j:choose>
       </span>
-      <a id="${it.id}-info" href="${it.id}/info">
-        <j:choose>
-          <j:when test="${size(s.errors) > 0}">
-            <fa:svg-icon name="exclamation-triangle" class="info-page-decorator"
-                         tooltip="${%Click to open details view to see all error messages}"/>
-          </j:when>
-          <j:otherwise>
-            <fa:svg-icon name="info-circle" class="info-page-decorator"
-                         tooltip="${%Click to open details view to see all information messages}"/>
-          </j:otherwise>
-        </j:choose>
-      </a>
+
+      <j:choose>
+        <j:when test="${size(s.errors) > 0}">
+          <fa:image-button label="${%Open log messages}" name="exclamation-triangle" tooltip="${%icon.error.tooltip}" url="${it.id}/info" class="fa-image-button-warning"/>
+        </j:when>
+        <j:otherwise>
+          <fa:image-button label="${%Open error messages}" name="info-circle" tooltip="${%icon.info.tooltip}" url="${it.id}/info"/>
+        </j:otherwise>
+      </j:choose>
 
       <ul id="${it.id}-details">
         <j:if test="${size(s.tools) > 1}">

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.properties
@@ -1,0 +1,2 @@
+icon.error.tooltip=Some errors have been logged during recording, click to see these errors in a details view.
+icon.info.tooltip=Click to see all logging messages during recording.

--- a/plugin/src/main/webapp/css/custom-style.css
+++ b/plugin/src/main/webapp/css/custom-style.css
@@ -49,14 +49,6 @@
     width: 200px;
 }
 
-.info-page-decorator {
-    fill: #b4b4b4;
-    height: 16px;
-    width: 16px;
-    vertical-align: text-bottom;
-    margin-left: 0.2em;
-}
-
 /* ------------------------------------------------------------------------------------------------------------------- */
 
 /* Bar graph in table */

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailFactoryTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailFactoryTest.java
@@ -24,6 +24,7 @@ import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.analysis.core.util.BuildFolderFacade;
 import io.jenkins.plugins.analysis.core.util.ConsoleLogHandler;
+import io.jenkins.plugins.bootstrap5.MessagesViewModel;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 import static io.jenkins.plugins.analysis.core.testutil.Assertions.*;
@@ -154,9 +155,9 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnInfoErrorDetailWhenCalledWithInfoLink() {
-        InfoErrorDetail details = createTrendDetails("info", RUN, createResult(),
+        MessagesViewModel details = createTrendDetails("info", RUN, createResult(),
                 ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
-                InfoErrorDetail.class);
+                MessagesViewModel.class);
         assertThat(details.getErrorMessages()).containsExactly(ERROR_MESSAGES);
         assertThat(details.getDisplayName()).contains(PARENT_NAME);
     }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/InfoErrorDetailTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/InfoErrorDetailTest.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins.analysis.core.model;
+
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.junit.jupiter.api.Test;
+
+import hudson.model.Run;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link InfoErrorDetail}.
+ *
+ * @author Ullrich Hafner
+ */
+class InfoErrorDetailTest {
+    private static final String TITLE = "Title";
+    private static final String DISPLAY_NAME = TITLE + " - Messages";
+    private static final ImmutableList<String> INFO_MESSAGES = Lists.immutable.of("One", "Two");
+    private static final ImmutableList<String> ERROR_MESSAGES = Lists.immutable.of("Error One", "Error Two");
+
+    @Test
+    void shouldCreateMessagesAndErrors() {
+        Run<?, ?> build = mock(Run.class);
+        InfoErrorDetail model = new InfoErrorDetail(build, ERROR_MESSAGES, INFO_MESSAGES, TITLE);
+
+        assertThat(model.getDisplayName()).isEqualTo(DISPLAY_NAME);
+        assertThat(model.getOwner()).isSameAs(build);
+        assertThat(model.getInfoMessages()).containsExactlyElementsOf(INFO_MESSAGES);
+        assertThat(model.getErrorMessages()).containsExactlyElementsOf(ERROR_MESSAGES);
+    }
+}

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/AnalysisSummary.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/AnalysisSummary.java
@@ -51,8 +51,8 @@ public class AnalysisSummary extends PageObject {
         WebElement summary = getElement(By.id(id + "-summary"));
         titleElement = summary.findElement(By.id(id + "-title"));
 
-        infoElement = summary.findElement(By.id(id + "-info"));
-        hasErrorIcon = infoElement.getText().contains("error messages");
+        infoElement = summary.findElement(By.className("fa-image-button"));
+        hasErrorIcon = !infoElement.findElements(By.className("fa-image-button-warning")).isEmpty();
         results = summary.findElements(by.xpath("ul[@id='" + id + "-details']/li"));
     }
 
@@ -307,7 +307,7 @@ public class AnalysisSummary extends PageObject {
      * Determines which icon is shown to represent the info messages view.
      */
     public enum InfoType {
-        INFO, ERROR;
+        INFO, ERROR
     }
 
     /**


### PR DESCRIPTION
Use the new messages dialog of the bootstrap plugin that has been introduced with jenkinsci/bootstrap5-api-plugin#65. Additionally use the new icon button introduced with jenkinsci/font-awesome-api-plugin#118. This new button uses the restyled tooltips that have been introduced in Jenkins 2.318 (jenkinsci/jenkins#5763).