### PR TITLE
Document variables injected into groovy parsers

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -242,6 +242,12 @@ if(!config.contains('pep8-groovy')){
 }
 ```
 
+The following variables are automatically injected into the script by the plugin:
+* `builder`: fluent API based builder for creating new issues (see above code snippet)
+* `matcher`: regular expression matcher (can be used to get more details on regular expression match)
+* `fileName`: name of the file (or console) being analyzed
+* `lineNumber`: current line number containing the match
+
 #### Importing a parser using configuration as code (JCasC)
 
 Groovy based parsers can also be specified using a section in your


### PR DESCRIPTION
Document the variables which are automatically injected into Groovy based parsers. Creators of those parsers should not have to go through the GroovyParser source code to find that information.

Local editor preview: 
![image](https://github.com/user-attachments/assets/e13261e8-0b4c-4f7d-9c95-b97a282f153a)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
