### PR TITLE
Correct sorting by issues column when some entries are missing

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumn/column.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumn/column.jelly
@@ -38,8 +38,7 @@
   </j:set>
   <td class="healthReport issues-total" data-html-tooltip="${total.isPresent() ? tooltip : null}"
       data-tooltip-interactive="true"
-      onmouseover="this.className='healthReport hover';return true;"
-      onmouseout="this.className='healthReport';return true;">
+      data="${total.orElse(-1)}">
     <j:choose>
       <j:when test="${total.isPresent() and size(url) > 0}">
         <a href="${rootURL}/${job.url}/${url}">${total.asInt}</a>


### PR DESCRIPTION
Adds `data` attribute used by `sortable.js`. Since `data` is always a number this guarantees sorting by number of issues will work as expected. Without this change, if one or more entries are missing in the column, alphabetical sort is used 
2 > 12 > 1 > 0 > -

Also removes 2 lines of inline JS that is no longer needed, improving CSP compatibility.
Code introduced in https://github.com/jenkinsci/warnings-ng-plugin/commit/0a5457e8, made redundant in https://github.com/jenkinsci/warnings-ng-plugin/pull/1379.

### Testing done

Manually checked that the column sorting works on my Jenkins instance and tooltip functionality is still OK.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
