### PR TITLE
Bump version of ATH to 5460

### DIFF
--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>acceptance-test-harness</artifactId>
-      <version>1.118</version>
+      <version>5460.va_c8a_323c73b_a</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Since 1.118 ATH switched to CD.

See https://github.com/jenkinsci/acceptance-test-harness/releases