### PR TITLE
Code checker shows position in code line

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SourcePrinter.java
@@ -102,9 +102,9 @@ public class SourcePrinter {
 
     private ContainerTag createTitle(final String message, final String iconUrl, final boolean isCollapseVisible) {
         return div().with(table().withClass("analysis-title").with(tr().with(
-                td().with(img().withSrc(iconUrl)),
                 td().withClass("analysis-title-column")
                         .with(div().withClass("analysis-warning-title").with(replaceNewLine(message))),
+                td().with(img().withSrc(iconUrl)),
                 createCollapseButton(isCollapseVisible)
         )));
     }

--- a/plugin/src/main/webapp/css/custom-prism.css
+++ b/plugin/src/main/webapp/css/custom-prism.css
@@ -11,9 +11,8 @@ pre > code.highlight {
 .analysis-warning {
     white-space: normal;
     border-radius: 4px;
-    border:1px solid #CCC;
+    border:0px solid #CCC;
     background-color:white;
-    font-family: Arial, Helvetica, sans-serif; /* Avoid the font override from the pre to affect the message */
     -moz-box-shadow:    2px 2px 18px 0 #ccc;
     -webkit-box-shadow: 2px 2px 18px 0 #ccc;
     box-shadow:         2px 2px 18px 0 #ccc;
@@ -21,12 +20,13 @@ pre > code.highlight {
 
 .analysis-warning-title {
     color: black;
-    padding-left: 0.25em;
+    padding-left: 0em;
     padding-right: 1em;
 }
 
 .analysis-title-column {
     vertical-align: middle;
+    padding-left: 0em;
 }
 
 .analysis-detail {
@@ -37,11 +37,12 @@ pre > code.highlight {
 
 .analysis-title {
     display: block;
-    padding: 15px 10px;
+    padding: 15px 0px;
     margin-bottom: 0;
     background: #FFF9C4;
     font-weight: normal;
     transition: background-color .2s ease;
+    border-spacing: 0px;
 }
 
 .analysis-detail > pre {


### PR DESCRIPTION
This pull request complements the pull request https://github.com/jenkinsci/analysis-model/pull/719.

The basic idea is to create multi line warning messages in CodeChecker that look like:
![webview3](https://user-images.githubusercontent.com/1757239/143507077-20e5f0a5-adef-465e-b89e-05c02ccd3ad7.png)
 This is useful if the same warning is emitted several times for one code line.


match the position of the `^` with the column in source line by
- removing horizontal padding from analysis-title
- using the same font as in source code
- reducing left padding for analysis-warning
- removing left padding from analysis-warning-title
 
The icon is not displayed anymore. I am not sure how to fix that. I tried to place it on the right side next to the text.
I could live without an icon, because I value the added information more than the icon.
But I am open for suggestions.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
