### PR TITLE
Make trend charts theme-aware

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -118,6 +118,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
+      <version>5.4.0-4-rc815.a_ff2e0060885</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
-      <version>5.4.0-4-rc815.a_ff2e0060885</version>
+      <version>5.4.0-4-rc819.ef2a_8d3f99c8</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
-      <version>5.4.0-4-rc819.ef2a_8d3f99c8</version>
+      <version>5.4.0-4-rc820.fc605555db_b_c</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
@@ -11,6 +11,7 @@ import edu.hm.hafner.echarts.Palette;
 
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 import io.jenkins.plugins.analysis.core.util.HealthDescriptor;
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the model for a trend chart showing all issues for a given number of builds. The issues are colored according
@@ -40,11 +41,11 @@ public class HealthTrendChart implements TrendChart {
         LinesChartModel model = new LinesChartModel(dataSet);
 
         if (healthDescriptor.isEnabled()) {
-            LineSeries healthy = createSeries(Messages.Healthy_Name(), Palette.GREEN);
+            LineSeries healthy = createSeries(Messages.Healthy_Name(), JenkinsPalette.GREEN);
             healthy.addAll(dataSet.getSeries(HealthSeriesBuilder.HEALTHY));
-            LineSeries intermediate = createSeries(Messages.Satisfactory_Name(), Palette.YELLOW);
+            LineSeries intermediate = createSeries(Messages.Satisfactory_Name(), JenkinsPalette.YELLOW);
             intermediate.addAll(dataSet.getSeries(HealthSeriesBuilder.BETWEEN));
-            LineSeries unhealthy = createSeries(Messages.Unhealthy_Name(), Palette.RED);
+            LineSeries unhealthy = createSeries(Messages.Unhealthy_Name(), JenkinsPalette.RED);
             unhealthy.addAll(dataSet.getSeries(HealthSeriesBuilder.UNHEALTHY));
             model.addSeries(healthy, intermediate, unhealthy);
         }
@@ -58,7 +59,7 @@ public class HealthTrendChart implements TrendChart {
         return model;
     }
 
-    private LineSeries createSeries(final String name, final Palette color) {
-        return new LineSeries(name, color.getNormal(), StackedMode.STACKED, FilledMode.FILLED);
+    private LineSeries createSeries(final String name, final JenkinsPalette color) {
+        return new LineSeries(name, color.normal(), StackedMode.STACKED, FilledMode.FILLED);
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
@@ -7,7 +7,6 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
 import io.jenkins.plugins.analysis.core.util.HealthDescriptor;
@@ -50,7 +49,7 @@ public class HealthTrendChart implements TrendChart {
             model.addSeries(healthy, intermediate, unhealthy);
         }
         else {
-            LineSeries total = new LineSeries(Messages.Total_Name(), Palette.YELLOW.getNormal(),
+            LineSeries total = new LineSeries(Messages.Total_Name(), JenkinsPalette.YELLOW.normal(),
                     StackedMode.SEPARATE_LINES, FilledMode.LINES);
             total.addAll(dataSet.getSeries(HealthSeriesBuilder.TOTAL));
             model.addSeries(total);

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedPieChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedPieChart.java
@@ -1,9 +1,10 @@
 package io.jenkins.plugins.analysis.core.charts;
 
 import edu.hm.hafner.analysis.Report;
-import edu.hm.hafner.echarts.Palette;
 import edu.hm.hafner.echarts.PieChartModel;
 import edu.hm.hafner.echarts.PieData;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the model for a pie chart showing the number of new, fixed, and outstanding issues.
@@ -26,9 +27,9 @@ public class NewVersusFixedPieChart {
     public PieChartModel create(final Report newIssues, final Report outstandingIssues, final Report fixedIssues) {
         PieChartModel model = new PieChartModel(Messages.NewVersusFixed_Name());
 
-        model.add(new PieData(Messages.New_Warnings_Short(), newIssues.size()), Palette.RED);
-        model.add(new PieData(Messages.Outstanding_Warnings_Short(), outstandingIssues.size()), Palette.YELLOW);
-        model.add(new PieData(Messages.Fixed_Warnings_Short(), fixedIssues.size()), Palette.GREEN);
+        model.add(new PieData(Messages.New_Warnings_Short(), newIssues.size()), JenkinsPalette.RED.normal());
+        model.add(new PieData(Messages.Outstanding_Warnings_Short(), outstandingIssues.size()), JenkinsPalette.YELLOW.normal());
+        model.add(new PieData(Messages.Fixed_Warnings_Short(), fixedIssues.size()), JenkinsPalette.GREEN.normal());
 
         return model;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChart.java
@@ -7,9 +7,9 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the model for a trend chart showing all new and fixed issues for a given number of builds.
@@ -24,9 +24,9 @@ public class NewVersusFixedTrendChart implements TrendChart {
         LinesDataSet dataSet = builder.createDataSet(configuration, results);
         LinesChartModel model = new LinesChartModel(dataSet);
 
-        LineSeries newSeries = getSeries(dataSet, Messages.New_Warnings_Short(), Palette.RED,
+        LineSeries newSeries = getSeries(dataSet, Messages.New_Warnings_Short(), JenkinsPalette.RED,
                 NewVersusFixedSeriesBuilder.NEW);
-        LineSeries fixedSeries = getSeries(dataSet, Messages.Fixed_Warnings_Short(), Palette.GREEN,
+        LineSeries fixedSeries = getSeries(dataSet, Messages.Fixed_Warnings_Short(), JenkinsPalette.GREEN,
                 NewVersusFixedSeriesBuilder.FIXED);
 
         model.addSeries(newSeries, fixedSeries);
@@ -35,8 +35,8 @@ public class NewVersusFixedTrendChart implements TrendChart {
     }
 
     private LineSeries getSeries(final LinesDataSet dataSet,
-            final String name, final Palette color, final String dataSetId) {
-        LineSeries newSeries = new LineSeries(name, color.getNormal(), StackedMode.SEPARATE_LINES, FilledMode.FILLED);
+            final String name, final JenkinsPalette color, final String dataSetId) {
+        LineSeries newSeries = new LineSeries(name, color.normal(), StackedMode.SEPARATE_LINES, FilledMode.FILLED);
         newSeries.addAll(dataSet.getSeries(dataSetId));
         return newSeries;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityPalette.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityPalette.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.analysis.core.charts;
 
 import edu.hm.hafner.analysis.Severity;
-import edu.hm.hafner.echarts.Palette;
 
 import io.jenkins.plugins.echarts.JenkinsPalette;
 
@@ -19,42 +18,18 @@ final class SeverityPalette {
      *
      * @return color of the specified severity
      */
-    static Palette getColor(final Severity severity) {
-        if (Severity.ERROR.equals(severity)) {
-            return Palette.RED;
-        }
-        if (Severity.WARNING_HIGH.equals(severity)) {
-            return Palette.ORANGE;
-        }
-        if (Severity.WARNING_NORMAL.equals(severity)) {
-            return Palette.YELLOW;
-        }
-        if (Severity.WARNING_LOW.equals(severity)) {
-            return Palette.LIME;
-        }
-        return Palette.PURPLE;
-    }
-
-    /**
-     * Returns the color of UI elements for the specified severity.
-     *
-     * @param severity
-     *         the severity to get the color for
-     *
-     * @return color of the specified severity
-     */
-    static JenkinsPalette getJenkinsPalette(final Severity severity) {
+    static JenkinsPalette mapToColor(final Severity severity) {
         if (Severity.ERROR.equals(severity)) {
             return JenkinsPalette.RED;
         }
         if (Severity.WARNING_HIGH.equals(severity)) {
-            return JenkinsPalette.ORANGE;
+            return JenkinsPalette.PINK;
         }
         if (Severity.WARNING_NORMAL.equals(severity)) {
-            return JenkinsPalette.YELLOW;
+            return JenkinsPalette.ORANGE;
         }
         if (Severity.WARNING_LOW.equals(severity)) {
-            return JenkinsPalette.INDIGO;
+            return JenkinsPalette.YELLOW;
         }
         return JenkinsPalette.BROWN;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityPalette.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityPalette.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.analysis.core.charts;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.echarts.Palette;
 
+import io.jenkins.plugins.echarts.JenkinsPalette;
+
 /**
  * Provides colors for {@link Severity}.
  *
@@ -31,6 +33,30 @@ final class SeverityPalette {
             return Palette.LIME;
         }
         return Palette.PURPLE;
+    }
+
+    /**
+     * Returns the color of UI elements for the specified severity.
+     *
+     * @param severity
+     *         the severity to get the color for
+     *
+     * @return color of the specified severity
+     */
+    static JenkinsPalette getJenkinsPalette(final Severity severity) {
+        if (Severity.ERROR.equals(severity)) {
+            return JenkinsPalette.RED;
+        }
+        if (Severity.WARNING_HIGH.equals(severity)) {
+            return JenkinsPalette.ORANGE;
+        }
+        if (Severity.WARNING_NORMAL.equals(severity)) {
+            return JenkinsPalette.YELLOW;
+        }
+        if (Severity.WARNING_LOW.equals(severity)) {
+            return JenkinsPalette.INDIGO;
+        }
+        return JenkinsPalette.BROWN;
     }
 
     private SeverityPalette() {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityPieChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityPieChart.java
@@ -28,7 +28,7 @@ public class SeverityPieChart {
             int total = report.getSizeOf(severity);
             if (total > 0 || !severity.equals(Severity.ERROR)) {
                 model.add(new PieData(LocalizedSeverity.getLocalizedString(severity), total),
-                        SeverityPalette.getColor(severity));
+                        SeverityPalette.mapToColor(severity).normal());
             }
         }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
@@ -66,7 +66,7 @@ public class SeverityTrendChart implements TrendChart {
 
     private LineSeries createSeries(final Severity severity) {
         return new LineSeries(LocalizedSeverity.getLocalizedString(severity),
-                SeverityPalette.getJenkinsPalette(severity).normal(),
+                SeverityPalette.mapToColor(severity).normal(),
                 StackedMode.STACKED, FilledMode.FILLED);
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
@@ -66,6 +66,7 @@ public class SeverityTrendChart implements TrendChart {
 
     private LineSeries createSeries(final Severity severity) {
         return new LineSeries(LocalizedSeverity.getLocalizedString(severity),
-                SeverityPalette.getColor(severity).getNormal(), StackedMode.STACKED, FilledMode.FILLED);
+                SeverityPalette.getJenkinsPalette(severity).normal(),
+                StackedMode.STACKED, FilledMode.FILLED);
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/ToolsTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/ToolsTrendChart.java
@@ -7,9 +7,9 @@ import edu.hm.hafner.echarts.LineSeries.FilledMode;
 import edu.hm.hafner.echarts.LineSeries.StackedMode;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 /**
  * Builds the line model for a trend chart showing the total number of issues per tool for a given number of builds.
@@ -25,14 +25,10 @@ public class ToolsTrendChart implements TrendChart {
 
         LinesChartModel model = new LinesChartModel(lineModel);
 
-        Palette[] colors = Palette.values();
         int index = 0;
         for (String name : lineModel.getDataSetIds()) {
-            LineSeries lineSeries = new LineSeries(name, colors[index++].getNormal(),
+            LineSeries lineSeries = new LineSeries(name, JenkinsPalette.chartColor(index++).normal(),
                     StackedMode.SEPARATE_LINES, FilledMode.LINES);
-            if (index == colors.length) {
-                index = 0;
-            }
             lineSeries.addAll(lineModel.getSeries(name));
             model.addSeries(lineSeries);
         }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/FileNameRenderer.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/FileNameRenderer.java
@@ -93,7 +93,7 @@ public class FileNameRenderer {
             return a().withHref(prefix + getSourceCodeUrl(issue))
                     .withText(getFileNameAtLine(issue))
                     .attr("data-bs-toggle", "tooltip")
-                    .attr("data-bs-placement", "left")
+                    .attr("data-bs-placement", "top")
                     .withTitle(issue.getFileName());
         }
         else {

--- a/plugin/src/main/resources/issues/property.jelly
+++ b/plugin/src/main/resources/issues/property.jelly
@@ -41,7 +41,7 @@
               <tr>
                 <td>
                   <a href="${t.property}.${key.hashCode()}/"
-                     data-bs-toggle="tooltip" data-bs-placement="left" title="${t.getToolTip(key)}">
+                     data-bs-toggle="tooltip" data-bs-placement="top" title="${t.getToolTip(key)}">
                     ${t.getDisplayName(key)}</a>
                 </td>
                 <td class="text-end">${count}</td>

--- a/plugin/src/main/resources/issues/severity-distribution.jelly
+++ b/plugin/src/main/resources/issues/severity-distribution.jelly
@@ -23,19 +23,19 @@
     <div title="${container.toolTip}">
         <j:if test="${error > 0}">
             <span class="bar-graph severity-error severity-error--hover" style="width:${error / max * 100}%"
-                  data-bs-toggle="tooltip" data-bs-placement="left" title="${%error.tooltip(error)}">.</span>
+                  data-bs-toggle="tooltip" data-bs-placement="top" title="${%error.tooltip(error)}">.</span>
         </j:if>
         <j:if test="${high > 0}">
             <span class="bar-graph severity-high severity-high--hover" style="width:${high / max * 100}%"
-                  data-bs-toggle="tooltip" data-bs-placement="left" title="${%high.tooltip(high)}">.</span>
+                  data-bs-toggle="tooltip" data-bs-placement="top" title="${%high.tooltip(high)}">.</span>
         </j:if>
         <j:if test="${normal > 0}">
             <span class="bar-graph severity-normal severity-normal--hover" style="width:${normal / max * 100}%"
-                  data-bs-toggle="tooltip" data-bs-placement="left" title="${%normal.tooltip(normal)}">.</span>
+                  data-bs-toggle="tooltip" data-bs-placement="top" title="${%normal.tooltip(normal)}">.</span>
         </j:if>
         <j:if test="${low > 0}">
             <span class="bar-graph severity-low severity-low--hover" style="width:${low / max * 100}%"
-                  data-bs-toggle="tooltip" data-bs-placement="left" title="${%low.tooltip(low)}">.</span>
+                  data-bs-toggle="tooltip" data-bs-placement="top" title="${%low.tooltip(low)}">.</span>
         </j:if>
     </div>
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedPieChartTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedPieChartTest.java
@@ -5,9 +5,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.Report;
-import edu.hm.hafner.echarts.Palette;
 import edu.hm.hafner.echarts.PieChartModel;
 import edu.hm.hafner.echarts.PieData;
+
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 import static io.jenkins.plugins.analysis.core.charts.Messages.*;
 import static org.assertj.core.api.Assertions.*;
@@ -23,7 +24,7 @@ class NewVersusFixedPieChartTest {
     void testCreate() {
         int[] sizes = {2, 3, 4};
         String[] names = {New_Warnings_Short(), Outstanding_Warnings_Short(), Fixed_Warnings_Short()};
-        Palette[] colors = {Palette.RED, Palette.YELLOW, Palette.GREEN};
+        JenkinsPalette[] colors = {JenkinsPalette.RED, JenkinsPalette.YELLOW, JenkinsPalette.GREEN};
 
         NewVersusFixedPieChart chart = new NewVersusFixedPieChart();
 
@@ -35,7 +36,7 @@ class NewVersusFixedPieChartTest {
         for (int i = 0; i < 3; i++) {
             assertThat(data.get(i).getName()).isEqualTo(names[i]);
             assertThat(data.get(i).getValue()).isEqualTo(sizes[i]);
-            assertThat(model.getColors().get(i)).isEqualTo(colors[i].getNormal());
+            assertThat(model.getColors().get(i)).isEqualTo(colors[i].normal());
         }
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChartTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChartTest.java
@@ -9,9 +9,9 @@ import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LineSeries;
 import edu.hm.hafner.echarts.LinesChartModel;
-import edu.hm.hafner.echarts.Palette;
 
 import io.jenkins.plugins.analysis.core.util.AnalysisBuildResult;
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 import static io.jenkins.plugins.analysis.core.charts.BuildResultStubs.*;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
@@ -32,8 +32,8 @@ class NewVersusFixedTrendChartTest {
 
         LinesChartModel model = chart.create(results, new ChartModelConfiguration());
 
-        verifySeries(model.getSeries().get(0), Palette.RED, "New", 10, 20);
-        verifySeries(model.getSeries().get(1), Palette.GREEN, "Fixed", 11, 21);
+        verifySeries(model.getSeries().get(0), JenkinsPalette.RED, "New", 10, 20);
+        verifySeries(model.getSeries().get(1), JenkinsPalette.GREEN, "Fixed", 11, 21);
 
         assertThatJson(model).node("domainAxisLabels")
                 .isArray().hasSize(2)
@@ -44,9 +44,9 @@ class NewVersusFixedTrendChartTest {
                 .isArray().hasSize(2);
     }
 
-    private void verifySeries(final LineSeries series, final Palette normalColor,
+    private void verifySeries(final LineSeries series, final JenkinsPalette normalColor,
             final String newVersusFixedSeriesBuilderName, final int... values) {
-        assertThatJson(series).node("itemStyle").node("color").isEqualTo(normalColor.getNormal());
+        assertThatJson(series).node("itemStyle").node("color").isEqualTo(normalColor.normal());
         assertThatJson(series).node("name").isEqualTo(newVersusFixedSeriesBuilderName);
         for (int value : values) {
             assertThatJson(series).node("data").isArray().hasSize(values.length).contains(value);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/AbstractDetailsModelTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractDetailsModelTest {
      * @return the file name column
      */
     protected String createExpectedFileName(final Issue issue) {
-        return String.format("<a href=\"source.%s/#15\" data-bs-toggle=\"tooltip\" data-bs-placement=\"left\" title=\"/path/to/file-1\">file-1:15</a>", issue.getId().toString());
+        return String.format("<a href=\"source.%s/#15\" data-bs-toggle=\"tooltip\" data-bs-placement=\"top\" title=\"/path/to/file-1\">file-1:15</a>", issue.getId().toString());
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/FileNameRendererTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/FileNameRendererTest.java
@@ -41,7 +41,7 @@ class FileNameRendererTest {
 
         Issue issue = new IssueBuilder().setFileName("/path/to/affected/file.txt").setLineStart(20).build();
 
-        assertThat(renderer.renderAffectedFileLink(issue)).matches("<a href=\"source\\.[0-9a-f-]+/#20\" data-bs-toggle=\"tooltip\" data-bs-placement=\"left\" title=\"/path/to/affected/file.txt\">file.txt:20</a>");
+        assertThat(renderer.renderAffectedFileLink(issue)).matches("<a href=\"source\\.[0-9a-f-]+/#20\" data-bs-toggle=\"tooltip\" data-bs-placement=\"top\" title=\"/path/to/affected/file.txt\">file.txt:20</a>");
         assertThat(renderer.renderAffectedFileLink(issue)).contains(issue.getId().toString());
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/DryTableModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/DryTableModelTest.java
@@ -80,7 +80,7 @@ class DryTableModelTest extends AbstractDetailsModelTest {
     }
 
     private String getFileNameFor(final Issue issue, final int index) {
-        return String.format("<a href=\"source.%s/#%d\" data-bs-toggle=\"tooltip\" data-bs-placement=\"left\" title=\"/path/to/file-"
+        return String.format("<a href=\"source.%s/#%d\" data-bs-toggle=\"tooltip\" data-bs-placement=\"top\" title=\"/path/to/file-"
                         + index + "\">file-%d:%d</a>",  issue.getId().toString(),
                 issue.getLineStart(), index, issue.getLineStart());
     }


### PR DESCRIPTION
Use colors from the new Echarts `JenkinsPalette` for trend charts.

Downstream PR of https://github.com/jenkinsci/echarts-api-plugin/pull/287.

![Bildschirmfoto 2023-05-15 um 21 34 30](https://github.com/jenkinsci/warnings-ng-plugin/assets/503338/5c4211eb-392a-426d-acf4-0115821df907)
![Bildschirmfoto 2023-05-15 um 21 35 53](https://github.com/jenkinsci/warnings-ng-plugin/assets/503338/06cccbac-77fb-4c6e-ab90-0cbb76321f1b)
![Bildschirmfoto 2023-05-15 um 21 35 38](https://github.com/jenkinsci/warnings-ng-plugin/assets/503338/8c106d2a-ec2e-4960-ae70-46351d7a2ad4)
