### PR TITLE
[JENKINS-75728] bugfix: initialize build.xml "item" element since this plugin uses it…

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/AnalysisResult.java
@@ -112,6 +112,10 @@ public class AnalysisResult implements Serializable, StaticAnalysisRun {
     /** The result of the quality gate evaluation. */
     private QualityGateResult qualityGateResult;
 
+    static {
+        Run.XSTREAM2.alias("item", QualityGateResult.QualityGateResultItem.class);
+    }
+
     /**
      * Creates a new instance of {@link AnalysisResult}.
      *


### PR DESCRIPTION
… in addition to the coverage plugin

This is a bug fix.
Failure to initialize "item" XML element by using `XSTREAM2.alias("item", ...)` was causing unreadable data
"item" is used by both coverage and warnings-ng plugin, but only coverage plugin initialize the xml.
This was causing a race condition where in some cases, build.xml could not be read.

### Testing done

Make sure no more unreadable data is present

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
