### PR TITLE
Remove deprecated ACL.SYSTEM constant usage

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/axivion/AxivionSuite.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/axivion/AxivionSuite.java
@@ -41,7 +41,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -124,7 +123,7 @@ public final class AxivionSuite extends Tool {
      * names.
      *
      * @param projectUrl
-     *         url to a Axivion dashboard project
+     *         url to an Axivion dashboard project
      */
     @DataBoundSetter
     public void setProjectUrl(final String projectUrl) {
@@ -213,10 +212,10 @@ public final class AxivionSuite extends Tool {
                 CredentialsProvider.lookupCredentials(
                         StandardUsernamePasswordCredentials.class,
                         (Item) null,
-                        ACL.SYSTEM,
+                        null,
                         Collections.emptyList());
 
-        StandardUsernamePasswordCredentials jenkinsCredentials =
+        final StandardUsernamePasswordCredentials jenkinsCredentials =
                 CredentialsMatchers.firstOrNull(all,
                         CredentialsMatchers.withId(credentialsId));
 
@@ -369,7 +368,7 @@ public final class AxivionSuite extends Tool {
                     CredentialsProvider.lookupCredentials(
                             StandardUsernamePasswordCredentials.class,
                             item,
-                            ACL.SYSTEM,
+                            null,
                             Collections.emptyList()),
                     CredentialsMatchers.withId(credentialsId))
                     == null) {
@@ -391,7 +390,7 @@ public final class AxivionSuite extends Tool {
         @POST
         public ListBoxModel doFillCredentialsIdItems(
                 @AncestorInPath final Item item, @QueryParameter final String credentialsId) {
-            StandardListBoxModel result = new StandardListBoxModel();
+            final StandardListBoxModel result = new StandardListBoxModel();
             if (item == null) {
                 if (!JENKINS.hasPermission(Jenkins.ADMINISTER)) {
                     return result.includeCurrentValue(credentialsId);
@@ -403,12 +402,17 @@ public final class AxivionSuite extends Tool {
                     return result.includeCurrentValue(credentialsId);
                 }
             }
-            return result.includeAs(
-                            ACL.SYSTEM,
-                            item,
-                            StandardUsernamePasswordCredentials.class,
-                            Collections.emptyList())
-                    .includeCurrentValue(credentialsId);
+
+            final ListBoxModel credentials = CredentialsProvider.listCredentials(
+                    StandardUsernamePasswordCredentials.class,
+                    item,
+                    null,
+                    Collections.emptyList(),
+                    CredentialsMatchers.always()
+            );
+
+            result.addMissing(credentials);
+            return result.includeCurrentValue(credentialsId);
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

ACL.SYSTEM can be safely replaced with null as the "authentication" argument. 
The credential api defaults to ACL.SYSTEM so Jenkins maintainers will need to replace the ACL.SYSTEM usages in the credential api. There are no ACL.SYSTEM2 equivalents yet.
