### PR TITLE
Extended message in codechecker report

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SourcePrinter.java
@@ -102,9 +102,9 @@ public class SourcePrinter {
 
     private ContainerTag createTitle(final String message, final String iconUrl, final boolean isCollapseVisible) {
         return div().with(table().withClass("analysis-title").with(tr().with(
-                td().with(img().withSrc(iconUrl)),
                 td().withClass("analysis-title-column")
                         .with(div().withClass("analysis-warning-title").with(replaceNewLine(message))),
+                td().with(img().withSrc(iconUrl)),
                 createCollapseButton(isCollapseVisible)
         )));
     }

--- a/plugin/src/main/webapp/css/custom-prism.css
+++ b/plugin/src/main/webapp/css/custom-prism.css
@@ -23,8 +23,6 @@ pre > code.highlight {
     color: black;
     padding-left: 0em;
     padding-right: 1em;
-    font-size: 1em !important;
-    font: bold 65%/1.5 sans-serif;
 }
 
 .analysis-title-column {

--- a/plugin/src/main/webapp/css/custom-prism.css
+++ b/plugin/src/main/webapp/css/custom-prism.css
@@ -11,7 +11,7 @@ pre > code.highlight {
 .analysis-warning {
     white-space: normal;
     border-radius: 4px;
-    border:1px solid #CCC;
+    border:0px solid #CCC;
     background-color:white;
     font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; /* Avoid the font override from the pre to affect the message */
     -moz-box-shadow:    2px 2px 18px 0 #ccc;

--- a/plugin/src/main/webapp/css/custom-prism.css
+++ b/plugin/src/main/webapp/css/custom-prism.css
@@ -13,7 +13,7 @@ pre > code.highlight {
     border-radius: 4px;
     border:1px solid #CCC;
     background-color:white;
-    font-family: Arial, Helvetica, sans-serif; /* Avoid the font override from the pre to affect the message */
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; /* Avoid the font override from the pre to affect the message */
     -moz-box-shadow:    2px 2px 18px 0 #ccc;
     -webkit-box-shadow: 2px 2px 18px 0 #ccc;
     box-shadow:         2px 2px 18px 0 #ccc;
@@ -21,8 +21,10 @@ pre > code.highlight {
 
 .analysis-warning-title {
     color: black;
-    padding-left: 0.25em;
+    padding-left: 0em;
     padding-right: 1em;
+    font-size: 1em !important;
+    font: bold 65%/1.5 sans-serif;
 }
 
 .analysis-title-column {
@@ -37,7 +39,7 @@ pre > code.highlight {
 
 .analysis-title {
     display: block;
-    padding: 15px 10px;
+    padding: 15px 0px;
     margin-bottom: 0;
     background: #FFF9C4;
     font-weight: normal;


### PR DESCRIPTION
This pull request complements the pull request https://github.com/jenkinsci/analysis-model/pull/716.

The basic idea is to create multi line warning messages in CodeChecker that look like:
![warnings-ng-proposal](https://user-images.githubusercontent.com/1757239/143468550-cd5c97f4-501a-4392-a8d2-c523ca5c723f.png)
 This is useful if the same warning is emitted several times for one code line. Before you could look at three warnings and would not know which warning matches which column in code line.

To make that work I tried to put the icon after the message on the right side. The icon disappeared.
I also tried to use the same font in the warning box like in the source code.
And removed any left padding to get the right position of the `^`.
All that with trial and error, without really knowing a lot about CSS/HTML.

About the "lost" icon: I could live without an icon, because I value the added information more than the icon.

I am open for suggestions.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

