### PR TITLE
Use responsive columns for all tables

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -34,7 +34,7 @@
     <plugin-util-api.version>2.17.0</plugin-util-api.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
     <prism-api.version>1.28.0-2</prism-api.version>
-    <data-tables-api.version>1.11.4-4</data-tables-api.version>
+    <data-tables-api.version>1.12.1-1-rc699.9872a30495f2</data-tables-api.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 
@@ -127,6 +127,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>data-tables-api</artifactId>
+      <version>${data-tables-api.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -605,53 +605,7 @@
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
-          <failBuildOnProblemsFound>true</failBuildOnProblemsFound>
-          <!-- Including provided-scope dependencies like Jenkins core results in too many false positives -->
-          <checkDependencies>false</checkDependencies>
-          <analysisConfiguration>
-            <revapi.ignore combine.children="append">
-              <item>
-                <regex>true</regex>
-                <code>java.field.serialVersionUIDUnchanged</code>
-                <classQualifiedName>io.jenkins.plugins.analysis.core.steps.*Step</classQualifiedName>
-                <justification>Serialization is only used in interprocess communication using the same classes
-                </justification>
-              </item>
-              <item>
-                <regex>true</regex>
-                <code>java.missing.*</code>
-                <justification>Dependencies are not being checked, so they are reported as missing</justification>
-              </item>
-              <item>
-                <code>java.annotation.added</code>
-                <annotationType>org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted</annotationType>
-                <justification>Annotation should be save to add.</justification>
-              </item>
-              <item>
-                <regex>true</regex>
-                <code>java.annotation.*</code>
-                <annotation>@edu.umd.cs.findbugs.annotations.*</annotation>
-                <justification>Annotation should be save to change.</justification>
-              </item>
-              <item>
-                <regex>true</regex>
-                <code>java.annotation.*</code>
-                <annotation>@org.kohsuke.stapler.*</annotation>
-                <justification>Annotation should be save to change.</justification>
-              </item>
-              <item>
-                <regex>true</regex>
-                <code>java.method.returnTypeChanged</code>
-                <methodName>getDescriptionProvider</methodName>
-                <justification>Return type must be part of the API.</justification>
-              </item>
-              <item>
-                <code>java.method.added</code>
-                <classSimpleName>Messages</classSimpleName>
-                <justification>Messages are now external API.</justification>
-              </item>
-            </revapi.ignore>
-          </analysisConfiguration>
+          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -34,7 +34,7 @@
     <plugin-util-api.version>2.17.0</plugin-util-api.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
     <prism-api.version>1.28.0-2</prism-api.version>
-    <data-tables-api.version>1.12.1-1-rc700.c12cd9a7969a</data-tables-api.version>
+    <data-tables-api.version>1.12.1-1</data-tables-api.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -34,7 +34,7 @@
     <plugin-util-api.version>2.17.0</plugin-util-api.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
     <prism-api.version>1.28.0-2</prism-api.version>
-    <data-tables-api.version>1.12.1-1-rc699.9872a30495f2</data-tables-api.version>
+    <data-tables-api.version>1.12.1-1-rc700.c12cd9a7969a</data-tables-api.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
@@ -10,6 +10,7 @@ import edu.hm.hafner.util.VisibleForTesting;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
 import io.jenkins.plugins.analysis.core.util.Blame;
 import io.jenkins.plugins.datatables.TableColumn;
+import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
 import io.jenkins.plugins.forensics.blame.Blames;
 import io.jenkins.plugins.forensics.util.CommitDecorator;
@@ -34,7 +35,6 @@ import io.jenkins.plugins.util.JenkinsFacade;
  */
 public class BlamesModel extends DetailsTableModel {
     static final String UNDEFINED = "-";
-    static final int UNDEFINED_DATE = 0;
 
     private final Blames blames;
     private final CommitDecorator commitDecorator;
@@ -67,11 +67,27 @@ public class BlamesModel extends DetailsTableModel {
         columns.add(createDetailsColumn());
         columns.add(createFileColumn());
         columns.add(createAgeColumn());
-        columns.add(new TableColumn(Messages.Table_Column_Author(), "author"));
-        columns.add(new TableColumn(Messages.Table_Column_Email(), "email"));
-        columns.add(new TableColumn(Messages.Table_Column_Commit(), "commit"));
-        columns.add(new TableColumn(Messages.Table_Column_AddedAt(), "addedAt")
-                .setHeaderClass(ColumnCss.DATE));
+        TableColumn author = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Author())
+                .withDataPropertyKey("author")
+                .withResponsivePriority(1)
+                .build();
+        columns.add(author);
+        TableColumn email = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Email())
+                .withDataPropertyKey("email")
+                .withResponsivePriority(50)
+                .build();
+        columns.add(email);
+        TableColumn commit = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Commit())
+                .withDataPropertyKey("commit")
+                .withResponsivePriority(10)
+                .build();
+        columns.add(commit);
+        TableColumn addedAt = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Commit())
+                .withDataPropertyKey("addedAt")
+                .withResponsivePriority(25)
+                .withHeaderClass(ColumnCss.DATE)
+                .build();
+        columns.add(addedAt);
         columns.add(createHiddenDetailsColumn());
 
         return columns;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/BlamesModel.java
@@ -82,7 +82,7 @@ public class BlamesModel extends DetailsTableModel {
                 .withResponsivePriority(10)
                 .build();
         columns.add(commit);
-        TableColumn addedAt = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Commit())
+        TableColumn addedAt = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_AddedAt())
                 .withDataPropertyKey("addedAt")
                 .withResponsivePriority(25)
                 .withHeaderClass(ColumnCss.DATE)

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
@@ -14,8 +14,11 @@ import j2html.tags.UnescapedText;
 
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
 import io.jenkins.plugins.analysis.core.util.LocalizedSeverity;
+import io.jenkins.plugins.datatables.DetailedCell;
 import io.jenkins.plugins.datatables.TableColumn;
+import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
+import io.jenkins.plugins.datatables.TableConfiguration;
 import io.jenkins.plugins.datatables.TableModel;
 import io.jenkins.plugins.prism.Sanitizer;
 import io.jenkins.plugins.util.JenkinsFacade;
@@ -55,10 +58,9 @@ public abstract class DetailsTableModel extends TableModel {
      * @param jenkinsFacade
      *         Jenkins facade to replaced with a stub during unit tests
      */
-    protected DetailsTableModel(final Report report,
-            final FileNameRenderer fileNameRenderer,
-            final AgeBuilder ageBuilder,
-            final DescriptionProvider descriptionProvider, final JenkinsFacade jenkinsFacade) {
+    protected DetailsTableModel(final Report report, final FileNameRenderer fileNameRenderer,
+            final AgeBuilder ageBuilder, final DescriptionProvider descriptionProvider,
+            final JenkinsFacade jenkinsFacade) {
         super();
 
         this.report = report;
@@ -66,6 +68,13 @@ public abstract class DetailsTableModel extends TableModel {
         this.ageBuilder = ageBuilder;
         this.descriptionProvider = descriptionProvider;
         this.jenkinsFacade = jenkinsFacade;
+    }
+
+    @Override
+    public TableConfiguration getTableConfiguration() {
+        TableConfiguration tableConfiguration = new TableConfiguration();
+        tableConfiguration.responsive();
+        return tableConfiguration;
     }
 
     protected JenkinsFacade getJenkinsFacade() {
@@ -103,25 +112,48 @@ public abstract class DetailsTableModel extends TableModel {
     }
 
     protected TableColumn createDetailsColumn() {
-        return new TableColumn(Messages.Table_Column_Details(), "description").setHeaderClass(ColumnCss.NO_SORT);
+        return new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Details())
+                .withDataPropertyKey("description")
+                .withResponsivePriority(1)
+                .withHeaderClass(ColumnCss.NO_SORT)
+                .build();
     }
 
     protected TableColumn createHiddenDetailsColumn() {
-        return new TableColumn("Hiddendetails", "message")
-            .setHeaderClass(ColumnCss.HIDDEN)
-            .setWidth(0);
+        return new ColumnBuilder().withHeaderLabel("Hiddendetails")
+                .withDataPropertyKey("message")
+                .withHeaderClass(ColumnCss.HIDDEN)
+                .build();
     }
 
     protected TableColumn createFileColumn() {
-        return new TableColumn(Messages.Table_Column_File(), "fileName", "string");
+        return new ColumnBuilder().withHeaderLabel(Messages.Table_Column_File())
+                .withDataPropertyKey("fileName")
+                .withResponsivePriority(1)
+                .withDetailedCell()
+                .build();
     }
 
     protected TableColumn createAgeColumn() {
-        return new TableColumn(Messages.Table_Column_Age(), "age").setHeaderClass(ColumnCss.NUMBER);
+        return new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Age())
+                .withDataPropertyKey("age")
+                .withHeaderClass(ColumnCss.NUMBER)
+                .withResponsivePriority(10)
+                .build();
     }
 
     protected TableColumn createSeverityColumn() {
-        return new TableColumn(Messages.Table_Column_Severity(), "severity");
+        return new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Severity())
+                .withDataPropertyKey("severity")
+                .withResponsivePriority(5)
+                .build();
+    }
+
+    protected TableColumn createPackageColumn() {
+        return new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Package())
+                .withDataPropertyKey("packageName")
+                .withResponsivePriority(50000)
+                .build();
     }
 
     /**
@@ -143,7 +175,7 @@ public abstract class DetailsTableModel extends TableModel {
 
         private final String description;
         private final String message;
-        private final DetailedColumnDefinition fileName;
+        private final DetailedCell<String> fileName;
         private final String age;
         private final JenkinsFacade jenkinsFacade;
 
@@ -161,10 +193,8 @@ public abstract class DetailsTableModel extends TableModel {
          * @param jenkinsFacade
          *         Jenkins facade to replaced with a stub during unit tests
          */
-        protected TableRow(final AgeBuilder ageBuilder,
-                final FileNameRenderer fileNameRenderer,
-                final DescriptionProvider descriptionProvider,
-                final Issue issue,
+        protected TableRow(final AgeBuilder ageBuilder, final FileNameRenderer fileNameRenderer,
+                final DescriptionProvider descriptionProvider, final Issue issue,
                 final JenkinsFacade jenkinsFacade) {
             this.jenkinsFacade = jenkinsFacade;
             message = render(issue.getMessage());
@@ -173,8 +203,8 @@ public abstract class DetailsTableModel extends TableModel {
             fileName = createFileName(fileNameRenderer, issue);
         }
 
-        private DetailedColumnDefinition createFileName(final FileNameRenderer fileNameRenderer, final Issue issue) {
-            return new DetailedColumnDefinition(fileNameRenderer.renderAffectedFileLink(issue),
+        private DetailedCell<String> createFileName(final FileNameRenderer fileNameRenderer, final Issue issue) {
+            return new DetailedCell<>(fileNameRenderer.renderAffectedFileLink(issue),
                     String.format("%s:%07d", issue.getFileName(), issue.getLineStart()));
         }
 
@@ -262,7 +292,7 @@ public abstract class DetailsTableModel extends TableModel {
             return message;
         }
 
-        public DetailedColumnDefinition getFileName() {
+        public DetailedCell<String> getFileName() {
             return fileName;
         }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
@@ -18,6 +18,7 @@ import io.jenkins.plugins.datatables.DetailedCell;
 import io.jenkins.plugins.datatables.TableColumn;
 import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
+import io.jenkins.plugins.datatables.TableColumn.ColumnType;
 import io.jenkins.plugins.datatables.TableConfiguration;
 import io.jenkins.plugins.datatables.TableModel;
 import io.jenkins.plugins.prism.Sanitizer;
@@ -137,7 +138,7 @@ public abstract class DetailsTableModel extends TableModel {
     protected TableColumn createAgeColumn() {
         return new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Age())
                 .withDataPropertyKey("age")
-                .withHeaderClass(ColumnCss.NUMBER)
+                .withType(ColumnType.NUMBER)
                 .withResponsivePriority(10)
                 .build();
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DetailsTableModel.java
@@ -152,7 +152,7 @@ public abstract class DetailsTableModel extends TableModel {
     protected TableColumn createPackageColumn() {
         return new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Package())
                 .withDataPropertyKey("packageName")
-                .withResponsivePriority(50000)
+                .withResponsivePriority(50_000)
                 .build();
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ForensicsModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ForensicsModel.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBui
 import io.jenkins.plugins.datatables.TableColumn;
 import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
+import io.jenkins.plugins.datatables.TableColumn.ColumnType;
 import io.jenkins.plugins.forensics.miner.FileStatistics;
 import io.jenkins.plugins.forensics.miner.RepositoryStatistics;
 import io.jenkins.plugins.util.JenkinsFacade;
@@ -71,13 +72,13 @@ public class ForensicsModel extends DetailsTableModel {
         TableColumn authorsSize = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_AuthorsSize())
                 .withDataPropertyKey("authorsSize")
                 .withResponsivePriority(1)
-                .withHeaderClass(ColumnCss.NUMBER)
+                .withType(ColumnType.NUMBER)
                 .build();
         columns.add(authorsSize);
         TableColumn commitsSize = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_CommitsSize())
                 .withDataPropertyKey("commitsSize")
                 .withResponsivePriority(1)
-                .withHeaderClass(ColumnCss.NUMBER)
+                .withType(ColumnType.NUMBER)
                 .build();
         columns.add(commitsSize);
         TableColumn modifiedAt = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_LastCommit())
@@ -95,13 +96,13 @@ public class ForensicsModel extends DetailsTableModel {
         TableColumn linesOfCode = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_LOC())
                 .withDataPropertyKey("linesOfCode")
                 .withResponsivePriority(25)
-                .withHeaderClass(ColumnCss.NUMBER)
+                .withType(ColumnType.NUMBER)
                 .build();
         columns.add(linesOfCode);
         TableColumn churn = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Churn())
                 .withDataPropertyKey("churn")
                 .withResponsivePriority(25)
-                .withHeaderClass(ColumnCss.NUMBER)
+                .withType(ColumnType.NUMBER)
                 .build();
         columns.add(churn);
         columns.add(createHiddenDetailsColumn());

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ForensicsModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ForensicsModel.java
@@ -9,6 +9,7 @@ import edu.hm.hafner.util.VisibleForTesting;
 
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
 import io.jenkins.plugins.datatables.TableColumn;
+import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
 import io.jenkins.plugins.forensics.miner.FileStatistics;
 import io.jenkins.plugins.forensics.miner.RepositoryStatistics;
@@ -64,22 +65,45 @@ public class ForensicsModel extends DetailsTableModel {
         List<TableColumn> columns = new ArrayList<>();
 
         columns.add(createDetailsColumn());
-        columns.add(createFileColumn().setWidth(2));
+        columns.add(createFileColumn());
         columns.add(createAgeColumn());
-        columns.add(new TableColumn(Messages.Table_Column_AuthorsSize(), "authorsSize")
-                .setHeaderClass(ColumnCss.NUMBER));
-        columns.add(new TableColumn(Messages.Table_Column_CommitsSize(), "commitsSize")
-                .setHeaderClass(ColumnCss.NUMBER));
-        columns.add(new TableColumn(Messages.Table_Column_LastCommit(), "modifiedAt")
-                .setWidth(2)
-                .setHeaderClass(ColumnCss.DATE));
-        columns.add(new TableColumn(Messages.Table_Column_AddedAt(), "addedAt")
-                .setWidth(2)
-                .setHeaderClass(ColumnCss.DATE));
-        columns.add(new TableColumn(Messages.Table_Column_LOC(), "linesOfCode")
-                .setHeaderClass(ColumnCss.NUMBER));
-        columns.add(new TableColumn(Messages.Table_Column_Churn(), "churn")
-                .setHeaderClass(ColumnCss.NUMBER));
+
+        TableColumn authorsSize = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_AuthorsSize())
+                .withDataPropertyKey("authorsSize")
+                .withResponsivePriority(1)
+                .withHeaderClass(ColumnCss.NUMBER)
+                .build();
+        columns.add(authorsSize);
+        TableColumn commitsSize = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_CommitsSize())
+                .withDataPropertyKey("commitsSize")
+                .withResponsivePriority(1)
+                .withHeaderClass(ColumnCss.NUMBER)
+                .build();
+        columns.add(commitsSize);
+        TableColumn modifiedAt = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_LastCommit())
+                .withDataPropertyKey("modifiedAt")
+                .withResponsivePriority(50)
+                .withHeaderClass(ColumnCss.DATE)
+                .build();
+        columns.add(modifiedAt);
+        TableColumn addedAt = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_AddedAt())
+                .withDataPropertyKey("addedAt")
+                .withResponsivePriority(50)
+                .withHeaderClass(ColumnCss.DATE)
+                .build();
+        columns.add(addedAt);
+        TableColumn linesOfCode = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_LOC())
+                .withDataPropertyKey("linesOfCode")
+                .withResponsivePriority(25)
+                .withHeaderClass(ColumnCss.NUMBER)
+                .build();
+        columns.add(linesOfCode);
+        TableColumn churn = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Churn())
+                .withDataPropertyKey("churn")
+                .withResponsivePriority(25)
+                .withHeaderClass(ColumnCss.NUMBER)
+                .build();
+        columns.add(churn);
         columns.add(createHiddenDetailsColumn());
 
         return columns;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesModel.java
@@ -9,6 +9,7 @@ import edu.hm.hafner.util.VisibleForTesting;
 
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
 import io.jenkins.plugins.datatables.TableColumn;
+import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
@@ -53,13 +54,21 @@ public class IssuesModel extends DetailsTableModel {
         columns.add(createDetailsColumn());
         columns.add(createFileColumn());
         if (getReport().hasPackages()) {
-            columns.add(new TableColumn(Messages.Table_Column_Package(), "packageName").setWidth(2));
+            columns.add(createPackageColumn());
         }
         if (getReport().hasCategories()) {
-            columns.add(new TableColumn(Messages.Table_Column_Category(), "category"));
+            TableColumn category = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Category())
+                    .withDataPropertyKey("category")
+                    .withResponsivePriority(100)
+                    .build();
+            columns.add(category);
         }
         if (getReport().hasTypes()) {
-            columns.add(new TableColumn(Messages.Table_Column_Type(), "type"));
+            TableColumn type = new ColumnBuilder().withHeaderLabel(Messages.Table_Column_Type())
+                    .withDataPropertyKey("type")
+                    .withResponsivePriority(1000)
+                    .build();
+            columns.add(type);
         }
         columns.add(createSeverityColumn());
         columns.add(createAgeColumn());

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/DuplicateCodeScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/DuplicateCodeScanner.java
@@ -30,6 +30,7 @@ import io.jenkins.plugins.analysis.core.model.FileNameRenderer;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
 import io.jenkins.plugins.analysis.core.model.SvgIconLabelProvider;
 import io.jenkins.plugins.datatables.TableColumn;
+import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 import io.jenkins.plugins.datatables.TableColumn.ColumnCss;
 import io.jenkins.plugins.prism.Sanitizer;
 import io.jenkins.plugins.util.JenkinsFacade;
@@ -342,14 +343,26 @@ public abstract class DuplicateCodeScanner extends AnalysisModelParser {
             List<TableColumn> columns = new ArrayList<>();
 
             columns.add(createDetailsColumn());
-            columns.add(createFileColumn().setWidth(2));
+            columns.add(createFileColumn());
             if (getReport().hasPackages()) {
-                columns.add(new TableColumn(Messages.DRY_Table_Column_Package(), "packageName").setWidth(2));
+                columns.add(createPackageColumn());
             }
-            columns.add(new TableColumn(Messages.DRY_Table_Column_Severity(), "severity"));
-            columns.add(new TableColumn(Messages.DRY_Table_Column_LinesCount(), "linesCount")
-                    .setHeaderClass(ColumnCss.NUMBER));
-            columns.add(new TableColumn(Messages.DRY_Table_Column_DuplicatedIn(), "duplicatedIn").setWidth(3));
+            TableColumn severity = new ColumnBuilder().withHeaderLabel(Messages.DRY_Table_Column_Severity())
+                    .withDataPropertyKey("severity")
+                    .withResponsivePriority(100)
+                    .build();
+            columns.add(severity);
+            TableColumn linesCount = new ColumnBuilder().withHeaderLabel(Messages.DRY_Table_Column_LinesCount())
+                    .withDataPropertyKey("linesCount")
+                    .withResponsivePriority(5)
+                    .withHeaderClass(ColumnCss.NUMBER)
+                    .build();
+            columns.add(linesCount);
+            TableColumn duplicatedIn = new ColumnBuilder().withHeaderLabel(Messages.DRY_Table_Column_DuplicatedIn())
+                    .withDataPropertyKey("duplicatedIn")
+                    .withResponsivePriority(50)
+                    .build();
+            columns.add(duplicatedIn);
             columns.add(createAgeColumn());
             return columns;
         }

--- a/plugin/src/main/resources/issues/property.jelly
+++ b/plugin/src/main/resources/issues/property.jelly
@@ -22,15 +22,15 @@
         <table class="table table-hover table-striped display property-table" id="${property}" isLoaded="true">
           <colgroup>
             <col class="col-width-5"/>
-            <col class="col-width-1 text-right"/>
-            <col class="col-width-1 text-right" />
+            <col class="col-width-1 text-end"/>
+            <col class="col-width-1 text-end" />
             <col class="col-width-5"/>
           </colgroup>
           <thead>
             <tr>
               <th>${name}</th>
-              <th class="text-right">${%Total}</th>
-              <th class="text-right">${%New}</th>
+              <th class="text-end">${%Total}</th>
+              <th class="text-end">${%New}</th>
               <th class="no-sort">${%Distribution}</th>
             </tr>
           </thead>
@@ -44,8 +44,8 @@
                      data-bs-toggle="tooltip" data-bs-placement="left" title="${t.getToolTip(key)}">
                     ${t.getDisplayName(key)}</a>
                 </td>
-                <td class="text-right">${count}</td>
-                <td class="text-right">${newCount}</td>
+                <td class="text-end">${count}</td>
+                <td class="text-end">${newCount}</td>
                 <td>
                   <issues:severity-distribution max="${t.max}" error="${t.getErrorsCount(key)}"
                                                 high="${t.getHighCount(key)}"
@@ -56,8 +56,8 @@
             <tfoot>
               <tr>
                 <td>${%Total}</td>
-                <td class="text-right">${t.total}</td>
-                <td class="text-right">${t.totalNewIssues}</td>
+                <td class="text-end">${t.total}</td>
+                <td class="text-end">${t.totalNewIssues}</td>
                 <td/>
               </tr>
             </tfoot>

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
@@ -109,10 +109,6 @@ public abstract class AbstractDetailsModelTest {
         return model.getColumns().stream().map(TableColumn::getHeaderLabel);
     }
 
-    protected Stream<Integer> getWidths(final DetailsTableModel model) {
-        return model.getColumns().stream().map(TableColumn::getWidth);
-    }
-
     protected JenkinsFacade createJenkinsFacade() {
         JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
         when(jenkinsFacade.getImagePath(anyString())).thenReturn("/path/to/icon");
@@ -127,11 +123,7 @@ public abstract class AbstractDetailsModelTest {
     }
 
     protected void verifyFileNameColumn(final String columnDefinitions) {
-        assertThatJson(columnDefinitions).node("[1].type")
-                .isEqualTo("string");
-        assertThatJson(columnDefinitions).node("[1].render._")
-                .isEqualTo("display");
-        assertThatJson(columnDefinitions).node("[1].render.sort")
-                .isEqualTo("sort");
+        assertThatJson(columnDefinitions).node("[1].render._").isEqualTo("display");
+        assertThatJson(columnDefinitions).node("[1].render.sort").isEqualTo("sort");
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
@@ -6,6 +6,8 @@ import java.util.stream.Stream;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.BeforeAll;
 
+import com.google.errorprone.annotations.MustBeClosed;
+
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.Severity;
@@ -14,8 +16,8 @@ import hudson.model.Run;
 
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.DefaultAgeBuilder;
 import io.jenkins.plugins.analysis.core.util.BuildFolderFacade;
+import io.jenkins.plugins.datatables.DetailedCell;
 import io.jenkins.plugins.datatables.TableColumn;
-import io.jenkins.plugins.datatables.TableModel.DetailedColumnDefinition;
 import io.jenkins.plugins.util.JenkinsFacade;
 
 import static j2html.TagCreator.*;
@@ -42,6 +44,7 @@ public abstract class AbstractDetailsModelTest {
                     + DETAILS_ICON + "</div>",
             StringEscapeUtils.escapeHtml4(MESSAGE), StringEscapeUtils.escapeHtml4(DESCRIPTION));
 
+    @MustBeClosed
     private IssueBuilder createBuilder() {
         return new IssueBuilder().setMessage(MESSAGE);
     }
@@ -96,7 +99,7 @@ public abstract class AbstractDetailsModelTest {
         return new DefaultAgeBuilder(1, "url");
     }
 
-    protected void assertThatDetailedColumnContains(final DetailedColumnDefinition actualColumn,
+    protected void assertThatDetailedColumnContains(final DetailedCell<String> actualColumn,
             final String expectedDisplayName, final String expectedSortOrder) {
         assertThat(actualColumn.getDisplay()).isEqualTo(expectedDisplayName);
         assertThat(actualColumn.getSort()).isEqualTo(expectedSortOrder);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/BlamesModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/BlamesModelTest.java
@@ -45,8 +45,6 @@ class BlamesModelTest extends AbstractDetailsModelTest {
 
         assertThat(getLabels(model))
                 .containsExactly("Details", "File", "Age", "Author", "Email", "Commit", "Added", "Hiddendetails");
-        assertThat(getWidths(model))
-                .containsExactly(1, 1, 1, 1, 1, 1, 1, 0);
 
         assertThat(model.getRows()).hasSize(2);
     }
@@ -92,7 +90,7 @@ class BlamesModelTest extends AbstractDetailsModelTest {
 
         BlamesRow actualRow = model.getRow(issue);
         assertThat(actualRow.getDescription()).isEqualTo(EXPECTED_DESCRIPTION);
-        
+
         assertThat(actualRow).hasDescription(EXPECTED_DESCRIPTION)
                 .hasAge("1")
                 .hasCommit(BlamesModel.UNDEFINED)

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ForensicsModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ForensicsModelTest.java
@@ -43,8 +43,6 @@ class ForensicsModelTest extends AbstractDetailsModelTest {
         assertThat(getLabels(model))
                 .containsExactly("Details", "File", "Age", "#Authors",
                         "#Commits", "Last Commit", "Added", "#LoC", "Code Churn", "Hiddendetails");
-        assertThat(getWidths(model))
-                .containsExactly(1, 2, 1, 1, 1, 2, 2, 1, 1, 0);
 
         assertThat(model.getRows()).hasSize(2);
     }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IssuesModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IssuesModelTest.java
@@ -62,27 +62,19 @@ class IssuesModelTest extends AbstractDetailsModelTest {
         DetailsTableModel model = createModel(report);
         assertThat(getLabels(model))
                 .containsExactly("Details", "File", "Severity", "Age", "Hiddendetails");
-        assertThat(getWidths(model))
-                .containsExactly(1, 1, 1, 1, 0);
         assertThat(model.getRows()).hasSize(1);
 
         when(report.hasPackages()).thenReturn(true);
         assertThat(getLabels(model))
                 .containsExactly("Details", "File", "Package", "Severity", "Age", "Hiddendetails");
-        assertThat(getWidths(model))
-                .containsExactly(1, 1, 2, 1, 1, 0);
 
         when(report.hasCategories()).thenReturn(true);
         assertThat(getLabels(model))
                 .containsExactly("Details", "File", "Package", "Category", "Severity", "Age", "Hiddendetails");
-        assertThat(getWidths(model))
-                .containsExactly(1, 1, 2, 1, 1, 1, 0);
 
         when(report.hasTypes()).thenReturn(true);
         assertThat(getLabels(model))
                 .containsExactly("Details", "File", "Package", "Category", "Type", "Severity", "Age", "Hiddendetails");
-        assertThat(getWidths(model))
-                .containsExactly(1, 1, 2, 1, 1, 1, 1, 0);
     }
 
     private IssuesModel createModel(final Report report) {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/DryTableModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/DryTableModelTest.java
@@ -63,8 +63,6 @@ class DryTableModelTest extends AbstractDetailsModelTest {
 
             assertThat(getLabels(model))
                     .containsExactly("Details", "File", "Severity", "#Lines", "Duplicated In", "Age");
-            assertThat(getWidths(model))
-                    .containsExactly(1, 2, 1, 1, 3, 1);
 
             DuplicationRow actualRow = model.getRow(issue);
             assertThat(actualRow)

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -20,7 +20,6 @@
     <json-smart.version>2.3</json-smart.version>
     <json-unit-assertj.version>2.35.0</json-unit-assertj.version>
     <module.name>${project.groupId}.warnings.ui.tests</module.name>
-    <codingstyle.config.version>2.24.0</codingstyle.config.version>
   </properties>
 
   <dependencyManagement>

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/ArchitectureTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/ArchitectureTest.java
@@ -18,7 +18,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 @AnalyzeClasses(packages = "io.jenkins.plugins.analysis")
 class ArchitectureTest {
     @ArchTest
-    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchitectureRules.NO_PUBLIC_ARCHITECTURE_TESTS;
+    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS;
 
     @ArchTest
     static final ArchRule NO_TEST_API_CALLED = ArchitectureRules.NO_TEST_API_CALLED;


### PR DESCRIPTION
Using the width option does not work as expected so it makes more sense to let DataTables internal code decide which width should be used for each column. If the columns do not fit on the page then columns will be hidden according the specified `responsivePriority`.