### PR TITLE
Support plugin compatibility tester (PCT)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <java.version>1.8</java.version>
+    <hpi-plugin.version>3.32</hpi-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -31,6 +32,11 @@
         <configuration>
           <skip>true</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>${hpi-plugin.version}</version>
       </plugin>
     </plugins>
     <pluginManagement>

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -16,7 +16,7 @@
   <name>UI Tests of Warnings Plugin</name>
 
   <properties>
-    <jenkins.version>2.363</jenkins.version>
+    <jenkins.version>2.361</jenkins.version>
     <hpi-plugin.version>3.32</hpi-plugin.version>
     <json-smart.version>2.3</json-smart.version>
     <json-unit-assertj.version>2.35.0</json-unit-assertj.version>

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <jenkins.version>2.361</jenkins.version>
+    <hpi-plugin.version>3.32</hpi-plugin.version>
     <json-smart.version>2.3</json-smart.version>
     <json-unit-assertj.version>2.35.0</json-unit-assertj.version>
     <module.name>${project.groupId}.warnings.ui.tests</module.name>
@@ -230,6 +231,11 @@
             </manifestEntries>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>${hpi-plugin.version}</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
### Background

See https://github.com/jenkinsci/bom/pull/1384#discussion_r940755394.

### Problem

When plugin compatibility tester (PCT) tests this plugin, it runs `mvn […] hpi:resolve-test-dependencies hpi:test-hpl surefire:test failsafe:integration-test failsafe:integration-test`, expecting all Jenkins plugins to have `hpi:resolve-test-dependencies` and `hpi:test-hpl` goals in all Maven modules. This plugin does not comply with the expectation, so PCT fails with:

> [ERROR] No plugin found for prefix 'hpi' in the current project and in the plugin groups [org.apache.maven.plugins, org.codehaus.mojo] available from the repositories [local (/home/basil/.m2/repository), central (https://repo.maven.apache.org/maven2)] -> [Help 1]

### Solution

The parent POM layout of this plugin is highly non-standard and would benefit from being standardized. In the short term we simply add the `maven-hpi-plugin` to the two projects in the Maven multi-module build that do not already have it. This chases the PCT problem away.

CC @uhafner