### PR TITLE
[JENKINS-75438] Store parser ID directly in `AnalysisResult`

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
@@ -51,7 +51,7 @@ import io.jenkins.plugins.util.ValidationUtilities;
  * @author Ullrich Hafner
  */
 @SuppressFBWarnings(value = "SE, DESERIALIZATION_GADGET", justification = "transient fields are restored using a Jenkins callback (or are checked for null)")
-@SuppressWarnings({"PMD.TooManyFields", "PMD.ExcessiveClassLength", "PMD.GodClass", "checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
+@SuppressWarnings({"PMD.TooManyFields", "PMD.ExcessiveClassLength", "PMD.GodClass", "PMD.CyclomaticComplexity", "checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 public class AnalysisResult implements Serializable, StaticAnalysisRun {
     @Serial
     private static final long serialVersionUID = 1110545450292087475L;

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ResultAction.java
@@ -43,6 +43,7 @@ import io.jenkins.plugins.util.QualityGateResult;
 @SuppressWarnings("ClassFanOutComplexity")
 @SuppressFBWarnings(value = "SE", justification = "transient field owner ist restored using a Jenkins callback")
 public class ResultAction implements HealthReportingAction, LastBuildAction, RunAction2, StaplerProxy, Serializable {
+    @Serial
     private static final long serialVersionUID = 6683647181785654908L;
 
     private transient Run<?, ?> owner;
@@ -317,11 +318,15 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
     }
 
     private String getParserId() {
-        var originalReport = getResult().getIssues();
-        if (originalReport.hasParserId()) {
-            return originalReport.getParserId();
+        var parserId = getResult().getParserId();
+        if (isValidId(parserId)) {
+            return parserId;
         }
         return id;
+    }
+
+    private boolean isValidId(final String parserId) {
+        return StringUtils.isNotBlank(parserId) && !"-".equals(parserId);
     }
 
     /**
@@ -335,7 +340,7 @@ public class ResultAction implements HealthReportingAction, LastBuildAction, Run
     }
 
     /**
-     * Empty method as workaround for Stapler bug: JavaScript method in target object is not found.
+     * Empty method as workaround for Stapler bug: JavaScript method in the target object is not found.
      *
      * @return unused string (since Firefox requires that Ajax calls return something)
      */


### PR DESCRIPTION
The [fix for JENKINS-72777](https://issues.jenkins.io/browse/JENKINS-72777) requires to store the original ID of a parser, so that we can show the correct name, label, and ID in the UI even when the user changed some of these properties.

This caused [JENKINS-75438](https://issues.jenkins.io/browse/JENKINS-75438) because now all issues are read from the XML to get this ID. This causes severe performance issues for jobs that have large reports with a lot of issues. 

It will improve the performance if the ID of the parser is stored in the `AnalysisResult` which is deserialized from XML anyway.

