### PR TITLE
[JENKINS-72777] Use icon of configured parser even when ID is overwritten by the user

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DeltaReport.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/DeltaReport.java
@@ -39,9 +39,12 @@ public class DeltaReport {
     public DeltaReport(final Report report, final int currentBuildNumber) {
         allIssues = report;
         outstandingIssues = report;
-        referenceIssues = EMPTY_REPORT;
-        newIssues = EMPTY_REPORT;
-        fixedIssues = EMPTY_REPORT;
+
+        var empty = report.copyEmptyInstance();
+        referenceIssues = empty;
+        newIssues = empty;
+        fixedIssues = empty;
+
         referenceBuildId = StringUtils.EMPTY;
 
         report.logInfo("No valid reference build found");

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IconLabelProvider.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IconLabelProvider.java
@@ -18,18 +18,6 @@ public class IconLabelProvider extends StaticAnalysisLabelProvider {
      *         the ID (i.e., URL)
      * @param name
      *         the name of the tool
-     */
-    public IconLabelProvider(final String id, final String name) {
-        this(id, name, EMPTY_DESCRIPTION, id);
-    }
-
-    /**
-     * Creates a new label provider with the specified ID and name.
-     *
-     * @param id
-     *         the ID (i.e., URL)
-     * @param name
-     *         the name of the tool
      * @param descriptionProvider
      *         provides additional descriptions for an issue
      */

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/LabelProviderFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/LabelProviderFactory.java
@@ -54,7 +54,7 @@ public class LabelProviderFactory {
      * @param name
      *         the name of the tool (might be empty or null)
      *
-     * @return The label provider of the selected static analysis tool. If the tool is not found then a default label
+     * @return The label provider of the selected static analysis tool. If the tool is not found, then a default label
      *         provider is returned.
      */
     public StaticAnalysisLabelProvider create(final String id, @CheckForNull final String name) {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
@@ -50,11 +50,10 @@ public abstract class ReportScanningTool extends Tool {
 
     private String pattern = StringUtils.EMPTY;
     private String reportEncoding = StringUtils.EMPTY;
-    // Use negative case to allow defaulting to false and defaulting to existing behaviour.
     private boolean skipSymbolicLinks = false;
 
     /**
-     * Sets the Ant file-set pattern of files to work with. If the pattern is undefined then the console log is
+     * Sets the Ant file-set pattern of files to work with. If the pattern is undefined, then the console log is
      * scanned.
      *
      * @param pattern
@@ -95,7 +94,7 @@ public abstract class ReportScanningTool extends Tool {
     public abstract IssueParser createParser();
 
     /**
-     * Specify if file scanning skip traversal of symbolic links.
+     * Specify if the file scanning step should skip the traversal of symbolic links.
      *
      * @param skipSymbolicLinks
      *         if symbolic links should be skipped during directory scanning.
@@ -180,6 +179,7 @@ public abstract class ReportScanningTool extends Tool {
 
             List<Report> results = report.getResults();
             Report aggregation;
+            // FIXME: properties are not set in the aggregation
             if (results.isEmpty()) {
                 aggregation = new Report();
             }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
@@ -314,7 +314,15 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
      * @return the label provider for this tool
      */
     public StaticAnalysisLabelProvider getLabelProvider() {
-        return new LabelProviderFactory().create(id, name);
+        return new LabelProviderFactory().create(getParserId(), name);
+    }
+
+    private String getParserId() {
+        var originalReport = getResult().getIssues();
+        if (originalReport.hasParserId()) {
+            return originalReport.getParserId();
+        }
+        return id;
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
@@ -99,16 +99,12 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
     }
 
     private String getIcon(final IssueType type) {
-        switch (type) {
-            case BUG:
-                return "symbol-solid/bug plugin-font-awesome-api";
-            case DUPLICATION:
-                return "symbol-regular/clone plugin-font-awesome-api";
-            case VULNERABILITY:
-                return "symbol-solid/shield-halved plugin-font-awesome-api";
-            default:
-                return ANALYSIS_SVG_ICON;
-        }
+        return switch (type) {
+            case BUG -> "symbol-solid/bug plugin-font-awesome-api";
+            case DUPLICATION -> "symbol-regular/clone plugin-font-awesome-api";
+            case VULNERABILITY -> "symbol-solid/shield-halved plugin-font-awesome-api";
+            default -> ANALYSIS_SVG_ICON;
+        };
     }
 
     private void changeName(final String originalName) {

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SvgIconLabelProvider.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/SvgIconLabelProvider.java
@@ -17,18 +17,6 @@ public class SvgIconLabelProvider extends StaticAnalysisLabelProvider {
      *         the ID (i.e., URL)
      * @param name
      *         the name of the tool
-     */
-    public SvgIconLabelProvider(final String id, final String name) {
-        this(id, name, EMPTY_DESCRIPTION, id);
-    }
-
-    /**
-     * Creates a new label provider with the specified ID and name.
-     *
-     * @param id
-     *         the ID (i.e., URL)
-     * @param name
-     *         the name of the tool
      * @param descriptionProvider
      *         provides additional descriptions for an issue
      */

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnnotatedReport.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnnotatedReport.java
@@ -19,7 +19,7 @@ import io.jenkins.plugins.forensics.blame.Blames;
 import io.jenkins.plugins.forensics.miner.RepositoryStatistics;
 
 /**
- * A report of issues and the associated blame information, i.e. author and commit information of the SCM.
+ * A report of issues and the associated blame information, i.e., author and commit information of the SCM.
  *
  * @author Ullrich Hafner
  */
@@ -27,7 +27,7 @@ public class AnnotatedReport implements Serializable {
     private static final long serialVersionUID = -4797152016409014028L;
 
     private final String id;
-    private final Report aggregatedReport = new Report();
+    private Report aggregatedReport = new Report();
     private final Blames aggregatedBlames = new Blames();
     private final RepositoryStatistics aggregatedRepositoryStatistics = new RepositoryStatistics();
 
@@ -44,14 +44,14 @@ public class AnnotatedReport implements Serializable {
     }
 
     /**
-     * Creates a new instance of {@link AnnotatedReport}. The blames will be initialized empty.
+     * Creates a new instance of {@link AnnotatedReport}. The SCM blames will be initialized empty.
      *
      * @param id
      *         the ID of the report
      * @param report
      *         report with issues
      */
-    public AnnotatedReport(@CheckForNull final String id, final Report report) {
+    public AnnotatedReport(final String id, final Report report) {
         this(id, report, new Blames(), new RepositoryStatistics());
     }
 
@@ -65,7 +65,7 @@ public class AnnotatedReport implements Serializable {
      * @param blames
      *         author and commit information for affected files
      */
-    public AnnotatedReport(@CheckForNull final String id, final Report report, final Blames blames) {
+    public AnnotatedReport(final String id, final Report report, final Blames blames) {
         this(id, report, blames, new RepositoryStatistics());
     }
 
@@ -81,11 +81,13 @@ public class AnnotatedReport implements Serializable {
      * @param statistics
      *         repository statistics for affected files
      */
-    public AnnotatedReport(@CheckForNull final String id, final Report report, final Blames blames,
+    public AnnotatedReport(final String id, final Report report, final Blames blames,
             final RepositoryStatistics statistics) {
         this(id);
 
-        addReport(id, report, blames, statistics);
+        aggregatedReport = report;
+
+        addBlames(id, blames, statistics, report.size());
     }
 
     /**
@@ -99,6 +101,7 @@ public class AnnotatedReport implements Serializable {
     public AnnotatedReport(@CheckForNull final String id, final List<AnnotatedReport> reports) {
         this(id);
 
+        aggregatedReport = new Report();
         addAllReports(reports);
     }
 
@@ -113,6 +116,7 @@ public class AnnotatedReport implements Serializable {
     public AnnotatedReport(@CheckForNull final String id, final Iterable<AnnotatedReport> reports) {
         this(id);
 
+        aggregatedReport = new Report();
         addAllReports(reports);
     }
 
@@ -248,7 +252,12 @@ public class AnnotatedReport implements Serializable {
     private void addReport(final String actualId, final Report report, final Blames blames,
             final RepositoryStatistics statistics) {
         aggregatedReport.addAll(report);
-        sizeOfOrigin.merge(actualId, report.size(), Integer::sum);
+        addBlames(actualId, blames, statistics, report.size());
+    }
+
+    private void addBlames(final String actualId, final Blames blames,
+            final RepositoryStatistics statistics, final int size) {
+        sizeOfOrigin.merge(actualId, size, Integer::sum);
         aggregatedBlames.addAll(blames);
         aggregatedRepositoryStatistics.addAll(statistics);
     }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/tasks/OpenTasks.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/tasks/OpenTasks.java
@@ -127,9 +127,9 @@ public class OpenTasks extends Tool {
     }
 
     /**
-     * Returns whether case should be ignored during the scanning.
+     * Returns whether the case of the characters should be ignored during the scanning.
      *
-     * @return {@code true}  if case should be ignored during the scanning
+     * @return {@code true} if the case should be ignored during the scanning
      */
     @SuppressWarnings("PMD.BooleanGetMethodName")
     public boolean getIgnoreCase() {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/IconLabelProviderTest.java
@@ -37,10 +37,6 @@ class IconLabelProviderTest {
                 .hasName(NAME)
                 .hasSmallIconUrl(DEFAULT_SVG)
                 .hasLargeIconUrl(DEFAULT_SVG);
-        assertThat(new SvgIconLabelProvider(ID, NAME))
-                .hasName(NAME)
-                .hasSmallIconUrl(DEFAULT_SVG)
-                .hasLargeIconUrl(DEFAULT_SVG);
     }
 
     @Test
@@ -50,10 +46,6 @@ class IconLabelProviderTest {
                 .hasSmallIconUrl(PATH + SYMBOL + "-24x24.png")
                 .hasLargeIconUrl(PATH + SYMBOL + "-48x48.png");
         assertThat(new IconLabelProvider(ID, NAME, EMPTY_DESCRIPTION))
-                .hasName(NAME)
-                .hasSmallIconUrl(PATH + ID + "-24x24.png")
-                .hasLargeIconUrl(PATH + ID + "-48x48.png");
-        assertThat(new IconLabelProvider(ID, NAME))
                 .hasName(NAME)
                 .hasSmallIconUrl(PATH + ID + "-24x24.png")
                 .hasLargeIconUrl(PATH + ID + "-48x48.png");

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/WarningsIntegrationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/testutil/WarningsIntegrationTest.java
@@ -308,7 +308,7 @@ public abstract class WarningsIntegrationTest extends IntegrationTest {
      * @param job
      *         the job to register the recorder for
      * @param tool
-     *         the tool tool to use
+     *         the tool to use
      * @param additionalTools
      *         the tool configurations to use
      *

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/MiscIssuesRecorderITest.java
@@ -157,6 +157,37 @@ class MiscIssuesRecorderITest extends IntegrationTestWithJenkinsPerSuite {
     }
 
     /**
+     * Runs the CheckStyle parser and changes name and ID and icon.
+     */
+    @Test
+    @org.junitpioneer.jupiter.Issue("JENKINS-73636, JENKINS-72777")
+    void shouldCreateResultWithCorrectIcon() {
+        var checkstyleImage = "checkstyle.svg";
+
+        FreeStyleProject project = createFreestyleJob("checkstyle.xml");
+        ReportScanningTool configuration = configurePattern(new CheckStyle());
+        enableGenericWarnings(project, configuration);
+
+        ResultAction checkstyle = getResultAction(buildWithResult(project, Result.SUCCESS));
+        assertThat(checkstyle.getId()).isEqualTo("checkstyle");
+        assertThat(checkstyle.getDisplayName()).startsWith("CheckStyle");
+        assertThat(checkstyle.getIconFileName()).endsWith(checkstyleImage);
+
+        project.getPublishersList().clear();
+
+        String changedId = "new-id";
+        configuration.setId(changedId);
+        String changedName = "new-name";
+        configuration.setName(changedName);
+        enableGenericWarnings(project, configuration);
+
+        ResultAction changedProperties = getResultAction(buildWithResult(project, Result.SUCCESS));
+        assertThat(changedProperties.getId()).isEqualTo(changedId);
+        assertThat(changedProperties.getDisplayName()).startsWith(changedName);
+        assertThat(checkstyle.getIconFileName()).endsWith(checkstyleImage);
+    }
+
+    /**
      * Runs the CheckStyle parser without specifying a pattern: the default pattern should be used.
      */
     @Test


### PR DESCRIPTION
See [JENKINS-72777](https://issues.jenkins.io/browse/JENKINS-72777).