### PR TITLE
[JENKINS-72054] Add an option to skip the time-consuming post-processing step

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -51,6 +51,7 @@ import io.jenkins.plugins.analysis.core.model.ResultAction;
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider;
 import io.jenkins.plugins.analysis.core.model.Tool;
 import io.jenkins.plugins.analysis.core.steps.IssuesScanner.BlameMode;
+import io.jenkins.plugins.analysis.core.steps.IssuesScanner.PostProcessingMode;
 import io.jenkins.plugins.analysis.core.steps.WarningChecksPublisher.AnnotationScope;
 import io.jenkins.plugins.analysis.core.util.HealthDescriptor;
 import io.jenkins.plugins.analysis.core.util.ModelValidation;
@@ -126,6 +127,8 @@ public class IssuesRecorder extends Recorder {
 
     private boolean skipPublishingChecks; // by default, checks will be published
     private boolean publishAllIssues; // by default, only new issues will be published
+
+    private boolean skipPostProcessing; // @since 10.6.0: by default, post-processing will be enabled
 
     @CheckForNull
     private ChecksInfo checksInfo;
@@ -483,6 +486,20 @@ public class IssuesRecorder extends Recorder {
     }
 
     /**
+     * Returns whether post-processing of the issues should be disabled.
+     *
+     * @return {@code true} if post-processing of the issues should be disabled.
+     */
+    public boolean isSkipPostProcessing() {
+        return skipPostProcessing;
+    }
+
+    @DataBoundSetter
+    public void setSkipPostProcessing(final boolean skipPostProcessing) {
+        this.skipPostProcessing = skipPostProcessing;
+    }
+
+    /**
      * Returns whether all issues should be published using the Checks API. If set to {@code false} only new issues will
      * be published.
      *
@@ -643,7 +660,7 @@ public class IssuesRecorder extends Recorder {
     }
 
     /**
-     * Sets the healthy threshold, i.e. the number of issues when health is reported as 0%.
+     * Sets the healthy threshold, i.e., the number of issues when health is reported as 0%.
      *
      * @param unhealthy
      *         the number of issues when health is reported as 0%
@@ -806,7 +823,8 @@ public class IssuesRecorder extends Recorder {
             final Tool tool) throws IOException, InterruptedException {
         IssuesScanner issuesScanner = new IssuesScanner(tool, getFilters(), getSourceCodeCharset(),
                 workspace, getSourceCodePaths(), run, new FilePath(run.getRootDir()), listener,
-                scm, isBlameDisabled ? BlameMode.DISABLED : BlameMode.ENABLED, quiet);
+                scm, isBlameDisabled ? BlameMode.DISABLED : BlameMode.ENABLED,
+                skipPostProcessing ? PostProcessingMode.DISABLED : PostProcessingMode.ENABLED, quiet);
 
         return issuesScanner.scan();
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/ScanForIssuesStep.java
@@ -28,6 +28,7 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.analysis.core.filter.RegexpFilter;
 import io.jenkins.plugins.analysis.core.model.Tool;
 import io.jenkins.plugins.analysis.core.steps.IssuesScanner.BlameMode;
+import io.jenkins.plugins.analysis.core.steps.IssuesScanner.PostProcessingMode;
 import io.jenkins.plugins.prism.SourceCodeDirectory;
 
 /**
@@ -41,6 +42,7 @@ public class ScanForIssuesStep extends Step {
     private String sourceDirectory = StringUtils.EMPTY;
     private Set<SourceCodeDirectory> sourceDirectories = new HashSet<>(); // @since 9.11.0
     private boolean isBlameDisabled;
+    private boolean skipPostProcessing; // @since 10.6.0: by default, post-processing will be enabled
     private boolean quiet;
 
     private List<RegexpFilter> filters = new ArrayList<>();
@@ -153,6 +155,20 @@ public class ScanForIssuesStep extends Step {
         // do nothing
     }
 
+    /**
+     * Returns whether post-processing of the issues should be disabled.
+     *
+     * @return {@code true} if post-processing of the issues should be disabled.
+     */
+    public boolean isSkipPostProcessing() {
+        return skipPostProcessing;
+    }
+
+    @DataBoundSetter
+    public void setSkipPostProcessing(final boolean skipPostProcessing) {
+        this.skipPostProcessing = skipPostProcessing;
+    }
+
     @CheckForNull
     public String getSourceCodeEncoding() {
         return sourceCodeEncoding;
@@ -228,6 +244,7 @@ public class ScanForIssuesStep extends Step {
         private final Tool tool;
         private final String sourceCodeEncoding;
         private final boolean isBlameDisabled;
+        private final boolean skipPostProcessing;
         private final List<RegexpFilter> filters;
         private final Set<String> sourceDirectories;
         private final String scm;
@@ -250,6 +267,7 @@ public class ScanForIssuesStep extends Step {
             filters = step.getFilters();
             sourceDirectories = step.getAllSourceDirectories();
             scm = step.getScm();
+            skipPostProcessing = step.isSkipPostProcessing();
             quiet = step.isQuiet();
         }
 
@@ -261,7 +279,9 @@ public class ScanForIssuesStep extends Step {
             IssuesScanner issuesScanner = new IssuesScanner(tool, filters,
                     getCharset(sourceCodeEncoding), workspace, sourceDirectories,
                     getRun(), new FilePath(getRun().getRootDir()), listener,
-                    scm, isBlameDisabled ? BlameMode.DISABLED : BlameMode.ENABLED, quiet);
+                    scm, isBlameDisabled ? BlameMode.DISABLED : BlameMode.ENABLED,
+                    skipPostProcessing ? PostProcessingMode.DISABLED : PostProcessingMode.ENABLED,
+                    quiet);
 
             return issuesScanner.scan();
         }

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-skipPostProcessing.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep/help-skipPostProcessing.html
@@ -1,0 +1,5 @@
+<div>
+    If this option is unchecked, then the plugin automatically resolves absolute paths, fingerprints,
+    package and module names from the source files in the workspace.
+    If this operation slows down your build, you can use this option to deactivate this feature.
+</div>

--- a/plugin/src/main/resources/issues/scan-parameters.jelly
+++ b/plugin/src/main/resources/issues/scan-parameters.jelly
@@ -12,6 +12,11 @@
   </f:entry>
   <s:scm/>
 
+  <f:entry field="skipPostProcessing">
+    <f:checkbox title="${%title.skipPostProcessing}" />
+  </f:entry>
+  <s:scm/>
+
   <i:hr title="${%Reading Affected Files}"/>
 
   <p:sourceConfig/>

--- a/plugin/src/main/resources/issues/scan-parameters.properties
+++ b/plugin/src/main/resources/issues/scan-parameters.properties
@@ -4,6 +4,7 @@ title.sourceDirectories=Source Directories
 description.sourceDirectories=Additional paths to the source code if not in the root of the workspace \
   (or outside the workspace).
 title.blameDisabled=Disable retrieval of blame information (author and commit) from SCM
+title.skipPostProcessing=Disable detection of missing package and module names 
 title.filter=Issue Filters
 description.filter=Issues will be matched with all the specified filters. If no filter is \
   defined, then all issues will be published. Filters with empty regular expression will be ignored.

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailsTableModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/DetailsTableModelTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.*;
  */
 class DetailsTableModelTest extends AbstractDetailsModelTest {
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-64051")
+    @org.junitpioneer.jupiter.Issue("JENKINS-64051")
     void shouldNotRemoveWhitespace() {
         try (IssueBuilder builder = new IssueBuilder()) {
             builder.setMessage("project: Defaults to NumberGroupSeparator on .NET Core except on Windows.");

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/IssuesAggregatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/IssuesAggregatorTest.java
@@ -74,7 +74,7 @@ class IssuesAggregatorTest {
         verify(recorder).publishResult(any(), any(), anyString(), any(), anyString(), any());
     }
 
-    @Test @org.jvnet.hudson.test.Issue("JENKINS-59178")
+    @Test @org.junitpioneer.jupiter.Issue("JENKINS-59178")
     void shouldCollectDifferentResultsForTwoAxes() {
         IssuesRecorder recorder = mock(IssuesRecorder.class);
         IssuesAggregator aggregator = createIssueAggregator(recorder);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/integrations/TimeStamperPluginITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/integrations/TimeStamperPluginITest.java
@@ -65,7 +65,7 @@ class TimeStamperPluginITest extends IntegrationTestWithJenkinsPerSuite {
     /**
      * Tests JENKINS-56484: Error while parsing clang errors with active timestamper plugin.
      */
-    @Test @org.jvnet.hudson.test.Issue("JENKINS-56484")
+    @Test @org.junitpioneer.jupiter.Issue("JENKINS-56484")
     void shouldCorrectlyParseClangErrors() {
         WorkflowJob project = createPipeline();
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/AffectedFilesResolverITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/AffectedFilesResolverITest.java
@@ -210,7 +210,7 @@ class AffectedFilesResolverITest extends IntegrationTestWithJenkinsPerSuite {
      * Verifies that a source code file will be copied from outside the workspace if configured correspondingly.
      */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-55998")
+    @org.junitpioneer.jupiter.Issue("JENKINS-55998")
     void shouldShowFileOutsideWorkspaceIfConfigured() {
         FreeStyleProject job = createFreeStyleProject();
         prepareGccLog(job);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
@@ -57,7 +57,7 @@ class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite {
     /**
      * Verifies that {@link FindBugs} handles the different severity mapping modes ({@link PriorityProperty}).
      */
-    @Test @org.jvnet.hudson.test.Issue("JENKINS-55514")
+    @Test @org.junitpioneer.jupiter.Issue("JENKINS-55514")
     void shouldMapSeverityFilterForFindBugs() {
         FreeStyleProject project = createFreeStyleProjectWithWorkspaceFilesWithSuffix("findbugs-severities.xml");
 
@@ -208,7 +208,6 @@ class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite {
                 first -> assertThat(first).endsWith("checkstyle-issues.txt"),
                 second -> assertThat(second).endsWith("pmd-warnings-issues.txt")
         );
-
     }
 
     private List<AnalysisResult> runJobWithAggregation(final boolean isAggregationEnabled) {
@@ -223,7 +222,7 @@ class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite {
 
     /**
      * Runs the CheckStyle and PMD tools for two corresponding files which contain 10 issues in total. Since a filter
-     * afterwords removes all issues, the actual result contains no warnings. However, the two origins are still
+     * afterword removes all issues, the actual result contains no warnings. However, the two origins are still
      * reported with a total of 0 warnings per origin.
      */
     @Test
@@ -258,7 +257,7 @@ class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite {
      * Verifies that a report that contains errors (since the report pattern does not find some files),
      * will fail the step if the property {@link IssuesRecorder#setFailOnError(boolean)} is enabled.
      */
-    @Test @org.jvnet.hudson.test.Issue("JENKINS-58056")
+    @Test @org.junitpioneer.jupiter.Issue("JENKINS-58056")
     void shouldFailBuildWhenFailBuildOnErrorsIsSet() {
         FreeStyleProject job = createFreeStyleProject();
         IssuesRecorder recorder = enableEclipseWarnings(job);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ModuleDetectorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ModuleDetectorITest.java
@@ -14,6 +14,7 @@ import edu.hm.hafner.analysis.ModuleDetector;
 
 import hudson.FilePath;
 import hudson.model.FreeStyleProject;
+import hudson.model.Run;
 
 import io.jenkins.plugins.analysis.core.model.ResultAction;
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSuite;
@@ -127,6 +128,36 @@ class ModuleDetectorITest extends IntegrationTestWithJenkinsPerSuite {
                 new PropertyRow("edu.hm.hafner.osgi.symbolicname", 1),
                 new PropertyRow("edu.hm.hafner.osgi.symbolicname (TestVendor)", 7),
                 new PropertyRow("Test-Bundle-Name", 1));
+    }
+
+    @Test
+    void shouldSkipPostProcessing() {
+        String[] workspaceFiles = {
+                BUILD_FILE_PATH + ANT_BUILD_FILE_LOCATION + "build.xml",
+                BUILD_FILE_PATH + ANT_BUILD_FILE_LOCATION + "m1/build.xml",
+                BUILD_FILE_PATH + MAVEN_BUILD_FILE_LOCATION + "pom.xml",
+                BUILD_FILE_PATH + MAVEN_BUILD_FILE_LOCATION + "m1/pom.xml",
+                BUILD_FILE_PATH + MAVEN_BUILD_FILE_LOCATION + "m2/pom.xml",
+                BUILD_FILE_PATH + OSGI_BUILD_FILE_LOCATION + "META-INF/MANIFEST.MF",
+                BUILD_FILE_PATH + OSGI_BUILD_FILE_LOCATION + "m1/META-INF/MANIFEST.MF",
+                BUILD_FILE_PATH + OSGI_BUILD_FILE_LOCATION + "m2/META-INF/MANIFEST.MF",
+                BUILD_FILE_PATH + OSGI_BUILD_FILE_LOCATION + "m3/META-INF/MANIFEST.MF",
+                BUILD_FILE_PATH + OSGI_BUILD_FILE_LOCATION + "plugin.properties"};
+
+        FreeStyleProject project = createFreeStyleProject();
+        copyWorkspaceFiles(project, workspaceFiles, file -> file.replaceFirst("detectors/buildfiles/\\w*/", ""));
+        var recorder = enableGenericWarnings(project, new Eclipse());
+        recorder.setSkipPostProcessing(true);
+
+        createEclipseWarningsReport(workspaceFiles.length - 1, true,
+                getJenkins().jenkins.getWorkspaceFor(project));
+
+        Run<?, ?> build = buildSuccessfully(project);
+        ResultAction result = getResultAction(build);
+        assertThat(result.getResult().getIssues().getModules()).containsExactly("-");
+
+        assertThat(getConsoleLog(build)).doesNotContain("Resolving module names from module definitions (build.xml, pom.xml, or Manifest.mf files)");
+        assertThat(getConsoleLog(build)).contains("Skipping post processing");
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -112,7 +112,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
      * Runs a pipeline and verifies the {@code recordIssues} step has some allowlisted methods.
      */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-63109")
+    @org.junitpioneer.jupiter.Issue("JENKINS-63109")
     void shouldWhitelistRecorderApi() {
         WorkflowJob job = createPipelineWithWorkspaceFilesWithSuffix("checkstyle1.xml", "checkstyle2.xml");
 
@@ -558,7 +558,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
 
     /** Runs the JavaDoc parser and enforces quality gates. */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-58253")
+    @org.junitpioneer.jupiter.Issue("JENKINS-58253")
     void shouldFailBuildWhenFailBuildOnErrorsIsSet() {
         WorkflowJob job = createPipeline();
 
@@ -575,7 +575,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
 
     /** Runs the JavaDoc parser and enforces quality gates. */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-58253")
+    @org.junitpioneer.jupiter.Issue("JENKINS-58253")
     void shouldSupportDeprecatedAttributesInRecord() {
         WorkflowJob job = createPipelineWithWorkspaceFilesWithSuffix("javadoc.txt");
 
@@ -602,7 +602,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
 
     /** Runs the JavaDoc parser and enforces quality gates. */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-58253")
+    @org.junitpioneer.jupiter.Issue("JENKINS-58253")
     void shouldSupportDeprecatedAttributesInPublish() {
         WorkflowJob job = createPipelineWithWorkspaceFilesWithSuffix("javadoc.txt");
 
@@ -677,7 +677,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
      * for the origin field as well.
      */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-57638")
+    @org.junitpioneer.jupiter.Issue("JENKINS-57638")
     void shouldUseCustomIdsForOrigin() {
         verifyCustomIdsForOrigin(asStage(
                 "def java = scanForIssues tool: java(pattern:'**/*issues.txt', reportEncoding:'UTF-8', id:'id1', name:'name1')",
@@ -690,7 +690,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
      * for the origin field as well.
      */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-57638")
+    @org.junitpioneer.jupiter.Issue("JENKINS-57638")
     void shouldUseCustomIdsForOriginSimpleStep() {
         verifyCustomIdsForOrigin(asStage(
                 "recordIssues(\n"
@@ -1090,7 +1090,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-39203">Issue 39203</a>
      */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-39203")
+    @org.junitpioneer.jupiter.Issue("JENKINS-39203")
     void publishIssuesShouldMarkStepWithWarningAction() {
         WorkflowJob job = createPipelineWithWorkspaceFilesWithSuffix("javac.txt");
         job.setDefinition(asStage(createScanForIssuesStep(new Java(), "java"),
@@ -1112,7 +1112,7 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-39203">Issue 39203</a>
      */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-39203")
+    @org.junitpioneer.jupiter.Issue("JENKINS-39203")
     void recordIssuesShouldMarkStepWithWarningAction() {
         WorkflowJob job = createPipelineWithWorkspaceFilesWithSuffix("javac.txt");
         job.setDefinition(asStage("recordIssues(tool: java(pattern:'**/*issues.txt', reportEncoding:'UTF-8'),"

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsOnAgentITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsOnAgentITest.java
@@ -35,7 +35,7 @@ class StepsOnAgentITest extends IntegrationTestWithJenkinsPerTest {
      * active, see JENKINS-56007 for details.
      */
     @Test
-    @org.jvnet.hudson.test.Issue("JENKINS-56007")
+    @org.junitpioneer.jupiter.Issue("JENKINS-56007")
     void shouldCopySourcesIfMasterAgentSecurityIsActive() {
         Slave agent = createAgentWithEnabledSecurity("agent");
 
@@ -58,7 +58,7 @@ class StepsOnAgentITest extends IntegrationTestWithJenkinsPerTest {
     }
 
     private String getSourceCode(final AnalysisResult result, final int rowIndex) {
-        IssuesDetail target = (IssuesDetail) result.getOwner().getAction(ResultAction.class).getTarget();
+        IssuesDetail target = result.getOwner().getAction(ResultAction.class).getTarget();
         String sourceCodeUrl = new FileNameRenderer(result.getOwner()).getSourceCodeUrl(
                 result.getIssues().get(rowIndex));
         SourceCodeViewModel dynamic = (SourceCodeViewModel) target.getDynamic(

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/tasks/TaskScannerTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/tasks/TaskScannerTest.java
@@ -118,7 +118,7 @@ class TaskScannerTest extends ResourceTest {
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-64622">Issue 64622</a>
      */
-    @Test @org.jvnet.hudson.test.Issue("JENKINS-64622")
+    @Test @org.junitpioneer.jupiter.Issue("JENKINS-64622")
     void shouldHandleEmptyMatchWithRegExp() {
         Report tasks = new TaskScannerBuilder()
                 .setHighTasks("(a)?(b)?.*")
@@ -134,7 +134,7 @@ class TaskScannerTest extends ResourceTest {
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-22744">Issue 22744</a>
      */
-    @Test @org.jvnet.hudson.test.Issue("JENKINS-22744")
+    @Test @org.junitpioneer.jupiter.Issue("JENKINS-22744")
     void issue22744() {
         Report tasks = new TaskScannerBuilder()
                 .setHighTasks("FIXME")

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
@@ -37,6 +37,7 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
     private final Control sourceCodeEncoding = control("sourceCodeEncoding");
     private final Control sourceDirectories = findRepeatableAddButtonFor("sourceDirectories");
     private final Control skipBlames = control("skipBlames");
+    private final Control skipPostProcessing = control("skipPostProcessing");
     private final Control ignoreFailedBuilds = control("ignoreFailedBuilds");
     private final Control failOnError = control("failOnError");
     private final Control skipPublishingChecks = control("skipPublishingChecks");
@@ -188,7 +189,7 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
     }
 
     /**
-     * Returns whether the report results is in logger output.  
+     * Returns whether the report results is in logger output.
      *
      * @return {@code true} then the report logging of each static analysis tool is muted
      *         {@code false} then reports logging goes to loghandler output
@@ -215,13 +216,12 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
         return scm.get();
     }
 
-    /**
-     * Returns whether SCM blaming should be disabled.
-     *
-     * @return {@code true} if SCM blaming should be disabled
-     */
     public boolean isSkipBlames() {
         return isChecked(skipBlames);
+    }
+
+    public boolean isSkipPostProcessing() {
+        return isChecked(skipPostProcessing);
     }
 
     public boolean isIgnoringFailedBuilds() {
@@ -375,7 +375,7 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
     }
 
     /**
-     * Determines whether the report results will go to logger output. 
+     * Determines whether the report results will go to logger output.
      *
      * @param quiet
      *         if {@code true} then the report logging of each static analysis tool is muted
@@ -414,6 +414,20 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
      */
     public IssuesRecorder setSkipBlames(final boolean blameDisabled) {
         skipBlames.check(blameDisabled);
+
+        return this;
+    }
+
+    /**
+     * Determines whether post-processing should be disabled or not.
+     *
+     * @param skipPostProcessing
+     *         {@code true} if post-processing should be disabled, {@code false} otherwise
+     *
+     * @return this recorder
+     */
+    public IssuesRecorder setSkipPostProcessing(final boolean skipPostProcessing) {
+        this.skipPostProcessing.check(skipPostProcessing);
 
         return this;
     }

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/FreeStyleConfigurationUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/FreeStyleConfigurationUiTest.java
@@ -45,6 +45,7 @@ public class FreeStyleConfigurationUiTest extends AbstractJUnitTest {
         issuesRecorder.setIgnoreQualityGate(true);
         issuesRecorder.setIgnoreFailedBuilds(true);
         issuesRecorder.setSkipPublishingChecks(true);
+        issuesRecorder.setSkipPostProcessing(true);
         issuesRecorder.setPublishAllIssues(true);
         issuesRecorder.setFailOnError(true);
         issuesRecorder.setQuiet(true);
@@ -67,6 +68,7 @@ public class FreeStyleConfigurationUiTest extends AbstractJUnitTest {
         assertThat(issuesRecorder).isIgnoringQualityGate();
         assertThat(issuesRecorder).isIgnoringFailedBuilds();
         assertThat(issuesRecorder).isSkipPublishingChecks();
+        assertThat(issuesRecorder).isSkipPostProcessing();
         assertThat(issuesRecorder).isPublishAllIssues();
         assertThat(issuesRecorder).isFailingOnError();
         assertThat(issuesRecorder).isQuiet();

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/SnippetGeneratorUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/SnippetGeneratorUiTest.java
@@ -42,6 +42,7 @@ public class SnippetGeneratorUiTest extends UiTest {
         snippetGenerator.selectRecordIssues()
                 .setAggregatingResults(false)
                 .setSkipBlames(false)
+                .setSkipPostProcessing(false)
                 .setEnabledForFailure(false)
                 .setIgnoreFailedBuilds(true)
                 .setIgnoreQualityGate(false)
@@ -75,6 +76,7 @@ public class SnippetGeneratorUiTest extends UiTest {
         assertThat(script).contains("recordIssues");
         assertThat(script).contains("aggregatingResults: true");
         assertThat(script).contains("skipBlames: true");
+        assertThat(script).contains("skipPostProcessing: true");
         assertThat(script).contains("enabledForFailure: true");
         assertThat(script).contains("ignoreFailedBuilds: false");
         assertThat(script).contains("ignoreQualityGate: true");
@@ -126,6 +128,7 @@ public class SnippetGeneratorUiTest extends UiTest {
         assertThat(script).contains("recordIssues");
         assertThat(script).contains("aggregatingResults: true");
         assertThat(script).contains("skipBlames: true");
+        assertThat(script).contains("skipPostProcessing: true");
         assertThat(script).contains("enabledForFailure: true");
         assertThat(script).contains("filters: [excludeType('*toExclude*')]");
         assertThat(script).contains("ignoreFailedBuilds: false");


### PR DESCRIPTION
Some projects noticed a long runtime of the post processing step after the issue parsing has been finished. It makes sense to make all of those steps optional (parameter), see also [JENKINS-71492](https://issues.jenkins.io/browse/JENKINS-71492) for details.