### PR TITLE
Align version of plugin-util-api plugin in test and compile dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ pom.xml.releaseBackup
 release.properties
 .DS_Store
 /package-lock.json
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.releaseBackup
 release.properties
 .DS_Store
 /package-lock.json
+.idea

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,7 +25,7 @@
     <changelist>-SNAPSHOT</changelist>
     <module.name>${project.groupId}.warnings.ng</module.name>
 
-    <analysis-model-api.version>10.20.0</analysis-model-api.version>
+    <analysis-model-api.version>10.21.0</analysis-model-api.version>
     <analysis-model-tests.version>${analysis-model-api.version}</analysis-model-tests.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
     <prism-api.version>1.29.0-1</prism-api.version>
@@ -51,6 +51,7 @@
 
     <!-- Maven Surefire ArgLine -->
     <argLine>-Djava.awt.headless=true -Xmx1024m -Djenkins.test.timeout=1000 --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED</argLine>
+    <plugin-util-api.version>2.20.0</plugin-util-api.version>
   </properties>
 
   <licenses>
@@ -101,7 +102,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>2.20.0</version>
+      <version>${plugin-util-api.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -311,6 +312,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>${plugin-util-api.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
       <exclusions>

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
@@ -10,6 +10,7 @@ import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import edu.hm.hafner.analysis.ParsingCanceledException;
 import edu.hm.hafner.util.ArchitectureRules;
@@ -47,7 +48,7 @@ class PluginArchitectureTest {
     static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
 
     @ArchTest
-    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchitectureRules.NO_PUBLIC_ARCHITECTURE_TESTS;
+    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchRuleDefinition.fields().that().areAnnotatedWith(ArchTest.class).should().notBePublic();
 
     @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
@@ -48,7 +48,7 @@ class PluginArchitectureTest {
     static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
 
     @ArchTest
-    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchRuleDefinition.fields().that().areAnnotatedWith(ArchTest.class).should().notBePublic();
+    static final ArchRule ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules. ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS;
 
     @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
@@ -10,7 +10,6 @@ import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import edu.hm.hafner.analysis.ParsingCanceledException;
 import edu.hm.hafner.util.ArchitectureRules;

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/PluginArchitectureTest.java
@@ -47,7 +47,7 @@ class PluginArchitectureTest {
     static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
 
     @ArchTest
-    static final ArchRule ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules. ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS;
+    static final ArchRule ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS;
 
     @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;


### PR DESCRIPTION
Tests and hpi runtime was using different versions causing test compilation errors when running with PCT.

Related: https://github.com/jenkinsci/prism-api-plugin/pull/72

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
