### PR TITLE
Test with job-dsl and maven plugin versions from BOM

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -40,8 +40,6 @@
     <!-- Jenkins Plug-in Dependencies Versions -->
     <git-forensics.version>2.2.1</git-forensics.version>
 
-    <jenkins-maven-plugin.version>3.22</jenkins-maven-plugin.version>
-    <job-dsl.version>1.84</job-dsl.version>
     <flexible-publish.version>0.15.2</flexible-publish.version>
     <form-element-path.version>1.11</form-element-path.version>
 
@@ -390,7 +388,6 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>${jenkins-maven-plugin.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -410,7 +407,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>${job-dsl.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Test with job-dsl and maven plugin versions from BOM

Since the plugin bill of materials includes those plugin versions, let's use them in the test configuration rather than declaring them explicitly and then maintaining them with dependabot updates.

Should not change the runtime dependencies in any way, since they are purely test dependencies.

Supersedes:

* https://github.com/jenkinsci/warnings-ng-plugin/pull/1828

### Testing done

Confirmed that automated tests pass in the plugin module that includes the change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
