### PR TITLE
[JENKINS-75394] Use custom ID and icon in project action

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.jenkins.plugins</groupId>
   <artifactId>warnings-ng</artifactId>
-  <version>12.5.0-SNAPSHOT</version>
+  <version>12.4.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Warnings Plugin</name>
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/JobAction.java
@@ -1,12 +1,12 @@
 package io.jenkins.plugins.analysis.core.model;
 
-import java.io.IOException;
-import java.util.Optional;
-
 import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.JacksonFacade;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import java.io.IOException;
+import java.util.Optional;
 
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
@@ -38,6 +38,7 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
     private final StaticAnalysisLabelProvider labelProvider;
     private final int numberOfTools;
     private final TrendChartType trendChartType;
+    private final String urlName;
 
     /**
      * Creates a new instance of {@link JobAction}.
@@ -48,9 +49,12 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
      *         the label provider
      * @param numberOfTools
      *         the number of tools that have results to show
+     * @deprecated
+     *        Use {@link #JobAction(Job, StaticAnalysisLabelProvider, int, TrendChartType, String)} instead.
      */
+    @Deprecated
     public JobAction(final Job<?, ?> owner, final StaticAnalysisLabelProvider labelProvider, final int numberOfTools) {
-        this(owner, labelProvider, numberOfTools, TrendChartType.TOOLS_ONLY);
+        this(owner, labelProvider, numberOfTools, TrendChartType.TOOLS_ONLY, labelProvider.getId());
     }
 
     /**
@@ -64,9 +68,32 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
      *         the number of tools that have results to show
      * @param trendChartType
      *         determines if the trend chart will be shown
+     * @deprecated
+     *        Use {@link #JobAction(Job, StaticAnalysisLabelProvider, int, TrendChartType, String)} instead.
      */
+    @Deprecated
     public JobAction(final Job<?, ?> owner, final StaticAnalysisLabelProvider labelProvider, final int numberOfTools,
             final TrendChartType trendChartType) {
+        this(owner, labelProvider, numberOfTools, trendChartType, labelProvider.getId());
+    }
+
+    /**
+     * Creates a new instance of {@link JobAction}.
+     *
+     * @param owner
+     *         the job that owns this action
+     * @param labelProvider
+     *         the label provider
+     * @param numberOfTools
+     *         the number of tools that have results to show
+     * @param trendChartType
+     *         determines if the trend chart will be shown
+     * @param urlName
+     *        the custom URL name of this action
+     */
+    public JobAction(final Job<?, ?> owner, final StaticAnalysisLabelProvider labelProvider, final int numberOfTools,
+            final TrendChartType trendChartType, final String urlName) {
+        this.urlName = urlName;
         this.owner = owner;
         this.labelProvider = labelProvider;
         this.numberOfTools = numberOfTools;
@@ -79,7 +106,7 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
      * @return the ID
      */
     public String getId() {
-        return labelProvider.getId();
+        return urlName;
     }
 
     @Override
@@ -116,7 +143,7 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
             return new NullAnalysisHistory();
         }
         else {
-            return new AnalysisHistory(lastCompletedBuild, new ByIdResultSelector(labelProvider.getId()));
+            return new AnalysisHistory(lastCompletedBuild, new ByIdResultSelector(getId()));
         }
     }
 
@@ -129,14 +156,12 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
     @Override
     @CheckForNull
     public String getIconFileName() {
-        return createBuildHistory().getBaselineResult()
-                .map(result -> labelProvider.getSmallIconUrl())
-                .orElse(null);
+        return labelProvider.getSmallIconUrl();
     }
 
     @Override
     public String getUrlName() {
-        return labelProvider.getId();
+        return urlName;
     }
 
     /**
@@ -155,7 +180,7 @@ public class JobAction implements Action, AsyncConfigurableTrendChart {
         Optional<ResultAction> action = getLatestAction();
         if (action.isPresent()) {
             response.sendRedirect2(String.format("../%d/%s", action.get().getOwner().getNumber(),
-                    labelProvider.getId()));
+                    getId()));
         }
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
@@ -9,6 +9,7 @@ import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Collection;
@@ -93,6 +94,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
      *
      * @return this
      */
+    @Serial
     protected Object readResolve() {
         if (trendChartType == null) {
             trendChartType = TrendChartType.TOOLS_ONLY;
@@ -202,7 +204,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
     public Collection<? extends Action> getProjectActions() {
         return Collections.singleton(
                 new JobAction(owner.getParent(), getLabelProvider(), result.getSizePerOrigin().size(),
-                        trendChartType));
+                        trendChartType, getUrlName()));
     }
 
     @Whitelisted

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/JobActionTest.java
@@ -1,9 +1,9 @@
 package io.jenkins.plugins.analysis.core.model;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.util.Collections;
-
-import org.junit.jupiter.api.Test;
 
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
@@ -38,12 +38,16 @@ class JobActionTest {
 
         Job<?, ?> job = mock(Job.class);
 
-        JobAction action = new JobAction(job, labelProvider, 1);
+        JobAction action = createJobAction(job, labelProvider);
         assertThat(action.getDisplayName()).isEqualTo(LINK_NAME);
         assertThat(action.getTrendName()).isEqualTo(TREND_NAME);
         assertThat(action.getId()).isEqualTo(ID);
         assertThat(action.getUrlName()).isEqualTo(ID);
         assertThat(action.getOwner()).isEqualTo(job);
+    }
+
+    private JobAction createJobAction(final Job<?, ?> job, final StaticAnalysisLabelProvider labelProvider) {
+        return new JobAction(job, labelProvider, 1, TrendChartType.TOOLS_ONLY, labelProvider.getId());
     }
 
     @Test
@@ -53,8 +57,8 @@ class JobActionTest {
         when(labelProvider.getSmallIconUrl()).thenReturn(ICON);
 
         Job<?, ?> job = mock(Job.class);
-        JobAction action = new JobAction(job, labelProvider, 1);
-        assertThat(action.getIconFileName()).isNull();
+        JobAction action = createJobAction(job, labelProvider);
+        assertThat(action.getIconFileName()).isEqualTo(ICON); // a JobAction should always show an icon
 
         Run<?, ?> reference = createValidReferenceBuild(0);
         when(job.getLastCompletedBuild()).thenAnswer(i -> reference);
@@ -74,15 +78,17 @@ class JobActionTest {
 
         verify(response).sendRedirect2("../0/" + ANALYSIS_ID);
 
-        JobAction hiddenAction = new JobAction(job, labelProvider, 1, TrendChartType.NONE);
+        var url = "something";
+        JobAction hiddenAction = new JobAction(job, labelProvider, 1, TrendChartType.NONE, url);
         assertThat(hiddenAction.isTrendVisible()).isFalse();
+        assertThat(hiddenAction.getUrlName()).isEqualTo(url);
     }
 
     @Test
     void shouldRedirect() throws IOException {
         StaticAnalysisLabelProvider labelProvider = mock(StaticAnalysisLabelProvider.class);
         Job<?, ?> job = mock(Job.class);
-        JobAction action = new JobAction(job, labelProvider, 1);
+        JobAction action = createJobAction(job, labelProvider);
 
         StaplerRequest2 request = mock(StaplerRequest2.class);
         action.doIndex(request, mock(StaplerResponse2.class));

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/JobActionITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/JobActionITest.java
@@ -1,8 +1,9 @@
 package io.jenkins.plugins.analysis.warnings.steps;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.Issue;
+
+import java.util.List;
 
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import hudson.model.Actionable;
@@ -67,6 +68,37 @@ class JobActionITest extends IntegrationTestWithJenkinsPerSuite {
         assertThatTrendChartIsVisible(jobActions.get(0));
         assertThat(jobActions.get(0).getIconFileName()).endsWith(StaticAnalysisLabelProvider.ANALYSIS_SVG_ICON);
         assertThat(jobActions.get(0).getUrlName()).isEqualTo(ECLIPSE_URL_NAME);
+    }
+
+    @Test
+    @Issue("JENKINS-75394")
+    void shouldShowTrendChartWithCustomUrlAndIcon() {
+        FreeStyleProject project = createFreeStyleProjectWithWorkspaceFilesWithSuffix(ECLIPSE_LOG);
+        var tool = new Eclipse();
+        var url = "custom-eclipse";
+        tool.setId(url);
+        var icon = "custom-eclipse.svg";
+        tool.setIcon(icon);
+        enableGenericWarnings(project, tool);
+
+        Run<?, ?> build = buildWithResult(project, Result.SUCCESS);
+        assertActionProperties(project, build, url, icon);
+
+        project.getActions(JobAction.class);
+        List<JobAction> jobActions = project.getActions(JobAction.class);
+
+        assertThatTrendChartIsHidden(jobActions.get(0)); // trend chart requires at least two builds
+        assertThat(jobActions.get(0).getIconFileName()).isEqualTo(icon);
+        assertThat(jobActions.get(0).getUrlName()).isEqualTo(url);
+
+        build = buildWithResult(project, Result.SUCCESS);
+        assertActionProperties(project, build, url, icon);
+
+        jobActions = project.getActions(JobAction.class);
+
+        assertThatTrendChartIsVisible(jobActions.get(0));
+        assertThat(jobActions.get(0).getIconFileName()).isEqualTo(icon);
+        assertThat(jobActions.get(0).getUrlName()).isEqualTo(url);
     }
 
     /**
@@ -182,7 +214,7 @@ class JobActionITest extends IntegrationTestWithJenkinsPerSuite {
     }
 
     /**
-     * Verifies that the side bar link is not missing if there are no issues in the latest build.
+     * Verifies that the sidebar link is not missing if there are no issues in the latest build.
      */
     @Test
     void shouldHaveSidebarLinkEvenWhenLastActionHasNoResults() {
@@ -251,6 +283,11 @@ class JobActionITest extends IntegrationTestWithJenkinsPerSuite {
     }
 
     private void assertActionProperties(final FreeStyleProject project, final Run<?, ?> build) {
+        assertActionProperties(project, build, "eclipse", "symbol-solid/triangle-exclamation plugin-font-awesome-api");
+    }
+
+    private void assertActionProperties(final FreeStyleProject project, final Run<?, ?> build,
+            final String urlName, final String iconName) {
         JobAction jobAction = project.getAction(JobAction.class);
         assertThat(jobAction).isNotNull();
 
@@ -260,8 +297,8 @@ class JobActionITest extends IntegrationTestWithJenkinsPerSuite {
         StaticAnalysisLabelProvider labelProvider = new Eclipse().getLabelProvider();
         assertThat(jobAction.getDisplayName()).isEqualTo(labelProvider.getLinkName());
         assertThat(jobAction.getTrendName()).isEqualTo(labelProvider.getTrendName());
-        assertThat(jobAction.getUrlName()).isEqualTo(labelProvider.getId());
+        assertThat(jobAction.getUrlName()).isEqualTo(urlName);
         assertThat(jobAction.getOwner()).isEqualTo(project);
-        assertThat(jobAction.getIconFileName()).endsWith(labelProvider.getSmallIconUrl());
+        assertThat(jobAction.getIconFileName()).endsWith(iconName);
     }
 }

--- a/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/analysis/warnings/IssuesRecorder.java
@@ -1,10 +1,10 @@
 package io.jenkins.plugins.analysis.warnings;
 
+import org.openqa.selenium.WebElement;
+
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import org.openqa.selenium.WebElement;
 
 import org.jenkinsci.test.acceptance.po.AbstractStep;
 import org.jenkinsci.test.acceptance.po.Control;
@@ -676,6 +676,7 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
         private final Control highThreshold = control("tool/highThreshold");
         private final Control id = control("tool/id");
         private final Control name = control("tool/name");
+        private final Control icon = control("tool/icon");
         private final Control analysisModelId = control("tool/analysisModelId");
         private final Control skipSymbolicLinks = control("tool/skipSymbolicLinks");
 
@@ -720,6 +721,20 @@ public class IssuesRecorder extends AbstractStep implements PostBuildStep {
          */
         public StaticAnalysisTool setName(final String name) {
             this.name.set(name);
+
+            return this;
+        }
+
+        /**
+         * Sets the custom name of the tool.
+         *
+         * @param icon
+         *         the icon
+         *
+         * @return this
+         */
+        public StaticAnalysisTool setIcon(final String icon) {
+            this.icon.set(icon);
 
             return this;
         }


### PR DESCRIPTION
Use the ID of the result action when creating a project action. This is a followup to
https://github.com/jenkinsci/warnings-ng-plugin/pull/1970
