### PR TITLE
[JENKINS-55445]: recordIssues doesn't use unique IDs when calling this step in multiple stages

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -749,7 +749,7 @@ public class IssuesRecorder extends Recorder {
         }
         else {
             for (Tool tool : analysisTools) {
-                AnnotatedReport report = new AnnotatedReport(tool.getActualId());
+                AnnotatedReport report = new AnnotatedReport(StringUtils.defaultIfEmpty(id, tool.getActualId()));
                 if (isAggregatingResults) {
                     report.logInfo("Ignoring 'aggregatingResults' and ID '%s' since only a single tool is defined.",
                             id);


### PR DESCRIPTION
[JENKINS-55445](https://issues.jenkins.io/browse/JENKINS-55445): According to the [documentation for the recordIssues step](https://www.jenkins.io/doc/pipeline/steps/warnings-ng/#recordissues-record-compiler-warnings-and-static-analysis-results), populating the `id` argument should create its own unique URL. This does not happen if the step isn't set to be aggregated or have more than one tool. If you call this step twice with unique `id`s, unless the two steps begin at exactly the same time, only one will pass and the others will fail: since the report already exists with a unique ID (i.e. the tool's name), one can never make another one. _This was especially relevant to trying to perform these actions in parallel/matrix stage configurations._

Resolution: attempt to use the ID passed into it first, and if unavailable, it will use the tool ID.

Side note: I've never done professional development in Java or IntelliJ, I'm just trying to fix a problem that's blocking my team. If there's a better way of doing this, or some things I am missing about the context of this project, please let me know. I also unfortunately don't really know how to self-test this either, but I'm open to any advice.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
