### PR TITLE
Allow plugin to be included in BOM

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -235,6 +235,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>config-file-provider</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
When attempting to add this plugin to `jenkinsci/bom`, I received the following error when testing locally against the megawar:

```
[ERROR]   ConfigurationAsCodeITest.shouldCreateFreestyleJobUsingJobDsl:108->configureJenkins:134 » NoClassDefFound org/jenkinsci/plugins/configfiles/GlobalConfigFiles
[ERROR]   ConfigurationAsCodeITest.shouldFreestyleJobWithSpotBugsUsingJobDsl:69->configureJenkins:134 » NoClassDefFound org/jenkinsci/plugins/configfiles/GlobalConfigFiles
[ERROR]   ConfigurationAsCodeITest.shouldFreestyleJobWithTaskScannerUsingJobDsl:86->configureJenkins:134 » NoClassDefFound org/jenkinsci/plugins/configfiles/GlobalConfigFiles
[ERROR]   JobDslITest.shouldCreateFreestyleJobUsingJobDslAndVerifyIssueRecorderWithDefaultConfiguration:36->configureJenkins:126 » NoClassDefFound org/jenkinsci/plugins/configfiles/GlobalConfigFiles
[ERROR]   JobDslITest.shouldCreateFreestyleJobUsingJobDslAndVerifyIssueRecorderWithValuesSet:78->configureJenkins:126 » NoClassDefFound org/jenkinsci/plugins/configfiles/GlobalConfigFiles
```

This is a known issue that we have seen when adding other plugins to the BOM, and we have applied the same workaround in each case. Applying the usual workaround to this plugin chased away the issue as expected in my local testing, enabling this plugin to be added to `jenkinsci/bom`.