### PR TITLE
Remove icon from reference link as it is broken in core again

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SummaryModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SummaryModel.java
@@ -10,6 +10,7 @@ import edu.hm.hafner.util.VisibleForTesting;
 
 import hudson.model.Run;
 
+import io.jenkins.plugins.forensics.reference.ReferenceBuild;
 import io.jenkins.plugins.util.QualityGateStatus;
 
 /**
@@ -155,6 +156,20 @@ public class SummaryModel {
         return analysisResult.getReferenceBuild();
     }
 
+    /**
+     * Renders the reference build as an HTML link.
+     *
+     * @return the reference build
+     * @see #getReferenceBuild()
+     */
+    @SuppressWarnings("unused") // Called by jelly view
+    public String getReferenceBuildLink() {
+        return facade.getReferenceLink(
+                analysisResult.getReferenceBuild()
+                        .map(Run::getExternalizableId)
+                        .orElse("-"));
+    }
+
     public boolean isZeroIssuesHighscore() {
         return getNoIssuesSinceBuild() > 0 && analysisResult.getOwner().getNumber() > getNoIssuesSinceBuild();
     }
@@ -174,6 +189,10 @@ public class SummaryModel {
     static class LabelProviderFactoryFacade {
         public StaticAnalysisLabelProvider get(final String id) {
             return new LabelProviderFactory().create(id);
+        }
+
+        public String getReferenceLink(final String id) {
+            return ReferenceBuild.getReferenceBuildLink(id);
         }
     }
 }

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ResultAction/summary.jelly
@@ -99,7 +99,7 @@
           <j:set var="r" value="${s.referenceBuild.get()}"/>
           <li>
             Reference build:
-            <t:buildLink jobName="${r.parent.displayName}" job="${r.parent}" number="${r.number}"/>
+            <j:out value="${s.referenceBuildLink}"/>
           </li>
         </j:if>
         <j:if test="${s.qualityGateStatus.name() != 'INACTIVE'}">

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryModelTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/SummaryModelTest.java
@@ -56,6 +56,7 @@ class SummaryModelTest {
                 .hasAnalysesCount(1)
                 .hasQualityGateStatus(QualityGateStatus.INACTIVE)
                 .hasReferenceBuild(Optional.empty())
+                .hasReferenceBuildLink("-")
                 .isNotZeroIssuesHighscore()
                 .hasNoErrors()
                 .isNotResetQualityGateVisible();
@@ -157,6 +158,7 @@ class SummaryModelTest {
 
         Run<?, ?> run = mock(Run.class);
         when(run.getFullDisplayName()).thenReturn("Job #15");
+        when(run.getExternalizableId()).thenReturn("#15");
         when(run.getUrl()).thenReturn("job/my-job/15");
         when(analysisResult.getReferenceBuild()).thenReturn(Optional.of(run));
 
@@ -164,7 +166,8 @@ class SummaryModelTest {
 
         SummaryModel summary = createSummary(analysisResult);
 
-        assertThat(summary).hasReferenceBuild(Optional.of(run));
+        assertThat(summary).hasReferenceBuild(Optional.of(run))
+                .hasReferenceBuildLink("#reference-link");
     }
 
     @Test
@@ -209,6 +212,8 @@ class SummaryModelTest {
         when(facade.get(CHECK_STYLE_ID)).thenReturn(checkStyleLabelProvider);
         StaticAnalysisLabelProvider pmdLabelProvider = new StaticAnalysisLabelProvider(PMD_ID, PMD_NAME);
         when(facade.get(PMD_ID)).thenReturn(pmdLabelProvider);
+        when(facade.getReferenceLink("-")).thenReturn("-");
+        when(facade.getReferenceLink(startsWith("#"))).thenReturn("#reference-link");
 
         SummaryModel summaryModel = new SummaryModel(new StaticAnalysisLabelProvider(TOOL_ID, TOOL_NAME), analysisResult, facade);
         summaryModel.setResetQualityGateCommand(createResetReferenceAction(false));


### PR DESCRIPTION
UI visualization of the link is broken again in Jenkins core: [JENKINS-72491](https://issues.jenkins.io/browse/JENKINS-72491). So it makes sense to remove the status icon and only show the raw link. When a fix for https://github.com/jenkinsci/jenkins/pull/8705 is available, we can revert that change.

