### PR TITLE
[JENKINS-75344] Fix custom URL name of result action

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -19,6 +19,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+        if: github.event_name == 'pull_request_target'
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
@@ -1,10 +1,5 @@
 package io.jenkins.plugins.analysis.core.model;
 
-import java.io.Serializable;
-import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.Collections;
-
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.analysis.Issue;
@@ -13,6 +8,11 @@ import edu.hm.hafner.util.Generated;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -164,7 +164,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
 
     @Override
     public String getUrlName() {
-        return getLabelProvider().getId();
+        return StringUtils.defaultIfEmpty(id, getLabelProvider().getId());
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -1,5 +1,12 @@
 package io.jenkins.plugins.analysis.core.steps;
 
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -8,13 +15,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-
-import edu.hm.hafner.analysis.Severity;
-import edu.hm.hafner.util.FilteredLog;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -680,11 +680,11 @@ public class IssuesRecorder extends Recorder {
             Tool tool = analysisTools.get(0);
 
             var customId = StringUtils.defaultIfBlank(getId(), tool.getActualId());
-            AnnotatedReport report = new AnnotatedReport(customId);
-            report.add(scanWithTool(run, workspace, listener, tool), tool.getActualId());
-
             var customName = StringUtils.defaultIfBlank(getName(), tool.getActualName());
             var customIcon = StringUtils.defaultIfBlank(getIcon(), tool.getIcon());
+
+            AnnotatedReport report = new AnnotatedReport(customId);
+            report.add(scanWithTool(run, workspace, listener, tool), tool.getActualId());
 
             results.add(publishResult(run, workspace, listener, customName,
                     report, customName, customIcon, resultHandler));
@@ -714,9 +714,9 @@ public class IssuesRecorder extends Recorder {
                     results.add(publishResult(run, workspace, listener, tool.getActualName(),
                             report, getReportName(tool), tool.getIcon(), resultHandler));
                 }
-            }
-            if (StringUtils.isNotBlank(getId()) || !StringUtils.isNotBlank(getName()) || !StringUtils.isNotBlank(getIcon())) {
-                logHandler.log("Do not set id, name, or icon for both the tool and the recorder");
+                if (StringUtils.isNotBlank(getId()) || StringUtils.isNotBlank(getName()) || StringUtils.isNotBlank(getIcon())) {
+                    logHandler.log("Do not set id, name, or icon of recorder when multiple tools are defined");
+                }
             }
         }
         return results;

--- a/plugin/src/main/webapp/js/issues-sunburst.js
+++ b/plugin/src/main/webapp/js/issues-sunburst.js
@@ -75,6 +75,11 @@
                     color: '#ddd',
                     borderWidth: 2
                 },
+                emphasis: {
+                    itemStyle: {
+                        color: 'inherit'
+                    }
+                },
                 label: {
                     rotate: 'horizontal'
                 }

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/AnalysisResult.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/AnalysisResult.java
@@ -1,11 +1,5 @@
 package io.jenkins.plugins.analysis.warnings;
 
-import java.net.URL;
-import java.util.Collection;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -14,6 +8,12 @@ import org.openqa.selenium.support.ui.Select;
 import com.google.inject.Injector;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.PageObject;
@@ -217,7 +217,7 @@ public class AnalysisResult extends PageObject {
      * @return the instance of the PageObject to which the link leads to
      */
     public <T extends PageObject> T openLinkOnSite(final WebElement element, final Class<T> type) {
-        String link = element.getAttribute("href");
+        String link = element.getDomAttribute("href");
         T retVal = newInstance(type, injector, url(link));
         element.click();
         return retVal;
@@ -229,7 +229,7 @@ public class AnalysisResult extends PageObject {
      * @return the select-element where the user can choose how many rows should be displayed
      */
     public Select getLengthSelectElementByActiveTab() {
-        var element = find(By.xpath(ACTIVE_TAB + "select[contains(@name, 'length')]"));
+        var element = find(By.xpath(ACTIVE_TAB + "select[@id[starts-with(., 'dt-length')]]"));
         return new Select(element);
     }
 

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/AnalysisSummary.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/AnalysisSummary.java
@@ -1,5 +1,9 @@
 package io.jenkins.plugins.analysis.warnings;
 
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -8,10 +12,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.PageObject;
@@ -34,6 +34,7 @@ public class AnalysisSummary extends PageObject {
     private final WebElement infoElement;
 
     private final List<WebElement> results;
+    private final WebElement summary;
 
     /**
      * Creates a new page object representing the analysis summary on the build page of a job.
@@ -49,7 +50,7 @@ public class AnalysisSummary extends PageObject {
 
         this.id = id;
 
-        WebElement summary = getElement(By.id(id + "-summary"));
+        summary = getElement(By.id(id + "-summary"));
         titleElement = summary.findElement(By.id(id + "-title"));
 
         infoElement = summary.findElement(By.className("fa-image-button"));
@@ -68,6 +69,15 @@ public class AnalysisSummary extends PageObject {
      */
     public String getTitleText() {
         return titleElement.getText();
+    }
+
+    /**
+     * Return the image the summary. Note that not all tools use an image. Symbols are not supported by this method.
+     *
+     * @return the image
+     */
+    public String getImage() {
+        return summary.findElement(by.xpath("../../td/img")).getDomAttribute("src");
     }
 
     /**

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/DetailsTabUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/DetailsTabUiTest.java
@@ -1,9 +1,5 @@
 package io.jenkins.plugins.analysis.warnings;
 
-import java.time.Duration;
-import java.util.Collection;
-import java.util.List;
-
 import org.junit.Test;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -11,6 +7,10 @@ import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.po.Build;
@@ -33,7 +33,7 @@ public class DetailsTabUiTest extends UiTest {
     private static final String DETAILS_TAB_RESOURCES = "details_tab_test/";
 
     /**
-     * When a single warning is being recognized only the issues-tab should be shown.
+     * When a single warning is being recognized, only the issues-tab should be shown.
      */
     @Test
     public void shouldPopulateDetailsTabSingleWarning() {
@@ -56,7 +56,7 @@ public class DetailsTabUiTest extends UiTest {
     }
 
     /**
-     * When two warnings are being recognized in one file the tabs issues, files and folders should be shown.
+     * When two warnings are being recognized in one file, then the tabs "issues", "files", and "folders" should be shown.
      */
     @Test
     public void shouldPopulateDetailsTabMultipleWarnings() {

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/SmokeTests.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/SmokeTests.java
@@ -178,16 +178,6 @@ public class SmokeTests extends UiTest {
         assertThat(resultPage.getPaginationButtons()).hasSize(1);
     }
 
-    private StringBuilder createReportFilesStep(final WorkflowJob job, final int build) {
-        String[] fileNames = {"checkstyle-report.xml", "pmd-report.xml", "findbugsXml.xml", "cpd.xml", "Main.java", "pep8Test.txt"};
-        StringBuilder resourceCopySteps = new StringBuilder();
-        for (String fileName : fileNames) {
-            resourceCopySteps.append(job.copyResourceStep(
-                    "/build_status_test/build_0" + build + "/" + fileName).replace("\\", "\\\\"));
-        }
-        return resourceCopySteps;
-    }
-
     @Override
     protected IssuesRecorder addAllRecorders(final FreeStyleJob job) {
         IssuesRecorder issuesRecorder = super.addAllRecorders(job);

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/UiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/UiTest.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.analysis.warnings;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -7,8 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.plugins.dashboard_view.DashboardView;
@@ -18,6 +18,7 @@ import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.Container;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.Job;
+import org.jenkinsci.test.acceptance.po.WorkflowJob;
 
 import io.jenkins.plugins.analysis.warnings.AnalysisResult.Tab;
 import io.jenkins.plugins.analysis.warnings.AnalysisSummary.InfoType;
@@ -29,6 +30,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
  * Base class for all UI tests. Provides several helper methods that can be used by all tests.
  */
 @SuppressFBWarnings("BC")
+@SuppressWarnings("checkstyle:ClassFanOutComplexity")
 abstract class UiTest extends AbstractJUnitTest {
     static final String WARNINGS_PLUGIN_PREFIX = "/";
     static final String CHECKSTYLE_ID = "checkstyle";
@@ -61,6 +63,16 @@ abstract class UiTest extends AbstractJUnitTest {
         }
         job.addPublisher(ReferenceFinder.class);
         return job;
+    }
+
+    protected StringBuilder createReportFilesStep(final WorkflowJob job, final int build) {
+        String[] fileNames = {"checkstyle-report.xml", "pmd-report.xml", "findbugsXml.xml", "cpd.xml", "Main.java", "pep8Test.txt"};
+        StringBuilder resourceCopySteps = new StringBuilder();
+        for (String fileName : fileNames) {
+            resourceCopySteps.append(job.copyResourceStep(
+                    "/build_status_test/build_0" + build + "/" + fileName).replace("\\", "\\\\"));
+        }
+        return resourceCopySteps;
     }
 
     protected IssuesRecorder addAllRecorders(final FreeStyleJob job) {

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/UiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/UiTest.java
@@ -30,7 +30,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
  * Base class for all UI tests. Provides several helper methods that can be used by all tests.
  */
 @SuppressFBWarnings("BC")
-@SuppressWarnings("checkstyle:ClassFanOutComplexity")
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity", "PMD.CouplingBetweenObjects"})
 abstract class UiTest extends AbstractJUnitTest {
     static final String WARNINGS_PLUGIN_PREFIX = "/";
     static final String CHECKSTYLE_ID = "checkstyle";


### PR DESCRIPTION
In https://github.com/jenkinsci/warnings-ng-plugin/pull/1919 a new icon property has been added to the recorder. This accidentally broke the URL mapping of the warning results.

When a custom ID is given, then this ID will be used as URL. Only for empty URLs, the default ID of the label provider will be used.

Additionally, the log messages have been fixed when the ID is used in tool and recorder (see JENKINS-75391).

