### PR TITLE
Use success colour variable rather than hardcoded colour

### DIFF
--- a/plugin/src/main/webapp/css/custom-style.css
+++ b/plugin/src/main/webapp/css/custom-style.css
@@ -46,7 +46,7 @@
 
 .no-issues-banner {
     padding: 30px;
-    color: #009688;
+    color: var(--success-color);
     height: 200px;
     width: 200px;
 }

--- a/plugin/src/main/webapp/css/pull-request-portlet.css
+++ b/plugin/src/main/webapp/css/pull-request-portlet.css
@@ -5,11 +5,11 @@
 
 .no-issues-banner {
     padding: 20px;
-    fill: #009688;
+    fill: var(--success-color);
 }
 
 .no-new-issues-banner {
-    fill: #009688;
+    fill: var(--success-color);
     width: 30px;
     height: 30px;
 }


### PR DESCRIPTION
Uses the Jenkins success colour variable rather than a hardcoded green.

**Before**
<img width="427" alt="image" src="https://github.com/jenkinsci/warnings-ng-plugin/assets/43062514/feb0ff53-6e26-4fde-87fe-9ef4711ca655">

**After**
<img width="439" alt="image" src="https://github.com/jenkinsci/warnings-ng-plugin/assets/43062514/950119dc-192a-4cff-8c4c-291a54f038ef">


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
