### PR TITLE
Use category if type is empty when publishing checks 

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -55,6 +55,10 @@ class WarningChecksPublisher {
         PUBLISH_NEW_ISSUES
     }
 
+    // fallback name for issue type / category.
+    // see: https://github.com/jenkinsci/analysis-model/blob/edf2a00e96bd2372da4f1fe34a226b984b7e0961/src/main/java/edu/hm/hafner/analysis/Issue.java#L30
+    private static final String UNDEFINED_ISSUE_STRING = "-";
+
     private final ResultAction action;
     private final TaskListener listener;
     @CheckForNull
@@ -215,7 +219,7 @@ class WarningChecksPublisher {
         for (Issue issue : issues) {
             ChecksAnnotationBuilder builder = new ChecksAnnotationBuilder()
                     .withPath(issue.getFileName())
-                    .withTitle(issue.getType())
+                    .withTitle(getIssueTitle(issue))
                     .withAnnotationLevel(ChecksAnnotationLevel.WARNING)
                     .withMessage(issue.getSeverity() + ":\n" + parseHtml(issue.getMessage()))
                     .withStartLine(issue.getLineStart())
@@ -252,5 +256,14 @@ class WarningChecksPublisher {
                 parseHtml(child, contents);
             }
         }
+    }
+
+    private static String getIssueTitle(final Issue issue) {
+        String title = issue.getType();
+        if (StringUtils.isBlank(title) || UNDEFINED_ISSUE_STRING.equals(title)) {
+            title = issue.getCategory();
+        }
+
+        return title;
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -45,7 +45,7 @@ import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
  *
  * @author Kezhi Xiong
  */
-@SuppressWarnings({"ClassDataAbstractionCouplingCheck", "ClassFanOutComplexityCheck"})
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String OLD_CHECKSTYLE_REPORT = "checkstyle.xml";
     private static final String NEW_CHECKSTYLE_REPORT = "checkstyle1.xml";

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -23,6 +23,7 @@ import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSu
 import io.jenkins.plugins.analysis.core.util.QualityGate.QualityGateResult;
 import io.jenkins.plugins.analysis.core.util.QualityGate.QualityGateType;
 import io.jenkins.plugins.analysis.warnings.CheckStyle;
+import io.jenkins.plugins.analysis.warnings.MsBuild;
 import io.jenkins.plugins.analysis.warnings.PVSStudio;
 import io.jenkins.plugins.analysis.warnings.Pmd;
 import io.jenkins.plugins.checks.api.ChecksAnnotation.ChecksAnnotationBuilder;
@@ -44,6 +45,7 @@ import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
  *
  * @author Kezhi Xiong
  */
+@SuppressWarnings({"ClassDataAbstractionCouplingCheck", "ClassFanOutComplexityCheck"})
 class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String OLD_CHECKSTYLE_REPORT = "checkstyle.xml";
     private static final String NEW_CHECKSTYLE_REPORT = "checkstyle1.xml";
@@ -360,6 +362,26 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
 
         assertThat(publishedChecks.get(1).getOutput()).isPresent().hasValueSatisfying(
                 output -> assertThat(output.getTitle()).isPresent().get().isEqualTo("No new issues, 6 total."));
+    }
+
+    /**
+     * Verifies that {@link WarningChecksPublisher} uses issue category when type is not provided.
+     */
+    @Test
+    void shouldFallbackToIssueCategory() {
+        FreeStyleProject project = createFreeStyleProject();
+        enableWarnings(project, createTool(new MsBuild(), "msbuild.log"));
+
+        buildSuccessfully(project);
+
+        copySingleFileToWorkspace(project, "msbuild.log");
+        Run<?, ?> run = buildSuccessfully(project);
+
+        WarningChecksPublisher publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
+        ChecksDetails details = publisher.extractChecksDetails(AnnotationScope.PUBLISH_NEW_ISSUES);
+
+        assertThat(details.getOutput().get().getChecksAnnotations().get(0))
+                .hasFieldOrPropertyWithValue("title", Optional.of("C4101"));
     }
 
     private ChecksDetails createExpectedCheckStyleDetails() {

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/core/steps/msbuild.log
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/core/steps/msbuild.log
@@ -1,0 +1,11 @@
+[1/10] Building CXX object CMakeFiles\merge_count.dir\merge_count.cpp.obj
+[2/10] Building CXX object CMakeFiles\palyndrome.dir\palyndrome.cpp.obj
+[3/10] Building CXX object CMakeFiles\bubble.dir\bubble.cpp.obj
+..\bubble.cpp(17): warning C4101: 'a': unreferenced local variable
+[4/10] Building CXX object CMakeFiles\merge.dir\merge.cpp.obj
+[5/10] Building CXX object CMakeFiles\olymp.dir\olymp.cpp.obj
+[6/10] Linking CXX executable merge_count.exe
+[7/10] Linking CXX executable bubble.exe
+[8/10] Linking CXX executable palyndrome.exe
+[9/10] Linking CXX executable merge.exe
+[10/10] Linking CXX executable olymp.exe


### PR DESCRIPTION
When using ChecksPublisher to publish warnings generated by MsBuild, the annotations title is mostly empty (`-`) because MsBuild parser creates issues with only a `category` when it can't determine both the issue `category` and the issue `type`. 
So the real problem is that the MsBuild parser misuses the issue 'category' but I think changing it would be a brackig change (e.g. breaks issue filters) and only changing the 'visualization' is the 'safer' way. And eventually there are other parsers that have the same 'problem' and this way the user gets more information about the issue.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
