### PR TITLE
Optional suppress file report by system property

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -607,6 +607,16 @@ node {
 }
 ``` 
   
+### Parsed files logging
+
+By default parsed file generates console output with number of found issues. This behaviour can be overriden by system property `io.jenkins.plugins.analysis.core.model.FilesScanner.logParsedFiles`.
+Jenkins service configuration suppressing such console output would then be like:
+
+```
+[Service]
+Environment="JAVA_OPTS=-Dio.jenkins.plugins.analysis.core.model.FilesScanner.logParsedFiles=false"
+```
+
 ## New features
 
 The most important new features are described in the following sections. 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/FilesScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/FilesScanner.java
@@ -34,6 +34,7 @@ public class FilesScanner extends MasterToSlaveFileCallable<Report> {
     private final IssueParser parser;
     private final String encoding;
     private final boolean followSymbolicLinks;
+    private final boolean stdoutReport;
 
     /**
      * Creates a new instance of {@link FilesScanner}.
@@ -55,6 +56,8 @@ public class FilesScanner extends MasterToSlaveFileCallable<Report> {
         this.parser = parser;
         this.encoding = encoding;
         this.followSymbolicLinks = followSymbolicLinks;
+        String stdoutReportProp = System.getProperty("warningsNgStdoutReport");
+        this.stdoutReport = stdoutReportProp == null ? true : Boolean.parseBoolean(stdoutReportProp);
     }
 
     @Override
@@ -106,10 +109,12 @@ public class FilesScanner extends MasterToSlaveFileCallable<Report> {
 
             aggregatedReport.addAll(fileReport);
             aggregatedReport.setOriginReportFile(file.toString());
-            aggregatedReport.logInfo("Successfully parsed file %s", file);
-            aggregatedReport.logInfo("-> found %s (skipped %s)",
-                    plural(fileReport.getSize(), "issue"),
-                    plural(fileReport.getDuplicatesSize(), "duplicate"));
+            if (stdoutReport) {
+                aggregatedReport.logInfo("Successfully parsed file %s", file);
+                aggregatedReport.logInfo("-> found %s (skipped %s)",
+                        plural(fileReport.getSize(), "issue"),
+                        plural(fileReport.getDuplicatesSize(), "duplicate"));
+            }
         }
         catch (ParsingException exception) {
             aggregatedReport.logException(exception, "Parsing of file '%s' failed due to an exception:", file);

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/FilesScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/FilesScanner.java
@@ -56,8 +56,8 @@ public class FilesScanner extends MasterToSlaveFileCallable<Report> {
         this.parser = parser;
         this.encoding = encoding;
         this.followSymbolicLinks = followSymbolicLinks;
-        String stdoutReportProp = System.getProperty("warningsNgStdoutReport");
-        this.stdoutReport = stdoutReportProp == null ? true : Boolean.parseBoolean(stdoutReportProp);
+        String stdoutReportProp = System.getProperty("io.jenkins.plugins.analysis.core.model.FilesScanner.logParsedFiles");
+        this.stdoutReport = stdoutReportProp == null || Boolean.parseBoolean(stdoutReportProp);
     }
 
     @Override


### PR DESCRIPTION
Goal: reduce console output in jenkins job when printing file name and num of issues found.
Change: added reading of specific system property `warningsNgStdoutReport`. By default use current behaviour - print report for every file.
Usage: add property to jenkins service cfg in override.conf:
```shell
[Service]
Environment="JAVA_OPTS=-DwarningsNgStdoutReport=false"
```
https://issues.jenkins.io/browse/JENKINS-69907

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
