### PR TITLE
Do not use format method when simply copying log messages

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,8 +25,8 @@
     <changelist>-SNAPSHOT</changelist>
     <module.name>${project.groupId}.warnings.ng</module.name>
 
-    <analysis-model-api.version>11.0.0</analysis-model-api.version>
-    <analysis-model-tests.version>11.0.0</analysis-model-tests.version>
+    <analysis-model-api.version>11.0.1</analysis-model-api.version>
+    <analysis-model-tests.version>${analysis-model-api.version}</analysis-model-tests.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
@@ -187,8 +187,7 @@ public abstract class ReportScanningTool extends Tool {
             else {
                 aggregation = new Report(results);
             }
-            log.getInfoMessages().forEach(aggregation::logInfo);
-            log.getErrorMessages().forEach(aggregation::logError);
+            aggregation.mergeLogMessages(log);
             return aggregation;
         }
         catch (IOException e) {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesPublisher.java
@@ -244,8 +244,7 @@ class IssuesPublisher {
                     log.logInfo("Obtaining reference build from same job (%s)", run.getParent().getDisplayName());
                     return run;
                 });
-        log.getInfoMessages().forEach(issues::logInfo);
-        log.getErrorMessages().forEach(issues::logError);
+        issues.mergeLogMessages(log);
         return reference;
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesScanner.java
@@ -118,8 +118,7 @@ class IssuesScanner {
         MinerService minerService = new MinerService();
         FilteredLog log = new FilteredLog("Errors while obtaining repository statistics");
         RepositoryStatistics statistics = minerService.queryStatisticsFor(scm, run, report.getFiles(), log);
-        log.getErrorMessages().forEach(report::logError);
-        log.getInfoMessages().forEach(report::logInfo);
+        report.mergeLogMessages(log);
         return statistics;
     }
 
@@ -172,8 +171,7 @@ class IssuesScanner {
             }
             Blamer blamer = BlamerFactory.findBlamer(scm, run, workspace, listener, log);
             log.logSummary();
-            log.getInfoMessages().forEach(report::logInfo);
-            log.getErrorMessages().forEach(report::logError);
+            report.mergeLogMessages(log);
 
             return blamer;
         }
@@ -286,8 +284,7 @@ class IssuesScanner {
             FilteredLog log = new FilteredLog("Errors while extracting author and commit information from Git:");
             Blames blames = blamer.blame(fileLocations, log);
             log.logSummary();
-            log.getInfoMessages().forEach(filtered::logInfo);
-            log.getErrorMessages().forEach(filtered::logError);
+            filtered.mergeLogMessages(log);
             return blames;
         }
 


### PR DESCRIPTION
Avoids similar problems as described in  [JENKINS-70804](https://issues.jenkins.io/browse/JENKINS-70804).