### PR TITLE
Add methods to configure context lines for fingerprinting 

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
@@ -51,6 +51,7 @@ public abstract class ReportScanningTool extends Tool {
     private String pattern = StringUtils.EMPTY;
     private String reportEncoding = StringUtils.EMPTY;
     private boolean skipSymbolicLinks = false;
+    private int linesLookAhead = 3;
 
     /**
      * Sets the Ant file-set pattern of files to work with. If the pattern is undefined, then the console log is
@@ -131,6 +132,21 @@ public abstract class ReportScanningTool extends Tool {
     @CheckForNull
     public String getReportEncoding() {
         return reportEncoding;
+    }
+
+    /**
+     * Sets the context lines which is used in the fingerprinting process.
+     *
+     * @param linesLookAhead
+     *         the actual number of lines.
+     */
+    @DataBoundSetter
+    public void setLinesLookAhead(final int linesLookAhead) {
+        this.linesLookAhead = linesLookAhead;
+    }
+
+    public int getLinesLookAhead() {
+        return linesLookAhead;
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesScanner.java
@@ -38,6 +38,7 @@ import jenkins.MasterToSlaveFileCallable;
 
 import io.jenkins.plugins.analysis.core.filter.RegexpFilter;
 import io.jenkins.plugins.analysis.core.model.ReportLocations;
+import io.jenkins.plugins.analysis.core.model.ReportScanningTool;
 import io.jenkins.plugins.analysis.core.model.Tool;
 import io.jenkins.plugins.analysis.core.util.AffectedFilesResolver;
 import io.jenkins.plugins.analysis.core.util.ConsoleLogHandler;
@@ -148,9 +149,13 @@ class IssuesScanner {
     }
 
     private ReportPostProcessor createPostProcessor(final Report report) {
+        int linesLookAhead = -1;
+        if (tool instanceof ReportScanningTool) {
+            linesLookAhead = ((ReportScanningTool) tool).getLinesLookAhead();
+        }
         return new ReportPostProcessor(tool.getActualId(), report, sourceCodeEncoding.name(),
                 createBlamer(report), filters, getPermittedSourceDirectories(), sourceDirectories,
-                postProcessingMode);
+                postProcessingMode, linesLookAhead);
     }
 
     private Set<String> getPermittedSourceDirectories() {
@@ -261,11 +266,12 @@ class IssuesScanner {
         private final Set<String> requestedSourceDirectories;
         private final PostProcessingMode postProcessingMode;
         private final List<RegexpFilter> filters;
+        private final int linesLookAhead;
 
         @SuppressWarnings("checkstyle:ParameterNumber")
         ReportPostProcessor(final String id, final Report report, final String sourceCodeEncoding,
-                final Blamer blamer, final List<RegexpFilter> filters, final Set<String> permittedSourceDirectories,
-                final Set<String> requestedSourceDirectories, final PostProcessingMode postProcessingMode) {
+                            final Blamer blamer, final List<RegexpFilter> filters, final Set<String> permittedSourceDirectories,
+                            final Set<String> requestedSourceDirectories, final PostProcessingMode postProcessingMode, final int linesLookAhead) {
             super();
 
             this.id = id;
@@ -276,6 +282,7 @@ class IssuesScanner {
             this.permittedSourceDirectories = permittedSourceDirectories;
             this.requestedSourceDirectories = requestedSourceDirectories;
             this.postProcessingMode = postProcessingMode;
+            this.linesLookAhead = linesLookAhead;
         }
 
         @Override
@@ -365,7 +372,13 @@ class IssuesScanner {
             report.logInfo("Creating fingerprints for all affected code blocks to track issues over different builds");
 
             FingerprintGenerator generator = new FingerprintGenerator();
-            generator.run(new FullTextFingerprint(), report, getCharset());
+            if (linesLookAhead < 0) {
+                // no-arg constructor defaults context lines to 3
+                generator.run(new FullTextFingerprint(), report, getCharset());
+            }
+            else {
+                generator.run(new FullTextFingerprint(linesLookAhead), report, getCharset());
+            }
         }
     }
 

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ReportScanningTool/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ReportScanningTool/config.jelly
@@ -35,6 +35,10 @@
     <f:combobox/>
   </f:entry>
 
+  <f:entry title="${%title.linesLookAhead}" field="linesLookAhead">
+    <f:number default="3" min="0"/>
+  </f:entry>
+
   <st:include class="${descriptor.clazz}" page="local-config.jelly" optional="true"/>
 
   <i:tool-defaults/>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ReportScanningTool/config.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ReportScanningTool/config.properties
@@ -12,3 +12,4 @@ description.patternOrConsole=<a rel="noopener noreferrer" href="{0}">Fileset ''i
     If you leave this field blank, then the console log will be scanned for issues.
 title.defaultPattern=Default Pattern
 title.skipSymbolicLinks=Skip symbolic links when searching for files
+title.linesLookAhead=Configure the context lines

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ReportScanningTool/help-linesLookAhead.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/ReportScanningTool/help-linesLookAhead.html
@@ -1,0 +1,6 @@
+<div>
+    Configures the number of context lines used for issue fingerprinting in report analysis.
+    This value determines how many lines before and after an issue are included for better context.
+    It cannot be negative and the default value is 3.
+    This setting applies only to report-based analysis and is not available for console log scanning.
+</div>

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/AffectedFilesResolverITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/AffectedFilesResolverITest.java
@@ -24,12 +24,15 @@ import hudson.model.Run;
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;
 import io.jenkins.plugins.analysis.core.model.IssuesDetail;
 import io.jenkins.plugins.analysis.core.model.IssuesModel.IssuesRow;
+import io.jenkins.plugins.analysis.core.model.ReportScanningTool;
 import io.jenkins.plugins.analysis.core.model.ResultAction;
 import io.jenkins.plugins.analysis.core.steps.IssuesRecorder;
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerSuite;
 import io.jenkins.plugins.analysis.core.util.AffectedFilesResolver;
 import io.jenkins.plugins.analysis.warnings.Eclipse;
 import io.jenkins.plugins.analysis.warnings.Gcc4;
+import io.jenkins.plugins.analysis.warnings.Java;
+import io.jenkins.plugins.forensics.reference.SimpleReferenceRecorder;
 import io.jenkins.plugins.prism.PermittedSourceCodeDirectory;
 import io.jenkins.plugins.prism.PrismConfiguration;
 import io.jenkins.plugins.prism.SourceCodeDirectory;
@@ -53,6 +56,10 @@ class AffectedFilesResolverITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String ECLIPSE_REPORT_ONE_AFFECTED_AFFECTED_FILE = FOLDER + "/eclipseOneAffectedFile.txt";
     private static final int ROW_NUMBER_ACTUAL_AFFECTED_FILE = 0;
     private static final String COPY_FILES = "Copying affected files to Jenkins' build folder";
+    private static final String INITIAL_JAVA_REPORT = FOLDER + "/javalog-1.txt";
+    private static final String MODIFIED_JAVA_REPORT = FOLDER + "/javalog-2.txt";
+    private static final String INITIAL_JAVA_FINGERPRINT_SOURCE_FILE =  FOLDER + "/FingerprintTestWithoutModification.java";
+    private static final String MODIFIED_JAVA_FINGERPRINT_SOURCE_FILE = FOLDER + "/FingerprintTestWithModification.java";
 
     /**
      * Verifies that the affected source code is copied and shown in the source code view. If the file is deleted in the
@@ -325,6 +332,57 @@ class AffectedFilesResolverITest extends IntegrationTestWithJenkinsPerSuite {
 
         assertThat(getConsoleLog(result))
                 .doesNotContain(COPY_FILES, " copied", " not-found", " with I/O error");
+    }
+
+    @Test
+    void shouldProduceDifferentFingerprints() {
+        FreeStyleProject project = createFreeStyleProject();
+
+        AnalysisResult firstBuildResult = configureBuildForFingerprintTests(project, INITIAL_JAVA_REPORT,
+                INITIAL_JAVA_FINGERPRINT_SOURCE_FILE, -1, false);
+
+        AnalysisResult secondBuildResult =  configureBuildForFingerprintTests(project, MODIFIED_JAVA_REPORT,
+                MODIFIED_JAVA_FINGERPRINT_SOURCE_FILE, -1, true);
+
+        assertThat(secondBuildResult.getNewIssues().size()).isEqualTo(1);
+        assertThat(firstBuildResult.getIssues().get(0).getFingerprint())
+                .isNotEqualTo(secondBuildResult.getIssues().get(0).getFingerprint());
+    }
+
+    @Test
+    void shouldProduceSameFingerprints() {
+        FreeStyleProject project = createFreeStyleProject();
+
+        AnalysisResult firstBuildResult = configureBuildForFingerprintTests(project, INITIAL_JAVA_REPORT,
+                INITIAL_JAVA_FINGERPRINT_SOURCE_FILE, 2, false);
+
+        AnalysisResult secondBuildResult =  configureBuildForFingerprintTests(project, MODIFIED_JAVA_REPORT,
+                MODIFIED_JAVA_FINGERPRINT_SOURCE_FILE, 2, true);
+
+        assertThat(secondBuildResult.getNewIssues().size()).isEqualTo(0);
+        assertThat(firstBuildResult.getIssues().get(0).getFingerprint())
+                .isEqualTo(secondBuildResult.getIssues().get(0).getFingerprint());
+    }
+
+    private AnalysisResult configureBuildForFingerprintTests(final FreeStyleProject project, final String logFile,
+                                                             final String srcFile, final int linesLookAhead, final boolean warningEnabled) {
+        copyFileToWorkspace(project, logFile, "log-java.txt");
+        copyFileToWorkspace(project, srcFile, "FingerprintITest.java");
+
+        ReportScanningTool tool = createTool(new Java(), "**/*.txt");
+
+        if (linesLookAhead != -1) {
+            tool.setLinesLookAhead(linesLookAhead);
+        }
+
+        // else linesLookAhead defaults to 3
+
+        if (!warningEnabled) {
+            project.getPublishersList().add(new SimpleReferenceRecorder());
+            enableWarnings(project, tool);
+        }
+
+        return scheduleBuildAndAssertStatus(project, Result.SUCCESS);
     }
 
     private AnalysisResult buildEclipseProject(final String... files) {

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/FingerprintTestWithModification.java
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/FingerprintTestWithModification.java
@@ -1,0 +1,9 @@
+public class FingerprintITest {
+    public static void main(String[] args) {
+        int a = 3;
+        //Newline comment to disrupt the fingerprint for default context i.e 3
+        String x = "Testing the tool-based linesLookAhead configuration";
+        System.out.println(a);
+        System.out.println(m);
+    }
+}

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/FingerprintTestWithoutModification.java
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/FingerprintTestWithoutModification.java
@@ -1,0 +1,8 @@
+public class FingerprintITest {
+    public static void main(String[] args) {
+        int a = 3;
+        String x = "Testing the tool-based linesLookAhead configuration";
+        System.out.println(a);
+        System.out.println(m);
+    }
+}

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/javalog-1.txt
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/javalog-1.txt
@@ -1,0 +1,5 @@
+FingerprintITest.java:6: error: cannot find symbol
+        System.out.println(m);
+                           ^
+  symbol:   variable m
+  location: class FingerprintITest

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/javalog-2.txt
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/affected-files/javalog-2.txt
@@ -1,0 +1,5 @@
+FingerprintITest.java:7: error: cannot find symbol
+        System.out.println(m);
+                           ^
+  symbol:   variable m
+  location: class FingerprintITest


### PR DESCRIPTION
This PR introduces a tool-based configuration for setting the context lines considered during the fingerprinting process in FullTextFingerprint.
See :
https://issues.jenkins.io/browse/JENKINS-61607
https://github.com/jenkinsci/analysis-model/pull/1136
https://github.com/jenkinsci/analysis-model-api-plugin/pull/184
(https://github.com/jenkinsci/warnings-ng-plugin/pull/1943)
