### PR TITLE
Recognize `\R` for multiline regex in groovy parsers

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParser.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParser.java
@@ -86,7 +86,7 @@ public class GroovyParser extends AbstractDescribableImpl<GroovyParser> implemen
     }
 
     private static boolean containsNewline(final String expression) {
-        return StringUtils.contains(expression, "\\n") || StringUtils.contains(expression, "\\r");
+        return StringUtils.containsAny(expression, "\\n", "\\r", "\\R");
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParser.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParser.java
@@ -1,12 +1,5 @@
 package io.jenkins.plugins.analysis.warnings.groovy;
 
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.groovy.control.CompilationFailedException;
@@ -20,6 +13,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import groovy.lang.Script;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -38,7 +37,7 @@ import io.jenkins.plugins.util.JenkinsFacade;
 import io.jenkins.plugins.util.ValidationUtilities;
 
 /**
- * Defines the properties of a warnings parser that uses a Groovy script to parse the warnings log.
+ * Defines the properties of a warning parser that uses a Groovy script to parse the console log.
  *
  * @author Ullrich Hafner
  */

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParserTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParserTest.java
@@ -1,15 +1,17 @@
 package io.jenkins.plugins.analysis.warnings.groovy;
 
-import java.io.IOException;
-import java.io.StringReader;
-
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.Issue;
 
 import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.util.SerializableTest;
+
+import java.io.IOException;
+import java.io.StringReader;
 
 import hudson.model.Run;
 
@@ -57,13 +59,11 @@ class GroovyParserTest extends SerializableTest<GroovyParser> {
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-35262">Issue 35262</a>
      */
-    @Test
-    void issue35262() throws IOException {
-        matchMultiLine("(make(?:(?!make)[\\s\\S])*?make-error:.*(?:\\n|\\r\\n?))");
-        matchMultiLine("(make(?:(?!make)[\\s\\S])*?make-error:.*(?:\\r?))");
-    }
-
-    private void matchMultiLine(final String multiLineRegexp) throws IOException {
+    @Issue("JENKINS-35262")
+    @ParameterizedTest(name = "{index}: Regular expression should be multiline \"{0}\"")
+    @ValueSource(strings = {"\\n|\\r\\n", "\\r", "\\R"})
+    void issue35262(final String regexp) throws IOException {
+        var multiLineRegexp = String.format("(make(?:(?!make)[\\s\\S])*?make-error:.*(?:%s?))", regexp);
         String textToMatch = toString("issue35262.log");
         String script = toString("issue35262.groovy");
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParserTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParserTest.java
@@ -57,6 +57,9 @@ class GroovyParserTest extends SerializableTest<GroovyParser> {
     /**
      * Tries to expose JENKINS-35262: multi-line regular expression parser.
      *
+     * @param regexp
+     *         the regular expression to check
+     *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-35262">Issue 35262</a>
      */
     @Issue("JENKINS-35262")


### PR DESCRIPTION
\R matches _any_ unicode newline sequence, and may appear in custom groovy parsers besides the usual \r and \n.

### Testing done

None. Currently sitting behind a company proxy that prohibits the Maven build to download all dependencies. If you need specific tests, I would have to rework this from a private machine.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue