### PR TITLE
Add delete and add methods for parsers in global configuration

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -228,7 +228,9 @@ text into an issue instance. Here is an example of such a Groovy based parser:
 #### Creating a Groovy parser programmatically
 
 The Groovy based parser can also be created using a Groovy script from within a pipeline, a Jenkins startup script or 
-the script console, see the following example:
+the script console.
+
+See the following example:
 
 ```groovy
 def config = io.jenkins.plugins.analysis.warnings.groovy.ParserConfiguration.getInstance()
@@ -241,7 +243,7 @@ if(!config.contains('pep8-groovy')){
         'return builder.setFileName(matcher.group(1)).setCategory(matcher.group(4)).setMessage(matcher.group(5)).buildOptional()', 
         "optparse.py:69:11: E401 multiple imports on one line"
     )
-    config.setParsers(config.getParsers().plus(newParser))
+    config.addParser(newParser)
 }
 ```
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
@@ -88,6 +88,39 @@ public class ParserConfiguration extends GlobalConfigurationItem {
     }
 
     /**
+     * Removes a GroovyParser from the list by Id.
+     *
+     * @param parserId
+     *         the ID of the Groovy parser to be deleted
+     */
+    @DataBoundSetter
+    public void deleteParser(final String parserId) {
+        if (contains(parserId)) {
+            GroovyParser parser = getParser(parserId);
+            this.parsers.remove(parser);
+        } else {
+            throw new NoSuchElementException("No parser with this ID.");
+        }
+        save();
+    }
+
+    /**
+     * Adds a GroovyParser to the list without removing other parsers.
+     *
+     * @param parser
+     *         the new Groovy parser to be added
+     */
+    @DataBoundSetter
+    public void addParser(final GroovyParser parser) {
+        if (!contains(parser.getId())) {
+            this.parsers.add(parser);
+        } else {
+            throw new IllegalArgumentException("ID already exists.");
+        }
+        save();
+    }
+
+    /**
      * Says if the admin has permitted groovy parsers to scan a build's console log.
      *
      * @return true if groovy parsers can scan the console, false if they are

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
@@ -99,7 +99,7 @@ public class ParserConfiguration extends GlobalConfigurationItem {
             this.parsers.remove(parser);
         }
         else {
-            throw new NoSuchElementException("No parser with this ID.");
+            throw new NoSuchElementException(String.format("No Groovy parser with ID '%s' found.", parserId));
         }
         save();
     }
@@ -111,8 +111,9 @@ public class ParserConfiguration extends GlobalConfigurationItem {
      *         the new Groovy parser to be added
      */
     public void addParser(final GroovyParser parser) {
-        if (contains(parser.getId())) {
-            throw new IllegalArgumentException("ID already exists.");
+        String parserId = parser.getId();
+        if (contains(parserId)) {
+            throw new IllegalArgumentException(String.format("ID '%s' already exists.", parserId));
         }
         this.parsers.add(parser);
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
@@ -93,12 +93,12 @@ public class ParserConfiguration extends GlobalConfigurationItem {
      * @param parserId
      *         the ID of the Groovy parser to be deleted
      */
-    @DataBoundSetter
     public void deleteParser(final String parserId) {
         if (contains(parserId)) {
             GroovyParser parser = getParser(parserId);
             this.parsers.remove(parser);
-        } else {
+        }
+        else {
             throw new NoSuchElementException("No parser with this ID.");
         }
         save();
@@ -110,11 +110,11 @@ public class ParserConfiguration extends GlobalConfigurationItem {
      * @param parser
      *         the new Groovy parser to be added
      */
-    @DataBoundSetter
     public void addParser(final GroovyParser parser) {
         if (!contains(parser.getId())) {
             this.parsers.add(parser);
-        } else {
+        }
+        else {
             throw new IllegalArgumentException("ID already exists.");
         }
         save();

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfiguration.java
@@ -111,12 +111,11 @@ public class ParserConfiguration extends GlobalConfigurationItem {
      *         the new Groovy parser to be added
      */
     public void addParser(final GroovyParser parser) {
-        if (!contains(parser.getId())) {
-            this.parsers.add(parser);
-        }
-        else {
+        if (contains(parser.getId())) {
             throw new IllegalArgumentException("ID already exists.");
         }
+        this.parsers.add(parser);
+
         save();
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
@@ -68,6 +68,7 @@ class ParserConfigurationTest {
         final FormValidation actualTrue = configuration.doCheckConsoleLogScanningPermitted(true);
         assertThat(actualTrue.kind).isEqualTo(FormValidation.Kind.WARNING);
     }
+
     @Test
     void shouldSaveConfigurationIfParserIsAdded() {
         GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
@@ -79,32 +80,34 @@ class ParserConfigurationTest {
         verify(facade).save();
         assertThat(configuration.getParsers().contains(test_parser));
     }
+
     @Test
     void shouldThrowIfParserExists() {
         GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
-        GroovyParser test_parser = new GroovyParser("1", "", "", "", "");
+        GroovyParser testParser = new GroovyParser("1", "", "", "", "");
 
         ParserConfiguration configuration = new ParserConfiguration(facade);
-        configuration.addParser(test_parser);
+        configuration.addParser(testParser);
         verify(facade).save();
 
-        assertThatIllegalArgumentException().isThrownBy(() -> configuration.addParser(test_parser));
+        assertThatIllegalArgumentException().isThrownBy(() -> configuration.addParser(testParser));
     }
+
     @Test
     void deleteShouldRemoveOnlySpecifiedParser() {
         GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
-        GroovyParser first_test_parser = new GroovyParser("1", "", "", "", "");
-        GroovyParser second_test_parser = new GroovyParser("2", "", "", "", "");
+        GroovyParser firstTestParser = new GroovyParser("1", "", "", "", "");
+        GroovyParser secondTestParser = new GroovyParser("2", "", "", "", "");
 
         ParserConfiguration configuration = new ParserConfiguration(facade);
-        configuration.addParser(first_test_parser);
-        configuration.addParser(second_test_parser);
+        configuration.addParser(firstTestParser);
+        configuration.addParser(secondTestParser);
 
-        assertThat(configuration.getParsers().contains(first_test_parser));
-        assertThat(configuration.getParsers().contains(second_test_parser));
+        assertThat(configuration.getParsers().contains(firstTestParser));
+        assertThat(configuration.getParsers().contains(secondTestParser));
 
-        configuration.deleteParser(first_test_parser.getId());
-        assertThat(!(configuration.getParsers().contains(first_test_parser)));
-        assertThat(configuration.getParsers().contains(first_test_parser));
+        configuration.deleteParser(firstTestParser.getId());
+        assertThat(!(configuration.getParsers().contains(firstTestParser)));
+        assertThat(configuration.getParsers().contains(firstTestParser));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
@@ -72,13 +72,13 @@ class ParserConfigurationTest {
     @Test
     void shouldSaveConfigurationIfParserIsAdded() {
         GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
-        GroovyParser test_parser = new GroovyParser("1", "", "", "", "");
+        GroovyParser additional_parser = new GroovyParser("1", "", "", "", "");
 
         ParserConfiguration configuration = new ParserConfiguration(facade);
-        configuration.addParser(test_parser);
+        configuration.addParser(additional_parser);
 
         verify(facade).save();
-        assertThat(configuration.getParsers().contains(test_parser));
+        assertThat(configuration.getParsers()).containsExactly(additional_parser);
     }
 
     @Test
@@ -90,7 +90,7 @@ class ParserConfigurationTest {
         configuration.addParser(testParser);
         verify(facade).save();
 
-        assertThatIllegalArgumentException().isThrownBy(() -> configuration.addParser(testParser));
+        assertThatIllegalArgumentException().isThrownBy(() -> configuration.addParser(testParser)).withMessageContaining(testParser.getId());
     }
 
     @Test
@@ -103,11 +103,10 @@ class ParserConfigurationTest {
         configuration.addParser(firstTestParser);
         configuration.addParser(secondTestParser);
 
-        assertThat(configuration.getParsers().contains(firstTestParser));
-        assertThat(configuration.getParsers().contains(secondTestParser));
+        assertThat(configuration.getParsers()).containsExactly(firstTestParser, secondTestParser);
 
         configuration.deleteParser(firstTestParser.getId());
-        assertThat(!(configuration.getParsers().contains(firstTestParser)));
-        assertThat(configuration.getParsers().contains(firstTestParser));
+        assertThat(configuration.getParsers()).containsExactly(secondTestParser);
+
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
@@ -72,13 +72,13 @@ class ParserConfigurationTest {
     @Test
     void shouldSaveConfigurationIfParserIsAdded() {
         GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
-        GroovyParser additional_parser = new GroovyParser("1", "", "", "", "");
+        GroovyParser additionalParser = new GroovyParser("1", "", "", "", "");
 
         ParserConfiguration configuration = new ParserConfiguration(facade);
-        configuration.addParser(additional_parser);
+        configuration.addParser(additionalParser);
 
         verify(facade).save();
-        assertThat(configuration.getParsers()).containsExactly(additional_parser);
+        assertThat(configuration.getParsers()).containsExactly(additionalParser);
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/ParserConfigurationTest.java
@@ -27,7 +27,7 @@ class ParserConfigurationTest {
     }
 
     @Test
-    void shouldSaveConfigurationIfParsersAreAdded() {
+    void shouldSaveConfigurationIfParsersAreSet() {
         GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
 
         ParserConfiguration configuration = new ParserConfiguration(facade);
@@ -67,5 +67,44 @@ class ParserConfigurationTest {
         assertThat(actualFalse).isOk();
         final FormValidation actualTrue = configuration.doCheckConsoleLogScanningPermitted(true);
         assertThat(actualTrue.kind).isEqualTo(FormValidation.Kind.WARNING);
+    }
+    @Test
+    void shouldSaveConfigurationIfParserIsAdded() {
+        GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
+        GroovyParser test_parser = new GroovyParser("1", "", "", "", "");
+
+        ParserConfiguration configuration = new ParserConfiguration(facade);
+        configuration.addParser(test_parser);
+
+        verify(facade).save();
+        assertThat(configuration.getParsers().contains(test_parser));
+    }
+    @Test
+    void shouldThrowIfParserExists() {
+        GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
+        GroovyParser test_parser = new GroovyParser("1", "", "", "", "");
+
+        ParserConfiguration configuration = new ParserConfiguration(facade);
+        configuration.addParser(test_parser);
+        verify(facade).save();
+
+        assertThatIllegalArgumentException().isThrownBy(() -> configuration.addParser(test_parser));
+    }
+    @Test
+    void deleteShouldRemoveOnlySpecifiedParser() {
+        GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
+        GroovyParser first_test_parser = new GroovyParser("1", "", "", "", "");
+        GroovyParser second_test_parser = new GroovyParser("2", "", "", "", "");
+
+        ParserConfiguration configuration = new ParserConfiguration(facade);
+        configuration.addParser(first_test_parser);
+        configuration.addParser(second_test_parser);
+
+        assertThat(configuration.getParsers().contains(first_test_parser));
+        assertThat(configuration.getParsers().contains(second_test_parser));
+
+        configuration.deleteParser(first_test_parser.getId());
+        assertThat(!(configuration.getParsers().contains(first_test_parser)));
+        assertThat(configuration.getParsers().contains(first_test_parser));
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I have a Jenkins instance that multiple teams work on at the same time. Since it requires admin permissions to add a new parser via the UI, we allow users to add them via Groovy. However, the function `ParserConfiguration#setParsers` is much more prone to accidentally deleting all other parsers.

With this PR, single parsers can be added and deleted from within pipelines.

### Testing done
-> Unit Tests and tested in localhost instance
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
