### PR TITLE
Exclude DuplicateCodeScanner.java from PMD analysis

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -506,6 +506,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>**/DuplicateCodeScanner.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
PMD 7.x fails with an IllegalStateException:

````
<![CDATA[org.apache.commons.lang3.exception.ContextedRuntimeException: java.lang.IllegalStateException: Disambiguation pass should resolve everything except qualified ctor calls
Exception Context:
	[1:Resolving type of=!debug only! [ClassType:105:43]SymbolIconLabelProvider]
---------------------------------
	at net.sourceforge.pmd.util.AssertionUtil.contexted(AssertionUtil.java:236)
	at net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode.getTypeMirror(AbstractJavaTypeNode.java:54)
	at net.sourceforge.pmd.lang.java.ast.ASTClassType.getTypeMirror(ASTClassType.java:37)
	at net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode.getTypeMirror(AbstractJavaTypeNode.java:39)
	at net.sourceforge.pmd.lang.java.ast.ASTClassType.getTypeMirror(ASTClassType.java:37)
	at net.sourceforge.pmd.lang.java.symbols.internal.ast.AstClassSym.getSuperclassType(AstClassSym.java:234)
	at net.sourceforge.pmd.lang.java.types.ClassTypeImpl.getSuperClass(ClassTypeImpl.java:290)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.SuperTypesEnumerator$3.iterable(SuperTypesEnumerator.java:59)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.JavaResolvers.walkSelf(JavaResolvers.java:382)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.JavaResolvers.hidingWalkResolvers(JavaResolvers.java:352)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.JavaResolvers.importOnDemandMembersResolvers(JavaResolvers.java:330)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.SymTableFactory.fillImportOnDemands(SymTableFactory.java:202)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.SymTableFactory.importsOnDemand(SymTableFactory.java:158)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.SymbolTableResolver$MyVisitor.visit(SymbolTableResolver.java:209)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.SymbolTableResolver$MyVisitor.visit(SymbolTableResolver.java:136)
	at net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit.acceptVisitor(ASTCompilationUnit.java:82)
	at net.sourceforge.pmd.lang.java.ast.AbstractJavaNode.acceptVisitor(AbstractJavaNode.java:38)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.SymbolTableResolver$MyVisitor.traverse(SymbolTableResolver.java:162)
	at net.sourceforge.pmd.lang.java.symbols.table.internal.SymbolTableResolver.traverse(SymbolTableResolver.java:99)
	at net.sourceforge.pmd.lang.java.internal.JavaAstProcessor.lambda$process$1(JavaAstProcessor.java:132)
	at net.sourceforge.pmd.benchmark.TimeTracker.bench(TimeTracker.java:163)
	at net.sourceforge.pmd.lang.java.internal.JavaAstProcessor.process(JavaAstProcessor.java:132)
	at net.sourceforge.pmd.lang.java.internal.JavaAstProcessor.process(JavaAstProcessor.java:164)
	at net.sourceforge.pmd.lang.java.internal.JavaAstProcessor.process(JavaAstProcessor.java:148)
	at net.sourceforge.pmd.lang.java.ast.JavaParser.parseImpl(JavaParser.java:69)
	at net.sourceforge.pmd.lang.java.ast.JavaParser.parseImpl(JavaParser.java:25)
	at net.sourceforge.pmd.lang.ast.impl.javacc.JjtreeParserAdapter.parse(JjtreeParserAdapter.java:36)
	at net.sourceforge.pmd.lang.impl.PmdRunnable.parse(PmdRunnable.java:112)
	at net.sourceforge.pmd.lang.impl.PmdRunnable.processSource(PmdRunnable.java:132)
	at net.sourceforge.pmd.lang.impl.PmdRunnable.run(PmdRunnable.java:80)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.IllegalStateException: Disambiguation pass should resolve everything except qualified ctor calls
	at net.sourceforge.pmd.lang.java.ast.TypesFromAst.getReferenceEnsureResolved(TypesFromAst.java:234)
	at net.sourceforge.pmd.lang.java.ast.TypesFromAst.makeFromClassType(TypesFromAst.java:133)
	at net.sourceforge.pmd.lang.java.ast.TypesFromAst.fromAstImpl(TypesFromAst.java:60)
	at net.sourceforge.pmd.lang.java.ast.TypesFromAst.fromAst(TypesFromAst.java:53)
	at net.sourceforge.pmd.lang.java.ast.InternalApiBridge.buildTypeFromAstInternal(InternalApiBridge.java:200)
	at net.sourceforge.pmd.lang.java.types.ast.internal.LazyTypeResolver.visitType(LazyTypeResolver.java:173)
	at net.sourceforge.pmd.lang.java.types.ast.internal.LazyTypeResolver.visitType(LazyTypeResolver.java:95)
	at net.sourceforge.pmd.lang.java.ast.JavaVisitorBase.visitReferenceType(JavaVisitorBase.java:95)
	at net.sourceforge.pmd.lang.java.ast.JavaVisitorBase.visit(JavaVisitorBase.java:123)
	at net.sourceforge.pmd.lang.java.ast.ASTClassType.acceptVisitor(ASTClassType.java:157)
	at net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode.getTypeMirror(AbstractJavaTypeNode.java:51)
	... 33 more
```