### PR TITLE
[JENKINS-71492] Limit property `skipPostProcessing` to package and module detection.

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesScanner.java
@@ -89,7 +89,8 @@ class IssuesScanner {
     IssuesScanner(final Tool tool, final List<RegexpFilter> filters, final Charset sourceCodeEncoding,
             final FilePath workspace, final Set<String> sourceDirectories, final Run<?, ?> run,
             final FilePath jenkinsRootDir, final TaskListener listener,
-            final String scm, final BlameMode blameMode, final PostProcessingMode postProcessingMode, final boolean quiet) {
+            final String scm, final BlameMode blameMode, final PostProcessingMode postProcessingMode,
+            final boolean quiet) {
         this.filters = new ArrayList<>(filters);
         this.sourceCodeEncoding = sourceCodeEncoding;
         this.tool = tool;
@@ -130,8 +131,7 @@ class IssuesScanner {
 
     private AnnotatedReport postProcessReport(final Report report) throws IOException, InterruptedException {
         if (tool.getDescriptor().isPostProcessingEnabled()
-                && report.isNotEmpty()
-                && postProcessingMode == PostProcessingMode.ENABLED) {
+                && report.isNotEmpty()) {
             report.logInfo("Post processing issues on '%s' with source code encoding '%s'",
                     getAgentName(), sourceCodeEncoding);
             AnnotatedReport result = workspace.act(createPostProcessor(report));
@@ -146,7 +146,8 @@ class IssuesScanner {
 
     private ReportPostProcessor createPostProcessor(final Report report) {
         return new ReportPostProcessor(tool.getActualId(), report, sourceCodeEncoding.name(),
-                createBlamer(report), filters, getPermittedSourceDirectories(), sourceDirectories);
+                createBlamer(report), filters, getPermittedSourceDirectories(), sourceDirectories,
+                postProcessingMode);
     }
 
     private Set<String> getPermittedSourceDirectories() {
@@ -246,6 +247,7 @@ class IssuesScanner {
     @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
     private static class ReportPostProcessor extends MasterToSlaveFileCallable<AnnotatedReport> {
         private static final long serialVersionUID = -9138045560271783096L;
+        private static final String SKIPPING_POST_PROCESSING = "Skipping detection of missing package and module names";
 
         private final String id;
         private final Report originalReport;
@@ -253,11 +255,13 @@ class IssuesScanner {
         private final Blamer blamer;
         private final Set<String> permittedSourceDirectories;
         private final Set<String> requestedSourceDirectories;
+        private final PostProcessingMode postProcessingMode;
         private final List<RegexpFilter> filters;
 
+        @SuppressWarnings("checkstyle:ParameterNumber")
         ReportPostProcessor(final String id, final Report report, final String sourceCodeEncoding,
                 final Blamer blamer, final List<RegexpFilter> filters, final Set<String> permittedSourceDirectories,
-                final Set<String> requestedSourceDirectories) {
+                final Set<String> requestedSourceDirectories, final PostProcessingMode postProcessingMode) {
             super();
 
             this.id = id;
@@ -267,15 +271,21 @@ class IssuesScanner {
             this.filters = filters;
             this.permittedSourceDirectories = permittedSourceDirectories;
             this.requestedSourceDirectories = requestedSourceDirectories;
+            this.postProcessingMode = postProcessingMode;
         }
 
         @Override
         public AnnotatedReport invoke(final File workspace, final VirtualChannel channel) {
             resolvePaths(workspace, originalReport);
-            resolveModuleNames(originalReport, workspace);
-            resolvePackageNames(originalReport);
+            if (postProcessingMode == PostProcessingMode.ENABLED) {
+                resolveModuleNames(originalReport, workspace);
+                resolvePackageNames(originalReport);
+            }
+            else {
+                originalReport.logInfo(SKIPPING_POST_PROCESSING);
+            }
 
-            Report filtered = filter(originalReport, filters);
+            Report filtered = filter(originalReport, filters); // the filters may depend on the resolved paths
 
             createFingerprints(filtered);
 

--- a/plugin/src/main/resources/issues/scan-parameters.properties
+++ b/plugin/src/main/resources/issues/scan-parameters.properties
@@ -4,7 +4,7 @@ title.sourceDirectories=Source Directories
 description.sourceDirectories=Additional paths to the source code if not in the root of the workspace \
   (or outside the workspace).
 title.blameDisabled=Disable retrieval of blame information (author and commit) from SCM
-title.skipPostProcessing=Disable post-processing of issues (package and modul names, file paths, fingerprints) 
+title.skipPostProcessing=Disable detection of missing package and module names
 title.filter=Issue Filters
 description.filter=Issues will be matched with all the specified filters. If no filter is \
   defined, then all issues will be published. Filters with empty regular expression will be ignored.

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ModuleDetectorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ModuleDetectorITest.java
@@ -157,7 +157,7 @@ class ModuleDetectorITest extends IntegrationTestWithJenkinsPerSuite {
         assertThat(result.getResult().getIssues().getModules()).containsExactly("-");
 
         assertThat(getConsoleLog(build)).doesNotContain("Resolving module names from module definitions (build.xml, pom.xml, or Manifest.mf files)");
-        assertThat(getConsoleLog(build)).contains("Skipping post processing");
+        assertThat(getConsoleLog(build)).contains("Skipping detection of missing package and module names");
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/PackageDetectorsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/PackageDetectorsITest.java
@@ -357,7 +357,7 @@ class PackageDetectorsITest extends IntegrationTestWithJenkinsPerSuite {
 
         String consoleLog = getConsoleLog(result);
         assertThat(consoleLog).doesNotContain(DEFAULT_DEBUG_LOG_LINE);
-        assertThat(consoleLog).contains("Skipping post processing");
+        assertThat(consoleLog).contains("Skipping detection of missing package and module names");
     }
 
     private String returnExpectedNumberOfResolvedPackageNames(final int expectedNumberOfResolvedPackageNames) {


### PR DESCRIPTION
See [JENKINS-71492](https://issues.jenkins.io/browse/JENKINS-71492). Now the new property skips only the package and module detection but not the absolute path resolving.