### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesDetail.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesDetail.java
@@ -21,8 +21,8 @@ import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.JacksonFacade;
 
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 import hudson.model.Api;
 import hudson.model.ModelObject;
@@ -576,7 +576,7 @@ public class IssuesDetail extends DefaultAsyncTableContentProvider implements Mo
      * @return the new subpage
      */
     @SuppressWarnings("unused") // Called by jelly view
-    public Object getDynamic(final String link, final StaplerRequest request, final StaplerResponse response) {
+    public Object getDynamic(final String link, final StaplerRequest2 request, final StaplerResponse2 response) {
         try {
             return new DetailFactory().createTrendDetails(link, owner, result,
                     report, newIssues, outstandingIssues, fixedIssues,

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
@@ -8,8 +8,8 @@ import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.JacksonFacade;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 import hudson.model.Action;
 import hudson.model.Job;
@@ -151,7 +151,7 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
      *         in case of an error
      */
     @SuppressWarnings("unused") // Called by jelly view
-    public void doIndex(final StaplerRequest request, final StaplerResponse response) throws IOException {
+    public void doIndex(final StaplerRequest2 request, final StaplerResponse2 response) throws IOException {
         Optional<ResultAction> action = getLatestAction();
         if (action.isPresent()) {
             response.sendRedirect2(String.format("../%d/%s", action.get().getOwner().getNumber(),

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
@@ -5,8 +5,8 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import hudson.model.Job;
 import hudson.model.Run;
 
@@ -69,8 +69,8 @@ class JobActionTest {
         assertThat(action.isTrendEmpty()).isFalse();
         assertThat(action.isTrendVisible()).isTrue();
 
-        StaplerResponse response = mock(StaplerResponse.class);
-        action.doIndex(mock(StaplerRequest.class), response);
+        StaplerResponse2 response = mock(StaplerResponse2.class);
+        action.doIndex(mock(StaplerRequest2.class), response);
 
         verify(response).sendRedirect2("../0/" + ANALYSIS_ID);
 
@@ -84,8 +84,8 @@ class JobActionTest {
         Job<?, ?> job = mock(Job.class);
         JobAction action = new JobAction(job, labelProvider, 1);
 
-        StaplerRequest request = mock(StaplerRequest.class);
-        action.doIndex(request, mock(StaplerResponse.class));
+        StaplerRequest2 request = mock(StaplerRequest2.class);
+        action.doIndex(request, mock(StaplerResponse2.class));
 
         verifyNoInteractions(request);
     }


### PR DESCRIPTION
Migrate from deprecated functionality to non-deprecated equivalents.