### PR TITLE
Make the no-issues icon green again

### DIFF
--- a/plugin/src/main/webapp/css/custom-style.css
+++ b/plugin/src/main/webapp/css/custom-style.css
@@ -46,7 +46,7 @@
 
 .no-issues-banner {
     padding: 30px;
-    color: var(--success-color);
+    color: var(--success-color) !important;
     height: 200px;
     width: 200px;
 }


### PR DESCRIPTION
After https://github.com/jenkinsci/font-awesome-api-plugin/releases/tag/v6.5.1-2 the icon color changed to gray.

# Before

![Bildschirmfoto 2024-01-31 um 11 20 34](https://github.com/jenkinsci/warnings-ng-plugin/assets/503338/e7feaf95-077f-4937-a456-a32f32d7c201)

# After

![Bildschirmfoto 2024-01-31 um 11 27 45](https://github.com/jenkinsci/warnings-ng-plugin/assets/503338/8065229c-4880-42a8-8f0b-86413bc3077e)
