### PR TITLE
Fix syntax for parameter-less function in documentation

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -394,7 +394,7 @@ will be selected automatically by running the reference recorder step. Simply ca
 before any of static analysis steps:
 
 ```groovy
-discoverGitReferenceBuild
+discoverGitReferenceBuild()
 recordIssues tool: checkStyle(pattern: 'checkstyle-result.xml')
 ```
 


### PR DESCRIPTION
Functions cannot be called without brackets if they do not have any parameter. When copying the syntax from the documentation, it would not work for "discoverGitReferenceBuild"

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
