### PR TITLE
Vale integration

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -2547,30 +2547,6 @@ analyze - iccxxxxcompiler_opts cstat2.c</pre></code>For details check the IAR C-
         </tr>
         <tr>
             <td>
-                vale
-            </td>
-            <td>
-                vale()
-            </td>
-            <td>
-                <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/solid/triangle-exclamation.svg" alt="YamlLint" height="48" width="48">
-            </td>
-            <td>
-                <a href="https://vale.sh">
-                    Vale
-                </a>
-            </td>
-            <td>
-                **/vale-report.json
-            </td>
-        </tr>
-        <tr>
-            <td colspan="5">
-                :bulb: Use option --output=JSON
-            </td>
-        </tr>
-        <tr>
-            <td>
                 yamllint
             </td>
             <td>

--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -2547,6 +2547,30 @@ analyze - iccxxxxcompiler_opts cstat2.c</pre></code>For details check the IAR C-
         </tr>
         <tr>
             <td>
+                vale
+            </td>
+            <td>
+                vale()
+            </td>
+            <td>
+                <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/solid/triangle-exclamation.svg" alt="YamlLint" height="48" width="48">
+            </td>
+            <td>
+                <a href="https://vale.sh">
+                    Vale
+                </a>
+            </td>
+            <td>
+                **/vale-report.json
+            </td>
+        </tr>
+        <tr>
+            <td colspan="5">
+                :bulb: Use option --output=JSON
+            </td>
+        </tr>
+        <tr>
+            <td>
                 yamllint
             </td>
             <td>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/Vale.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/Vale.java
@@ -1,0 +1,31 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.jenkinsci.Symbol;
+import hudson.Extension;
+import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
+
+/**
+* Provides parser for vale reports.
+*/
+public class Vale extends AnalysisModelParser {
+    private static final long serialVersionUID = -251368548183118686L;
+    private static final String ID = "vale";
+
+    /** Create instance. */
+    @DataBoundConstructor
+    public Vale() {
+        super();
+        // empty constructor required for stapler
+    }
+
+    /** Descriptor for this static analysis tool. */
+    @Symbol("vale")
+    @Extension
+    public static class Descriptor extends AnalysisModelParserDescriptor {
+        /** Create instance. **/
+        public Descriptor() {
+            super(ID);
+        }
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
@@ -1056,6 +1056,12 @@ class ParsersITest extends IntegrationTestWithJenkinsPerSuite {
         shouldFindIssuesOfTool(3, new Grype(), "grype-report.json");
     }
 
+    /** Runs the Vale analysis parser on an output file that contains 3 issues. */
+    @Test
+    void shouldFindAllValeIssues() {
+        shouldFindIssuesOfTool(3, new Vale(), "vale-report.json");
+    }
+
     private ResultAction shouldFindIssuesOfTool(final int expectedSizeOfIssues, final ReportScanningTool tool,
             final String... fileNames) {
         String defaultPipelineDefinition = "recordIssues tool: %s(pattern:'**/%s', reportEncoding:'UTF-8')";
@@ -1098,9 +1104,7 @@ class ParsersITest extends IntegrationTestWithJenkinsPerSuite {
     }
 
     @SuppressWarnings({"illegalcatch", "OverlyBroadCatchBlock", "PMD.LinguisticNaming"})
-    private ResultAction findIssuesInPipeline(final String pipelineDefinition,
-            final int expectedSizeOfIssues, final ReportScanningTool tool, final String... fileNames) {
-        try {
+    private ResultAction findIssuesInPipeline(final String pipelineDefinition, final int expectedSizeOfIssues, final ReportScanningTool tool, final String... fileNames) { try {
             WorkflowJob job = createPipeline();
             copyMultipleFilesToWorkspace(job, fileNames);
             job.setDefinition(asStage(String.format(

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/vale-report.json
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/vale-report.json
@@ -1,0 +1,234 @@
+{
+  "file1.adoc": [
+    {
+      "Action": {
+        "Name": "",
+        "Params": null
+      },
+      "Span": [
+        1,
+        5
+      ],
+      "Check": "RedHat.SentenceLength",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/sentencelength/",
+      "Message": "Try to keep sentences to an average of 32 words or fewer.",
+      "Severity": "suggestion",
+      "Match": "While",
+      "Line": 10
+    }
+  ],
+  "file2.adoc": [
+    {
+      "Action": {
+        "Name": "replace",
+        "Params": [
+          "might",
+          "can"
+        ]
+      },
+      "Span": [
+        143,
+        145
+      ],
+      "Check": "RedHat.TermsWarnings",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termswarnings/",
+      "Message": "Consider using 'might' or 'can' rather than 'may' unless updating existing content that uses the term.",
+      "Severity": "warning",
+      "Match": "may",
+      "Line": 39
+    },
+    {
+      "Action": {
+        "Name": "edit",
+        "Params": [
+          "regex",
+          "(\\w+)( using)",
+          "$1 by using"
+        ]
+      },
+      "Span": [
+        44,
+        64
+      ],
+      "Check": "RedHat.Using",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/using/",
+      "Message": "Use 'by using' instead of 'using' when it follows a noun for clarity and grammatical correctness.",
+      "Severity": "warning",
+      "Match": "functionalities using",
+      "Line": 51
+    },
+    {
+      "Action": {
+        "Name": "replace",
+        "Params": [
+          "might",
+          "can"
+        ]
+      },
+      "Span": [
+        24,
+        26
+      ],
+      "Check": "RedHat.TermsWarnings",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termswarnings/",
+      "Message": "Consider using 'might' or 'can' rather than 'may' unless updating existing content that uses the term.",
+      "Severity": "warning",
+      "Match": "may",
+      "Line": 65
+    }
+  ],
+  "file3.adoc": [
+    {
+      "Action": {
+        "Name": "replace",
+        "Params": [
+          "give",
+          "offer"
+        ]
+      },
+      "Span": [
+        11,
+        17
+      ],
+      "Check": "RedHat.SimpleWords",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/simplewords/",
+      "Message": "Use simple language. Consider using 'give' or 'offer' rather than 'provide'.",
+      "Severity": "suggestion",
+      "Match": "provide",
+      "Line": 170
+    },
+    {
+      "Action": {
+        "Name": "replace",
+        "Params": [
+          "complete",
+          "finish"
+        ]
+      },
+      "Span": [
+        29,
+        36
+      ],
+      "Check": "RedHat.SimpleWords",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/simplewords/",
+      "Message": "Use simple language. Consider using 'complete' or 'finish' rather than 'finalize'.",
+      "Severity": "suggestion",
+      "Match": "finalize",
+      "Line": 212
+    },
+    {
+      "Action": {
+        "Name": "replace",
+        "Params": [
+          "complete",
+          "finish"
+        ]
+      },
+      "Span": [
+        5,
+        12
+      ],
+      "Check": "RedHat.SimpleWords",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/simplewords/",
+      "Message": "Use simple language. Consider using 'complete' or 'finish' rather than 'finalize'.",
+      "Severity": "suggestion",
+      "Match": "finalize",
+      "Line": 451
+    },
+    {
+      "Action": {
+        "Name": "replace",
+        "Params": [
+          "give",
+          "offer"
+        ]
+      },
+      "Span": [
+        16,
+        22
+      ],
+      "Check": "RedHat.SimpleWords",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/simplewords/",
+      "Message": "Use simple language. Consider using 'give' or 'offer' rather than 'provide'.",
+      "Severity": "suggestion",
+      "Match": "provide",
+      "Line": 530
+    },
+    {
+      "Action": {
+        "Name": "",
+        "Params": null
+      },
+      "Span": [
+        1,
+        4
+      ],
+      "Check": "RedHat.SentenceLength",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/sentencelength/",
+      "Message": "Try to keep sentences to an average of 32 words or fewer.",
+      "Severity": "suggestion",
+      "Match": "When",
+      "Line": 533
+    },
+    {
+      "Action": {
+        "Name": "",
+        "Params": null
+      },
+      "Span": [
+        1,
+        4
+      ],
+      "Check": "RedHat.SentenceLength",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/sentencelength/",
+      "Message": "Try to keep sentences to an average of 32 words or fewer.",
+      "Severity": "suggestion",
+      "Match": "When",
+      "Line": 535
+    },
+    {
+      "Action": {
+        "Name": "",
+        "Params": null
+      },
+      "Span": [
+        1,
+        3
+      ],
+      "Check": "RedHat.SentenceLength",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/sentencelength/",
+      "Message": "Try to keep sentences to an average of 32 words or fewer.",
+      "Severity": "suggestion",
+      "Match": "The",
+      "Line": 571
+    },
+    {
+      "Action": {
+        "Name": "",
+        "Params": null
+      },
+      "Span": [
+        1,
+        12
+      ],
+      "Check": "RedHat.SentenceLength",
+      "Description": "",
+      "Link": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/sentencelength/",
+      "Message": "Try to keep sentences to an average of 32 words or fewer.",
+      "Severity": "suggestion",
+      "Match": "Additionally",
+      "Line": 717
+    }
+  ]
+}


### PR DESCRIPTION
This adds parsing support for results produced by vale (https://vale.sh/)
Vale is a static checker for English prose.

Depends on https://github.com/jenkinsci/analysis-model/pull/1119

### Testing done

Junit test added.
We're also using this in our own infrastructure.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

