### PR TITLE
[JENKINS-70172] Use project configure permission for reset quality gate action

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommand.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommand.java
@@ -79,7 +79,7 @@ public class ResetQualityGateCommand {
      * @return {@code true} if the command is enabled, {@code false} otherwise
      */
     public boolean isEnabled(final Run<?, ?> selectedBuild, final String id) {
-        if (!jenkinsFacade.hasPermission(Item.CONFIGURE)) {
+        if (!selectedBuild.hasPermission(Item.CONFIGURE) && !jenkinsFacade.hasPermission(Item.CONFIGURE)) {
             return false;
         }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommandTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommandTest.java
@@ -34,18 +34,29 @@ class ResetQualityGateCommandTest {
 
         command.setJenkinsFacade(configureCorrectUserRights(true));
         ResultAction resultAction = createResultAction(status, ID);
-        FreeStyleBuild selectedBuild = attachReferenceBuild(true, resultAction);
+        FreeStyleBuild selectedBuild = attachReferenceBuild(true, false, resultAction);
 
         assertThat(command.isEnabled(selectedBuild, ID)).isTrue();
     }
 
     @Test
-    void shouldBeDisabledIfUserHasNoConfigureRights() {
+    void shouldBeEnabledIfUserHasLocalConfigureRights() {
         ResetQualityGateCommand command = new ResetQualityGateCommand();
 
         command.setJenkinsFacade(configureCorrectUserRights(false));
         ResultAction resultAction = createResultAction(QualityGateStatus.WARNING, ID);
-        FreeStyleBuild selectedBuild = attachReferenceBuild(true, resultAction);
+        FreeStyleBuild selectedBuild = attachReferenceBuild(true, true, resultAction);
+
+        assertThat(command.isEnabled(selectedBuild, ID)).isTrue();
+    }
+
+    @Test
+    void shouldBeDisabledIfUserHasNoConfigureRightsAtAll() {
+        ResetQualityGateCommand command = new ResetQualityGateCommand();
+
+        command.setJenkinsFacade(configureCorrectUserRights(false));
+        ResultAction resultAction = createResultAction(QualityGateStatus.WARNING, ID);
+        FreeStyleBuild selectedBuild = attachReferenceBuild(true, false, resultAction);
 
         assertThat(command.isEnabled(selectedBuild, ID)).isFalse();
     }
@@ -56,7 +67,7 @@ class ResetQualityGateCommandTest {
 
         command.setJenkinsFacade(configureCorrectUserRights(true));
         ResultAction resultAction = createResultAction(QualityGateStatus.WARNING, ID);
-        FreeStyleBuild selectedBuild = attachReferenceBuild(false, resultAction);
+        FreeStyleBuild selectedBuild = attachReferenceBuild(false, false, resultAction);
         when(selectedBuild.getActions(ResultAction.class)).thenReturn(Lists.list(resultAction));
 
         assertThat(command.isEnabled(selectedBuild, ID)).isFalse();
@@ -68,7 +79,7 @@ class ResetQualityGateCommandTest {
 
         command.setJenkinsFacade(configureCorrectUserRights(true));
         ResultAction resultAction = createResultAction(QualityGateStatus.PASSED, ID);
-        FreeStyleBuild selectedBuild = attachReferenceBuild(true, resultAction);
+        FreeStyleBuild selectedBuild = attachReferenceBuild(true, false, resultAction);
         when(selectedBuild.getActions(ResultAction.class)).thenReturn(Lists.list(resultAction));
 
         assertThat(command.isEnabled(selectedBuild, ID)).isFalse();
@@ -93,7 +104,7 @@ class ResetQualityGateCommandTest {
 
         command.setJenkinsFacade(configureCorrectUserRights(true));
         ResultAction resultAction = createResultAction(QualityGateStatus.WARNING, "other");
-        FreeStyleBuild selectedBuild = attachReferenceBuild(true, resultAction);
+        FreeStyleBuild selectedBuild = attachReferenceBuild(true, false, resultAction);
         when(selectedBuild.getActions(ResultAction.class)).thenReturn(Lists.list(resultAction));
 
         assertThat(command.isEnabled(selectedBuild, ID)).isFalse();
@@ -105,7 +116,7 @@ class ResetQualityGateCommandTest {
 
         command.setJenkinsFacade(configureCorrectUserRights(true));
         ResultAction resultAction = createResultAction(QualityGateStatus.WARNING, ID);
-        FreeStyleBuild selectedBuild = attachReferenceBuild(true, resultAction);
+        FreeStyleBuild selectedBuild = attachReferenceBuild(true, false, resultAction);
         FreeStyleBuild next = mock(FreeStyleBuild.class);
         when(selectedBuild.getNextBuild()).thenReturn(next);
 
@@ -134,12 +145,13 @@ class ResetQualityGateCommandTest {
     }
 
     private FreeStyleBuild attachReferenceBuild(final boolean hasNoReferenceBuild,
-            final ResultAction resultAction) {
+            final boolean hasRight, final ResultAction resultAction) {
         FreeStyleBuild selectedBuild = mock(FreeStyleBuild.class);
         when(selectedBuild.getActions(ResetReferenceAction.class)).thenReturn(
                 Lists.list(new ResetReferenceAction(hasNoReferenceBuild ? "other" : ID)));
         when(selectedBuild.getActions(ResultAction.class)).thenReturn(Lists.list(resultAction));
         when(selectedBuild.getAction(ResultAction.class)).thenReturn(resultAction);
+        when(selectedBuild.hasPermission(Item.CONFIGURE)).thenReturn(hasRight);
         return selectedBuild;
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommandTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommandTest.java
@@ -151,7 +151,7 @@ class ResetQualityGateCommandTest {
                 Lists.list(new ResetReferenceAction(hasNoReferenceBuild ? "other" : ID)));
         when(selectedBuild.getActions(ResultAction.class)).thenReturn(Lists.list(resultAction));
         when(selectedBuild.getAction(ResultAction.class)).thenReturn(resultAction);
-        when(selectedBuild.hasPermission(Item.CONFIGURE)).thenReturn(hasRight);
+        when(selectedBuild.hasPermission(Item.CONFIGURE)).thenReturn(hasConfigurePermission);
         return selectedBuild;
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommandTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ResetQualityGateCommandTest.java
@@ -145,7 +145,7 @@ class ResetQualityGateCommandTest {
     }
 
     private FreeStyleBuild attachReferenceBuild(final boolean hasNoReferenceBuild,
-            final boolean hasRight, final ResultAction resultAction) {
+            final boolean hasConfigurePermission, final ResultAction resultAction) {
         FreeStyleBuild selectedBuild = mock(FreeStyleBuild.class);
         when(selectedBuild.getActions(ResetReferenceAction.class)).thenReturn(
                 Lists.list(new ResetReferenceAction(hasNoReferenceBuild ? "other" : ID)));


### PR DESCRIPTION
[JENKINS-70172](https://issues.jenkins.io/browse/JENKINS-70172)

Currently only users with the global configure right see and may click the "Reset quality gate" button.

Useres that may configure the job/build should also be able to reset the quality gate.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

