### PR TITLE
Display Project Actions from previous builds when missing in latest build

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisBuildsFallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisBuildsFallback.java
@@ -37,7 +37,7 @@ public final class AnalysisBuildsFallback extends TransientActionFactory<Job<?, 
                 .map(ResultAction.class::cast)
                 .collect(Collectors.toList());
 
-        if (!currentResultActions.isEmpty()) {
+        if (!currentResultActions.isEmpty() || currentBuild.isBuilding()) {
             return Collections.emptyList();
         }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisBuildsFallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisBuildsFallback.java
@@ -1,0 +1,91 @@
+package io.jenkins.plugins.analysis.core.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.model.TransientActionFactory;
+
+/**
+ * Registers this class as a Jenkins extension that provides fallback for analysis builds.
+ * This helps display warnings in the job view even when no analysis is present in the latest build.
+ * The actions are rendered by attaching the most recent valid {@link ResultAction} to the build.
+ */
+@Extension
+public final class AnalysisBuildsFallback extends TransientActionFactory<Job<?, ?>> {
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<Job<?, ?>> type() {
+        return (Class) Job.class;
+    }
+
+    @NonNull
+    @Override
+    public Collection<? extends Action> createFor(@NonNull final Job<?, ?> target) {
+        //Check if the current build has valid action(s) and returns an empty list.
+        Run<?, ?> currentBuild = target.getLastBuild();
+        List<ResultAction> currentResultActions = currentBuild.getActions().stream()
+                .filter(ResultAction.class::isInstance)
+                .map(ResultAction.class::cast)
+                .collect(Collectors.toList());
+
+        if (!currentResultActions.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        //Iterate through previous builds to find most recent valid ResultAction instance and return it.
+        Run<?, ?> previousBuild = currentBuild.getPreviousBuild();
+        while (previousBuild != null) {
+            List<ResultAction> resultActions = previousBuild.getActions().stream()
+                    .filter(ResultAction.class::isInstance)
+                    .map(ResultAction.class::cast)
+                    .collect(Collectors.toList());
+
+            List<Action> actionList = new ArrayList<>();
+            for (ResultAction action : resultActions) {
+                actionList.addAll(action.getProjectActions());
+                actionList.add(new TransientProjectResultAction(action));
+            }
+
+            if (!resultActions.isEmpty()) {
+                return actionList;
+            }
+
+            previousBuild = previousBuild.getPreviousBuild();
+        }
+
+        return Collections.emptyList();
+    }
+}
+
+//Wrapper class for ResultActions to get the absolute URL for the link on the side panel.
+class TransientProjectResultAction implements Action {
+    private final ResultAction resultActions;
+
+    TransientProjectResultAction(final ResultAction resultActions) {
+        this.resultActions = resultActions;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return resultActions.getIconFileName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return resultActions.getDisplayName() + " (Previous)";
+    }
+
+    @Override
+    public String getUrlName() {
+        return resultActions.getAbsoluteUrl();
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/MissingResultFallbackHandler.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/MissingResultFallbackHandler.java
@@ -37,7 +37,6 @@ public final class MissingResultFallbackHandler extends TransientActionFactory<J
         }
 
         List<ResultAction> currentResultActions = currentBuild.getActions(ResultAction.class);
-
         if (!currentResultActions.isEmpty()) {
             return Collections.emptyList();
         }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/MissingResultFallbackHandler.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/MissingResultFallbackHandler.java
@@ -30,7 +30,6 @@ public final class MissingResultFallbackHandler extends TransientActionFactory<J
     @NonNull
     @Override
     public Collection<? extends Action> createFor(@NonNull final Job<?, ?> target) {
-        // Check if the current build has valid action(s) and returns an empty list.
         Run<?, ?> currentBuild = target.getLastBuild();
         if (currentBuild == null || currentBuild.isBuilding()) {
             return Collections.emptyList();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR introduces an extension which helps to display job links and charts even if latest builds does not contain results.
See: [Issue](https://issues.jenkins.io/browse/JENKINS-57636)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
