### PR TITLE
Rename the `id` parameter of `analysisModel` tool to `analysisModelId`

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -180,7 +180,7 @@ recordIssues tool: checkStyle(pattern: 'checkstyle-result.xml')
 #### Pipeline step with a generic symbol
 
 ```groovy
-recordIssues tool: analysisParser(pattern: 'checkstyle-result.xml', id: 'checkstyle')
+recordIssues tool: analysisParser(pattern: 'checkstyle-result.xml', analysisModelId: 'checkstyle')
 ```
 
 ### Creating support for a custom tool

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -566,9 +566,11 @@
             <package>io.jenkins.plugins.analysis.core.scm</package>
             <package>io.jenkins.plugins.analysis.core.model</package>
             <package>io.jenkins.plugins.analysis.core.util</package>
+            <package>io.jenkins.plugins.analysis.warnings</package>
           </packages>
           <excludes combine.children="append">
             <exclude>.*Thresholds</exclude>
+            <exclude>.*TaskScanner.*</exclude>
           </excludes>
           <entryPointClassPackage>io.jenkins.plugins.analysis.core.assertions</entryPointClassPackage>
         </configuration>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,7 +29,7 @@
     <analysis-model-tests.version>${analysis-model-api.version}</analysis-model-tests.version>
 
     <forensics-api-plugin.version>1.7.0</forensics-api-plugin.version>
-    <plugin-util-api.version>2.5.1</plugin-util-api.version>
+    <plugin-util-api.version>2.6.0</plugin-util-api.version>
 
     <data-tables-api.version>1.11.3-4</data-tables-api.version>
     <echarts-api.version>5.2.2-1</echarts-api.version>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/Tool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/Tool.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import edu.hm.hafner.analysis.ParsingCanceledException;
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.util.VisibleForTesting;
 
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -39,6 +40,13 @@ public abstract class Tool extends AbstractDescribableImpl<Tool> implements Seri
 
     private String id = StringUtils.EMPTY;
     private String name = StringUtils.EMPTY;
+
+    private JenkinsFacade jenkins = new JenkinsFacade();
+
+    @VisibleForTesting
+    public void setJenkinsFacade(final JenkinsFacade jenkinsFacade) {
+        this.jenkins = jenkinsFacade;
+    }
 
     /**
      * Overrides the default ID of the results. The ID is used as URL of the results and as identifier in UI elements.
@@ -122,7 +130,7 @@ public abstract class Tool extends AbstractDescribableImpl<Tool> implements Seri
 
     @Override
     public ToolDescriptor getDescriptor() {
-        return (ToolDescriptor) super.getDescriptor();
+        return (ToolDescriptor) jenkins.getDescriptorOrDie(getClass());
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/RegisteredParser.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/RegisteredParser.java
@@ -26,26 +26,30 @@ public class RegisteredParser extends ReportScanningTool {
 
     private static final ParserRegistry REGISTRY = new ParserRegistry();
 
-    private final String id;
+    private final String analysisModelId;
 
     /**
      * Creates a new instance of {@link RegisteredParser}.
      *
-     * @param id
-     *         the unique ID of the tool
+     * @param analysisModelId
+     *         the unique ID of the tool in the analysis-model module
      */
     @DataBoundConstructor
-    public RegisteredParser(final String id) {
+    public RegisteredParser(final String analysisModelId) {
         super();
 
-        this.id = id;
-        if (!REGISTRY.contains(id)) {
-            throw new NoSuchElementException("No such parser found with the specified ID: " + id);
+        this.analysisModelId = analysisModelId;
+        if (!REGISTRY.contains(analysisModelId)) {
+            throw new NoSuchElementException("No such parser found with the specified ID: " + analysisModelId);
         }
     }
 
+    public String getAnalysisModelId() {
+        return analysisModelId;
+    }
+
     private ParserDescriptor getParserDescriptor() {
-        return REGISTRY.get(id);
+        return REGISTRY.get(analysisModelId);
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/RegisteredParser.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/RegisteredParser.java
@@ -71,7 +71,7 @@ public class RegisteredParser extends ReportScanningTool {
     public StaticAnalysisLabelProvider getLabelProvider() {
         ParserDescriptor descriptor = getParserDescriptor();
 
-        return new StaticAnalysisLabelProvider(descriptor.getId(), descriptor.getName(), descriptor::getDescription);
+        return new StaticAnalysisLabelProvider(descriptor.getId(), getName(), descriptor::getDescription);
     }
 
     @Override

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/RegisteredParserTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/RegisteredParserTest.java
@@ -1,0 +1,34 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
+
+import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+
+/**
+ * Tests the class {@link RegisteredParser}.
+ *
+ * @author Ullrich Hafner
+ */
+class RegisteredParserTest {
+    private static final String CHECKSTYLE_ID = "checkstyle";
+
+    @Test
+    void shouldThrowExceptionIfThereIsNoParserAvailable() {
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> new RegisteredParser("-unknown-"));
+    }
+
+    @Test
+    void shouldAllowChangingId() {
+        RegisteredParser parser = new RegisteredParser(CHECKSTYLE_ID);
+
+        assertThat(parser.createParser()).isInstanceOf(CheckStyleParser.class);
+        assertThat(parser).hasId(CHECKSTYLE_ID);
+        assertThat(parser.getLabelProvider()).hasId(CHECKSTYLE_ID);
+        assertThat(parser.getLabelProvider()).hasName("CheckStyle");
+
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/RegisteredParserTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/RegisteredParserTest.java
@@ -6,7 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
 
+import io.jenkins.plugins.util.JenkinsFacade;
+
 import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link RegisteredParser}.
@@ -15,6 +18,8 @@ import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
  */
 class RegisteredParserTest {
     private static final String CHECKSTYLE_ID = "checkstyle";
+    private static final String CHECK_STYLE_NAME = "CheckStyle";
+    private static final String CHECKSTYLE_PATTERN = "**/checkstyle-result.xml";
 
     @Test
     void shouldThrowExceptionIfThereIsNoParserAvailable() {
@@ -25,10 +30,36 @@ class RegisteredParserTest {
     void shouldAllowChangingId() {
         RegisteredParser parser = new RegisteredParser(CHECKSTYLE_ID);
 
-        assertThat(parser.createParser()).isInstanceOf(CheckStyleParser.class);
-        assertThat(parser).hasId(CHECKSTYLE_ID);
-        assertThat(parser.getLabelProvider()).hasId(CHECKSTYLE_ID);
-        assertThat(parser.getLabelProvider()).hasName("CheckStyle");
+        JenkinsFacade jenkins = mock(JenkinsFacade.class);
+        when(jenkins.getDescriptorOrDie(RegisteredParser.class)).thenReturn(new RegisteredParser.Descriptor());
+        parser.setJenkinsFacade(jenkins);
 
+        assertThat(parser.createParser()).isInstanceOf(CheckStyleParser.class);
+        assertThat(parser)
+                .hasAnalysisModelId(CHECKSTYLE_ID)
+                .hasId(CHECKSTYLE_ID)
+                .hasActualId(CHECKSTYLE_ID)
+                .hasActualName(CHECK_STYLE_NAME)
+                .hasActualPattern(CHECKSTYLE_PATTERN);
+
+        assertThat(parser.getLabelProvider()).hasId(CHECKSTYLE_ID);
+        assertThat(parser.getLabelProvider()).hasName(CHECK_STYLE_NAME);
+
+        String customId = "customId";
+        parser.setId(customId);
+        String customName = "Custom Name";
+        parser.setName(customName);
+        String customPattern = "Custom Pattern";
+        parser.setPattern(customPattern);
+
+        assertThat(parser)
+                .hasAnalysisModelId(CHECKSTYLE_ID)
+                .hasId(customId)
+                .hasActualId(customId)
+                .hasActualName(customName)
+                .hasActualPattern(customPattern);
+
+        assertThat(parser.getLabelProvider()).hasId(CHECKSTYLE_ID); // get decorations for checkstyle
+        assertThat(parser.getLabelProvider()).hasName(customName);
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
@@ -124,7 +124,7 @@ public class ParsersITest extends IntegrationTestWithJenkinsPerSuite {
                 "recordIssues tool:analysisParser("
                         + "pattern:'**/%s', "
                         + "reportEncoding:'UTF-8', "
-                        + "id:'code-checker')", logFile)));
+                        + "analysisModelId:'code-checker')", logFile)));
 
         AnalysisResult result = scheduleSuccessfulBuild(job);
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -78,7 +78,7 @@ public class StepsITest extends IntegrationTestWithJenkinsPerSuite {
 
         job.setDefinition(new CpsFlowDefinition("node {\n"
                 + "  stage ('Integration Test') {\n"
-                + "         recordIssues tool: analysisParser(id: 'checkstyle', pattern: '**/" + "checkstyle1" + "*')\n"
+                + "         recordIssues tool: analysisParser(analysisModelId: 'checkstyle', pattern: '**/" + "checkstyle1" + "*')\n"
                 + "  }\n"
                 + "}", true));
 


### PR DESCRIPTION
Otherwise we cannot replace the tool ID with a custom ID.
