### PR TITLE
[JENKINS-67114] Remove link to tool result if number of warnings is 0

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
@@ -5,6 +5,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.Charset;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -128,9 +129,10 @@ public class DetailFactory {
         String property = StringUtils.substringBefore(link, ".");
         Predicate<Issue> filter = createPropertyFilter(plainLink, property);
         Report selectedIssues = allIssues.filter(filter);
+        String displayName = getDisplayNameOfDetails(property, selectedIssues, plainLink, result.getSizePerOrigin().keySet());
         return new IssuesDetail(owner, result,
                 selectedIssues, newIssues.filter(filter), outstandingIssues.filter(filter),
-                fixedIssues.filter(filter), getDisplayNameOfDetails(property, selectedIssues), url,
+                fixedIssues.filter(filter), displayName, url,
                 labelProvider, sourceEncoding);
     }
 
@@ -178,10 +180,16 @@ public class DetailFactory {
                 Issue.getPropertyValueAsString(issue, property).hashCode()));
     }
 
-    private String getDisplayNameOfDetails(final String property, final Report selectedIssues) {
+    private String getDisplayNameOfDetails(final String property, final Report selectedIssues,
+            final String originHash, final Set<String> origins) {
         if ("origin".equals(property)) {
             LabelProviderFactory factory = createFactory();
-            return factory.create(getPropertyValueAsString(property, selectedIssues)).getName();
+            for (String origin : origins) {
+                if (String.valueOf(origin.hashCode()).equals(originHash)) {
+                    return factory.create(origin).getName();
+                }
+            }
+            return "n/a";
         }
         return getColumnHeaderFor(selectedIssues, property)
                 + " "

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
@@ -189,7 +189,7 @@ public class DetailFactory {
                     return factory.create(origin).getName();
                 }
             }
-            return "n/a";
+            return factory.create(StringUtils.EMPTY).getName();
         }
         return getColumnHeaderFor(selectedIssues, property)
                 + " "

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailFactory.java
@@ -180,6 +180,7 @@ public class DetailFactory {
                 Issue.getPropertyValueAsString(issue, property).hashCode()));
     }
 
+    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Hashcode is used as URL")
     private String getDisplayNameOfDetails(final String property, final Report selectedIssues,
             final String originHash, final Set<String> origins) {
         if ("origin".equals(property)) {
@@ -202,6 +203,9 @@ public class DetailFactory {
     }
 
     private String getPropertyValueAsString(final String property, final Report selectedIssues) {
+        if (selectedIssues.isEmpty()) {
+            return "n/a";
+        }
         if ("fileName".equals(property)) {
             return selectedIssues.get(0).getBaseName();
         }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/LabelProviderFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/LabelProviderFactory.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
-import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 
 import io.jenkins.plugins.analysis.core.model.Tool.ToolDescriptor;
@@ -59,7 +58,7 @@ public class LabelProviderFactory {
      *         provider is returned.
      */
     public StaticAnalysisLabelProvider create(final String id, @CheckForNull final String name) {
-        DescriptorExtensionList<Tool, ToolDescriptor> extensions = jenkins.getDescriptorsFor(Tool.class);
+        List<ToolDescriptor> extensions = jenkins.getDescriptorsFor(Tool.class);
         for (ToolDescriptor descriptor : extensions) {
             if (descriptor.getId().equals(id)) {
                 return createNamedLabelProvider(descriptor.getLabelProvider(), name);

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SummaryModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SummaryModel.java
@@ -109,10 +109,27 @@ public class SummaryModel {
         return analysisResult.getFixedSize();
     }
 
+    /**
+     * Returns the tools that contribute to this result.
+     *
+     * @return the tools that have been used in this report
+     */
     public List<StaticAnalysisLabelProvider> getTools() {
         return analysisResult.getSizePerOrigin().keySet().stream()
                 .map(facade::get)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the number of issues for a specific tool given by its {@code origin} value.
+     *
+     * @param origin
+     *         the ID of the tool
+     *
+     * @return the number of issues for this tool
+     */
+    public int totalSize(final String origin) {
+        return analysisResult.getSizePerOrigin().get(origin);
     }
 
     public QualityGateStatus getQualityGateStatus() {

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.jelly
@@ -20,10 +20,10 @@
           <j:otherwise>
             ${s.title}
           </j:otherwise>
-          <j:if test="${s.analysesCount > 1}">
-            <st:nbsp/>(from ${s.analysesCount} analyses)
-          </j:if>
         </j:choose>
+        <j:if test="${s.analysesCount > 1}">
+          <st:nbsp/>(from ${s.analysesCount} analyses)
+        </j:if>
       </span>
       <a id="${it.id}-info" href="${it.id}/info">
         <j:choose>
@@ -44,7 +44,14 @@
             Static analysis results from:
             <j:set var="i" value="0"/>
             <j:forEach var="t" items="${s.tools}">
-              <a href="${it.id}/origin.${t.id.hashCode()}">${t.name}</a>
+              <j:choose>
+                <j:when test="${s.totalSize(t.id) != 0}">
+                  <a href="${it.id}/origin.${t.id.hashCode()}">${t.name} (${s.totalSize(t.id)})</a>
+                </j:when>
+                <j:otherwise>
+                  ${t.name} (0)
+                </j:otherwise>
+              </j:choose>
               <j:set var="i" value="${i + 1}"/>
               <j:if test="${i lt size(s.tools)}">,
                 <st:nbsp/>
@@ -83,7 +90,10 @@
             <l:icon alt="${s.qualityGateStatus.description}" class="${s.qualityGateStatus.iconClass} icon-sm"/>
             <j:if test="${s.resetQualityGateVisible}">
               <span class="yui-button">
-                <button id="${it.id}-reset-reference" style="padding: 0.3em 0.5em; min-width: 0.20em; min-height: 0.20em" type="button" title="Reset quality gate so that next build will use this build as a reference." >Reset</button>
+                <button id="${it.id}-reset-reference"
+                        style="padding: 0.3em 0.5em; min-width: 0.20em; min-height: 0.20em" type="button"
+                        title="Reset quality gate so that next build will use this build as a reference.">Reset
+                </button>
               </span>
             </j:if>
           </li>
@@ -95,9 +105,9 @@
 
   <script>
     {
-      const proxy = <st:bind value="${it}"/>;
-      const handler = new ResetQualityGateButtonHandler();
-      handler.bindResetButton('${it.id}', proxy);
+    const proxy =<st:bind value="${it}"/>;
+    const handler = new ResetQualityGateButtonHandler();
+    handler.bindResetButton('${it.id}', proxy);
     }
   </script>
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailFactoryTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailFactoryTest.java
@@ -5,7 +5,9 @@ import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 
@@ -38,7 +40,7 @@ import static org.mockito.Mockito.*;
  */
 class DetailFactoryTest {
     private static final Charset ENCODING = StandardCharsets.UTF_8;
-    private static final Run RUN = mock(Run.class);
+    private static final Run<?, ?> RUN = mock(Run.class);
     private static final String[] ERROR_MESSAGES = {"error", "messages"};
     private static final String[] LOG_MESSAGES = {"log", "messages"};
 
@@ -60,9 +62,46 @@ class DetailFactoryTest {
     }
 
     @Test
+    void shouldCreateDetailsForEmpty() {
+        Report empty = new Report();
+
+        IssuesDetail originDetails = createTrendDetails("origin.123", createResult(),
+                empty, empty, empty, empty, createParent(),
+                IssuesDetail.class);
+        assertThat(originDetails).hasIssues(empty);
+        assertThat(originDetails).hasFixedIssues(empty);
+        assertThat(originDetails).hasNewIssues(empty);
+        assertThat(originDetails).hasOutstandingIssues(empty);
+
+        IssuesDetail fileDetails = createTrendDetails("file.123", createResult(),
+                empty, empty, empty, empty, createParent(),
+                IssuesDetail.class);
+        assertThat(fileDetails).hasIssues(empty);
+        assertThat(fileDetails).hasFixedIssues(empty);
+        assertThat(fileDetails).hasNewIssues(empty);
+        assertThat(fileDetails).hasOutstandingIssues(empty);
+    }
+
+    @Test
+    void shouldCreateOrigin() {
+        AnalysisResult result = createResult();
+        Map<String, Integer> sizes = new HashMap<>();
+        sizes.put(TOOL_ID, 20);
+        when(result.getSizePerOrigin()).thenReturn(sizes);
+        IssuesDetail details = createTrendDetails("origin." + TOOL_ID.hashCode(), result,
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
+                IssuesDetail.class);
+        assertThat(details).hasIssues(ALL_ISSUES);
+        IssuesDetail empty = createTrendDetails("origin.wrongID", result,
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
+                IssuesDetail.class);
+        assertThat(empty.getIssues()).isEmpty();
+    }
+
+    @Test
     void shouldReturnFixedWarningsDetailWhenCalledWithFixedLink() {
-        FixedWarningsDetail details = createTrendDetails("fixed", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        FixedWarningsDetail details = createTrendDetails("fixed", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 FixedWarningsDetail.class);
         assertThat(details).hasIssues(FIXED_ISSUES);
         assertThat(details).hasFixedIssues(FIXED_ISSUES);
@@ -72,8 +111,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnAllIssues() {
-        IssuesDetail details = createTrendDetails("all", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        IssuesDetail details = createTrendDetails("all", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 IssuesDetail.class);
         assertThat(details).hasIssues(ALL_ISSUES);
         assertThat(details).hasFixedIssues(FIXED_ISSUES);
@@ -96,8 +135,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnIssuesDetailWithNewIssuesWhenCalledWithNewLink() {
-        IssuesDetail details = createTrendDetails("new", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        IssuesDetail details = createTrendDetails("new", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 IssuesDetail.class);
         assertThat(details).hasIssues(NEW_ISSUES);
         assertThat(details).hasFixedIssues(NO_ISSUES);
@@ -107,8 +146,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnIssuesDetailWithOutstandingIssuesWhenCalledWithOutstandingLink() {
-        IssuesDetail details = createTrendDetails("outstanding", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        IssuesDetail details = createTrendDetails("outstanding", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 IssuesDetail.class);
         assertThat(details).hasIssues(OUTSTANDING_ISSUES);
         assertThat(details).hasFixedIssues(NO_ISSUES);
@@ -118,8 +157,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnPriorityDetailWithHighPriorityIssuesWhenCalledWithHighLink() {
-        IssuesDetail details = createTrendDetails("HIGH", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        IssuesDetail details = createTrendDetails("HIGH", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 IssuesDetail.class);
         assertThatPrioritiesAreFiltered(details, Severity.WARNING_HIGH);
         assertThatPrioritiesAreCorrectlySet(details, 3, 0, 0);
@@ -127,8 +166,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnPriorityDetailWithNormalPriorityIssuesWhenCalledWithNormalLink() {
-        IssuesDetail details = createTrendDetails("NORMAL", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        IssuesDetail details = createTrendDetails("NORMAL", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 IssuesDetail.class);
 
         assertThatPrioritiesAreFiltered(details, Severity.WARNING_NORMAL);
@@ -137,8 +176,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnPriorityDetailWithLowPriorityIssuesWhenCalledWithLowLink() {
-        IssuesDetail details = createTrendDetails("LOW", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        IssuesDetail details = createTrendDetails("LOW", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 IssuesDetail.class);
 
         assertThatPrioritiesAreFiltered(details, Severity.WARNING_LOW);
@@ -154,8 +193,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnInfoErrorDetailWhenCalledWithInfoLink() {
-        InfoErrorDetail details = createTrendDetails("info", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        InfoErrorDetail details = createTrendDetails("info", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 InfoErrorDetail.class);
         assertThat(details.getErrorMessages()).containsExactly(ERROR_MESSAGES);
         assertThat(details.getDisplayName()).contains(PARENT_NAME);
@@ -239,14 +278,16 @@ class DetailFactoryTest {
     }
 
     @SuppressWarnings("ParameterNumber")
-    private <T extends ModelObject> T createTrendDetails(final String link, final Run<?, ?> owner,
+    private <T extends ModelObject> T createTrendDetails(final String link,
             final AnalysisResult result,
             final Report allIssues, final Report newIssues,
             final Report outstandingIssues, final Report fixedIssues,
-            final Charset sourceEncoding, final IssuesDetail parent, final Class<T> actualType) {
-        DetailFactory detailFactory = new DetailFactory();
-        Object details = detailFactory.createTrendDetails(link, owner,
-                result, allIssues, newIssues, outstandingIssues, fixedIssues, sourceEncoding, parent);
+            final IssuesDetail parent, final Class<T> actualType) {
+        JenkinsFacade jenkins = mock(JenkinsFacade.class);
+        when(jenkins.getDescriptorsFor(Tool.class)).thenReturn(DescriptorExtensionList.createDescriptorList((Jenkins) null, Tool.class));
+        DetailFactory detailFactory = new DetailFactory(jenkins, mock(BuildFolderFacade.class));
+        Object details = detailFactory.createTrendDetails(link, DetailFactoryTest.RUN,
+                result, allIssues, newIssues, outstandingIssues, fixedIssues, DetailFactoryTest.ENCODING, parent);
         assertThat(details).isInstanceOf(actualType);
         return actualType.cast(details);
     }
@@ -299,7 +340,7 @@ class DetailFactoryTest {
 
     private static Report createReportWith(final int high, final int normal, final int low, final String link) {
         try (IssueBuilder builder = new IssueBuilder().setOrigin(TOOL_ID)) {
-            Report issues = new Report();
+            Report issues = new Report(TOOL_ID, "SpotBugs");
             for (int i = 0; i < high; i++) {
                 issues.add(builder.setSeverity(Severity.WARNING_HIGH)
                         .setMessage(link + " - " + i)

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailFactoryTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailFactoryTest.java
@@ -194,8 +194,8 @@ class DetailFactoryTest {
 
     @Test
     void shouldReturnInfoErrorDetailWhenCalledWithInfoLink() {
-        MessagesViewModel details = createTrendDetails("info", RUN, createResult(),
-                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, ENCODING, createParent(),
+        MessagesViewModel details = createTrendDetails("info", createResult(),
+                ALL_ISSUES, NEW_ISSUES, OUTSTANDING_ISSUES, FIXED_ISSUES, createParent(),
                 MessagesViewModel.class);
         assertThat(details.getErrorMessages()).containsExactly(ERROR_MESSAGES);
         assertThat(details.getDisplayName()).contains(PARENT_NAME);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryModelTest.java
@@ -92,6 +92,7 @@ class SummaryModelTest {
                 .hasName(TOOL_NAME)
                 .hasTitle(Messages.Tool_MultipleIssues(2))
                 .hasNoErrors();
+        assertThat(summary.totalSize(CHECK_STYLE_ID)).isEqualTo(2);
     }
 
     @Test
@@ -131,7 +132,8 @@ class SummaryModelTest {
                 .containsExactly(
                         tuple(CHECK_STYLE_ID, CHECK_STYLE_NAME),
                         tuple(PMD_ID, PMD_NAME));
-
+        assertThat(summary.totalSize(CHECK_STYLE_ID)).isEqualTo(2);
+        assertThat(summary.totalSize(PMD_ID)).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
Additionally, show the number of warnings per tool in the summary.

![Bildschirmfoto 2021-11-22 um 00 00 29](https://user-images.githubusercontent.com/503338/142782348-cfc7d6ea-e0c6-4134-a0e5-eb0a050f7542.png)

See [JENKINS-67114](https://issues.jenkins.io/browse/JENKINS-67114) for details.