### PR TITLE
Add SCM section to `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,13 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
   </properties>
 
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://github.com/jenkinsci/warnings-ng-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/warnings-ng-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/warnings-ng-plugin</url>
+    <tag>${scmTag}</tag>
+  </scm>
+
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>


### PR DESCRIPTION
A future Maven multi-module aware version of PCT will require that every plugin has an `<scm>` section in its root `pom.xml` file. This PR proactively prepares this plugin to comply. The `child.scm.*.inherit.append.path` gibberish is part of the archetype and a standard practice in the Jenkins ecosystem for multi-module plugins to work around a surprising Maven behavior.