### PR TITLE
[JENKINS-68336] Check only for `READ` permissions when populating list models

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnalysisStepDescriptor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnalysisStepDescriptor.java
@@ -37,7 +37,7 @@ public abstract class AnalysisStepDescriptor extends StepDescriptor {
      */
     @POST
     public ComboBoxModel doFillSourceCodeEncodingItems(@AncestorInPath final AbstractProject<?, ?> project) {
-        if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        if (JENKINS.hasPermission(Item.READ, project)) {
             return new CharsetValidation().getAllCharsets();
         }
         return new ComboBoxModel();
@@ -92,7 +92,7 @@ public abstract class AnalysisStepDescriptor extends StepDescriptor {
      */
     @POST
     public ListBoxModel doFillMinimumSeverityItems(@AncestorInPath final AbstractProject<?, ?> project) {
-        if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
+        if (JENKINS.hasPermission(Item.READ, project)) {
             return model.getAllSeverityFilters();
         }
         return new ListBoxModel();
@@ -167,7 +167,10 @@ public abstract class AnalysisStepDescriptor extends StepDescriptor {
      */
     @POST
     public ListBoxModel doFillTrendChartTypeItems(@AncestorInPath final AbstractProject<?, ?> project) {
-        return model.getAllTrendChartTypes();
+        if (JENKINS.hasPermission(Item.READ, project)) {
+            return model.getAllTrendChartTypes();
+        }
+        return new ListBoxModel();
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnalysisStepDescriptor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnalysisStepDescriptor.java
@@ -167,10 +167,7 @@ public abstract class AnalysisStepDescriptor extends StepDescriptor {
      */
     @POST
     public ListBoxModel doFillTrendChartTypeItems(@AncestorInPath final AbstractProject<?, ?> project) {
-        if (JENKINS.hasPermission(Item.CONFIGURE, project)) {
-            return model.getAllTrendChartTypes();
-        }
-        return new ListBoxModel();
+        return model.getAllTrendChartTypes();
     }
 
     /**


### PR DESCRIPTION
Currently the `recordIssues` step does not work in the Pipeline snippet generator. Since I do not see why the trend chart types should be restricted, I'm removing the permission check.
For details see [JENKINS-68336](https://issues.jenkins.io/browse/JENKINS-68336)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
