### PR TITLE
[JENKINS-67414] Do not ignore description of issue

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
@@ -37,7 +37,7 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
     @VisibleForTesting
     static final String INFO_ICON = "info-circle";
     /** Provides an empty description. */
-    protected static final DescriptionProvider EMPTY_DESCRIPTION = i -> StringUtils.EMPTY;
+    protected static final DescriptionProvider EMPTY_DESCRIPTION = Issue::getDescription;
 
     private final String id;
     @CheckForNull

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProviderTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProviderTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
+import edu.hm.hafner.analysis.IssueBuilder;
+
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.CompositeLocalizable;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.DefaultAgeBuilder;
@@ -21,6 +23,20 @@ class StaticAnalysisLabelProviderTest {
     private static final String ID = "id";
     private static final String NAME = "name";
     private static final String OTHER_NAME = "other";
+
+    @Test
+    void shouldShowDescriptionOfIssueByDefault() {
+        try (IssueBuilder issueBuilder = new IssueBuilder()) {
+            StaticAnalysisLabelProvider labelProvider = new StaticAnalysisLabelProvider("description", "-");
+
+            String text = "Hello Description";
+            issueBuilder.setDescription(text);
+            assertThat(labelProvider.getDescription(issueBuilder.build())).isEqualTo(text);
+
+            StaticAnalysisLabelProvider emptyDescription = new StaticAnalysisLabelProvider("description", "-", i -> "empty");
+            assertThat(emptyDescription.getDescription(issueBuilder.build())).isEqualTo("empty");
+        }
+    }
 
     @Test
     void shouldIgnoreUndefinedName() {


### PR DESCRIPTION
Currently the description of an issue is not always shown. This depends on the actual parser used. 

See https://issues.jenkins.io/browse/JENKINS-67414