### PR TITLE
Remove unused exclusion of spotbugs-annotations from checks-api

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -152,12 +152,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>checks-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -329,12 +323,6 @@
       <artifactId>checks-api</artifactId>
       <scope>test</scope>
       <classifier>tests</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Remove unused exclusion of spotbugs-annotations from checks-api

Current checks-api does not require the exclusion

### Testing done

Confirmed that spotbugs-annotations is not included in the plugin packaging.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

