### PR TITLE
[JENKINS-73894] Un-inline JavaScript in IssuesChartPortlet/portlet.jelly

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/portlet.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/portlet.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
 
   <j:set var="model" value="${it.register(jobs)}"/>
 
@@ -15,12 +15,10 @@
 
   <st:adjunct includes="io.jenkins.plugins.echarts"/>
 
-  <script>
-      {
-          const trendProxy = <st:bind value="${it}"/>;
-
-          echartsJenkinsApi.renderTrendChart('${it.id}-issues-chart', `false`, trendProxy);
-      }
-  </script>
+  <st:bind value="${it}" var="trendProxy"/>
+  <f:invisibleEntry>
+    <span class="issues-chart-portlet-data-holder" data-id="${it.id}" />
+  </f:invisibleEntry>
+  <st:adjunct includes="io.jenkins.plugins.analysis.core.portlets.IssuesChartPortlet.render-trend-chart" />
 
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/render-trend-chart.js
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/render-trend-chart.js
@@ -1,0 +1,2 @@
+const issuesChartPortletId = document.querySelector(".issues-chart-portlet-data-holder").getAttribute("data-id");
+echartsJenkinsApi.renderTrendChart(`${issuesChartPortletId}-issues-chart`, `false`, trendProxy);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-73894
Makes the plugin a step closer to being CSP compatible.

### Testing done
I've installed https://plugins.jenkins.io/dashboard-view/ plugin so that I can reach the code in question. Created a new dashboard view, and in Portlets at the top of the page section I've added Static analysis issues chart. I've not spent time setting up a project that would have actual violations, so my issues chart is empty.

https://www.loom.com/share/9ed2252e9eda40e4a17e8e745757fe18?sid=e90705e4-c41c-4b35-9a20-0bf361676310

https://www.loom.com/share/7a2a6a2cab2d428f8aa8a3af873174a0?sid=8cee3380-af6b-44eb-aff7-a352d126c549


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
