### PR TITLE
Add additional configuration options for the warnings column

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration.java
@@ -1,0 +1,152 @@
+package io.jenkins.plugins.analysis.core.columns;
+
+import edu.hm.hafner.util.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.verb.POST;
+import org.jenkinsci.Symbol;
+import hudson.Extension;
+import hudson.util.ListBoxModel;
+import jenkins.appearance.AppearanceCategory;
+import jenkins.model.GlobalConfigurationCategory;
+import jenkins.model.Jenkins;
+
+import io.jenkins.plugins.analysis.core.util.IssuesStatistics.StatisticProperties;
+import io.jenkins.plugins.util.GlobalConfigurationFacade;
+import io.jenkins.plugins.util.GlobalConfigurationItem;
+import io.jenkins.plugins.util.JenkinsFacade;
+
+/**
+ * Global appearance configuration for the Warnings Plugin.
+ */
+@Extension
+@Symbol("warnings")
+public class WarningsAppearanceConfiguration extends GlobalConfigurationItem {
+    /**
+     * Returns the singleton instance of this {@link WarningsAppearanceConfiguration}.
+     *
+     * @return the singleton instance
+     */
+    public static WarningsAppearanceConfiguration getInstance() {
+        return all().get(WarningsAppearanceConfiguration.class);
+    }
+
+    private boolean enableColumnByDefault = true;
+    private StatisticProperties defaultType = StatisticProperties.TOTAL;
+    private String defaultName = Messages.IssuesTotalColumn_Label();
+
+    private final JenkinsFacade jenkins;
+
+    /**
+     * Creates the global configuration and loads the initial values from the corresponding
+     * XML file.
+     */
+    @DataBoundConstructor
+    public WarningsAppearanceConfiguration() {
+        super();
+
+        jenkins =  new JenkinsFacade();
+
+        load();
+    }
+
+    @VisibleForTesting
+    WarningsAppearanceConfiguration(final GlobalConfigurationFacade facade, final JenkinsFacade jenkins) {
+        super(facade);
+
+        this.jenkins = jenkins;
+
+        load();
+    }
+
+    @NonNull
+    @Override
+    public GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(AppearanceCategory.class);
+    }
+
+    /**
+     * Returns whether the warnings column should be displayed by default.
+     *
+     * @return {@code true} if warnings column is shown by default, {@code false} otherwise
+     */
+    public boolean isEnableColumnByDefault() {
+        return enableColumnByDefault;
+    }
+
+    /**
+     * Enables or disables the warnings column by default.
+     *
+     * @param enableColumnByDefault
+     *         {@code true} to enable the warnings column by default, {@code false} to disable it
+     */
+    @DataBoundSetter
+    public void setEnableColumnByDefault(final boolean enableColumnByDefault) {
+        this.enableColumnByDefault = enableColumnByDefault;
+
+        save();
+    }
+
+    /**
+     * Returns the default type to be used.
+     *
+     * @return the default type
+     */
+    public StatisticProperties getDefaultType() {
+        return defaultType;
+    }
+
+    /**
+     * Sets the default type to be used.
+     *
+     * @param defaultType
+     *         the default type to use
+     */
+    @DataBoundSetter
+    public void setDefaultType(final StatisticProperties defaultType) {
+        this.defaultType = defaultType;
+
+        save();
+    }
+
+    /**
+     * Returns the default name for the warnings' column.
+     *
+     * @return the default name for the warnings' column
+     */
+    public String getDefaultName() {
+        return defaultName;
+    }
+
+    /**
+     * Sets the default name for the warnings' column.
+     *
+     * @param defaultName
+     *         the default name for the warnings' column
+     */
+    @DataBoundSetter
+    public void setDefaultName(final String defaultName) {
+        this.defaultName = defaultName;
+
+        save();
+    }
+
+    /**
+     * Returns a model with all {@link StatisticProperties types} that can be used in the column.
+     *
+     * @return a model with all {@link StatisticProperties types}.
+     */
+    @POST
+    @SuppressWarnings("unused") // used by Stapler view data binding
+    public ListBoxModel doFillDefaultTypeItems() {
+        var model = new ListBoxModel();
+        if (jenkins.hasPermission(Jenkins.READ)) {
+            for (StatisticProperties types : StatisticProperties.values()) {
+                model.add(types.getDisplayName(), types.name());
+            }
+        }
+        return model;
+    }
+}

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/Messages.properties
@@ -1,1 +1,2 @@
 IssuesTotalColumn.Name=Number of static analysis issues
+IssuesTotalColumn.Label=# Issues

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/config.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:section title="${%Warnings Plugin}">
+    <f:entry title="${%title.defaultVisibility}" field="enableColumnByDefault">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="${%title.defaultColumnName}" field="defaultName">
+      <f:textbox default="${%# Issues}"/>
+    </f:entry>
+
+    <f:entry title="${%title.defaultType}" field="defaultType">
+      <f:select/>
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/config.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/config.properties
@@ -1,0 +1,3 @@
+title.defaultColumnName=Default Column Name
+title.defaultType=Default Issues Type
+title.defaultVisibility=Display warnings column in 'All View' by default

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/help-defaultName.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/help-defaultName.html
@@ -1,0 +1,2 @@
+The default name for the warnings column of the "All View". The "All View" cannot be configured by
+users, so this option provides a way to set the name for all users globally.

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/help-defaultType.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/help-defaultType.html
@@ -1,0 +1,3 @@
+The default type of the warnings counter to display in the warnings column of the "All View".
+The "All View" cannot be configured by users, so this option provides a way to set the type
+for all users globally.

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/help-enableColumnByDefault.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfiguration/help-enableColumnByDefault.html
@@ -1,0 +1,2 @@
+Show the "Warnings" column in the "All View" by default. The "All View" cannot be configured by users,
+so this option provides a way to enable or disable the warnings column for all users globally.

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumnTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/columns/IssuesTotalColumnTest.java
@@ -6,12 +6,17 @@ import org.junitpioneer.jupiter.Issue;
 import java.util.Arrays;
 import java.util.Collections;
 
+import hudson.DescriptorExtensionList;
 import hudson.model.Job;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn.AnalysisResultDescription;
 import io.jenkins.plugins.analysis.core.model.AnalysisResult;
 import io.jenkins.plugins.analysis.core.model.LabelProviderFactory;
 import io.jenkins.plugins.analysis.core.util.IssuesStatistics.StatisticProperties;
+import io.jenkins.plugins.util.GlobalConfigurationFacade;
+import io.jenkins.plugins.util.JenkinsFacade;
 
 import static io.jenkins.plugins.analysis.core.testutil.JobStubs.*;
 import static org.assertj.core.api.Assertions.*;
@@ -194,7 +199,11 @@ class IssuesTotalColumnTest {
     }
 
     private IssuesTotalColumn createColumn() {
-        var column = new IssuesTotalColumn();
+        var jenkins = mock(JenkinsFacade.class);
+        var descriptorList = DescriptorExtensionList.createDescriptorList((Jenkins) null, GlobalConfiguration.class);
+        descriptorList.add(new WarningsAppearanceConfiguration(mock(GlobalConfigurationFacade.class), jenkins));
+        when(jenkins.getDescriptorsFor(GlobalConfiguration.class)).thenReturn(descriptorList);
+        var column = new IssuesTotalColumn(jenkins);
         column.setName(NAME);
         LabelProviderFactory labelProviderFactory = mock(LabelProviderFactory.class);
         registerTool(labelProviderFactory, CHECK_STYLE_ID, CHECK_STYLE_NAME);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/columns/WarningsAppearanceConfigurationTest.java
@@ -1,0 +1,65 @@
+package io.jenkins.plugins.analysis.core.columns;
+
+import org.junit.jupiter.api.Test;
+
+import jenkins.model.Jenkins;
+
+import io.jenkins.plugins.analysis.core.util.IssuesStatistics.StatisticProperties;
+import io.jenkins.plugins.util.GlobalConfigurationFacade;
+import io.jenkins.plugins.util.JenkinsFacade;
+
+import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class WarningsAppearanceConfigurationTest {
+    @Test
+    void shouldInitializeConfiguration() {
+        var facade = mock(GlobalConfigurationFacade.class);
+        var jenkins = mock(JenkinsFacade.class);
+        var configuration = new WarningsAppearanceConfiguration(facade, jenkins);
+
+        assertThat(configuration.doFillDefaultTypeItems()).isEmpty();
+        when(jenkins.hasPermission(Jenkins.READ)).thenReturn(true);
+        assertThat(configuration.doFillDefaultTypeItems()).map(o -> o.value)
+                .contains("TOTAL",
+                        "TOTAL_ERROR",
+                        "TOTAL_HIGH",
+                        "TOTAL_NORMAL",
+                        "TOTAL_LOW",
+                        "TOTAL_MODIFIED",
+                        "NEW",
+                        "NEW_ERROR",
+                        "NEW_HIGH",
+                        "NEW_NORMAL",
+                        "NEW_LOW",
+                        "NEW_MODIFIED",
+                        "DELTA",
+                        "DELTA_ERROR",
+                        "DELTA_HIGH",
+                        "DELTA_NORMAL",
+                        "DELTA_LOW",
+                        "FIXED");
+
+        verify(facade).load();
+
+        assertThat(configuration).isEnableColumnByDefault();
+        assertThat(configuration).hasDefaultType(StatisticProperties.TOTAL);
+        assertThat(configuration).hasDefaultName(Messages.IssuesTotalColumn_Label());
+
+        configuration.setEnableColumnByDefault(false);
+
+        verify(facade).save();
+        assertThat(configuration).isNotEnableColumnByDefault();
+
+        configuration.setDefaultType(StatisticProperties.NEW);
+
+        verify(facade, times(2)).save();
+        assertThat(configuration).hasDefaultType(StatisticProperties.NEW);
+
+        var name = "Warnings";
+        configuration.setDefaultName(name);
+
+        verify(facade, times(3)).save();
+        assertThat(configuration).hasDefaultName(name);
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/integrations/JobDslITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/integrations/JobDslITest.java
@@ -12,6 +12,7 @@ import hudson.views.ListViewColumn;
 
 import io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn;
 import io.jenkins.plugins.analysis.core.columns.Messages;
+import io.jenkins.plugins.analysis.core.columns.WarningsAppearanceConfiguration;
 import io.jenkins.plugins.analysis.core.model.Tool;
 import io.jenkins.plugins.analysis.core.steps.IssuesRecorder;
 import io.jenkins.plugins.analysis.core.testutil.IntegrationTestWithJenkinsPerTest;
@@ -32,6 +33,19 @@ import static io.jenkins.plugins.analysis.core.assertions.Assertions.*;
  * @author Lorenz Munsch
  */
 class JobDslITest extends IntegrationTestWithJenkinsPerTest {
+    /**
+     * Reads a YAML file with the coverage column configuration and verifies that the column has been configured.
+     */
+    @Test
+    void shouldImportWarningsAppearanceFromYaml() {
+        configureJenkins("column.yaml");
+
+        assertThat(WarningsAppearanceConfiguration.getInstance())
+                .isNotEnableColumnByDefault()
+                .hasDefaultType(StatisticProperties.NEW)
+                .hasDefaultName("New Warnings");
+    }
+
     /**
      * Creates a freestyle job from a YAML file and verifies that issue recorder finds warnings.
      */

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/integrations/column.yaml
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/integrations/column.yaml
@@ -1,0 +1,5 @@
+appearance:
+  warnings:
+    enableColumnByDefault: false
+    defaultType: NEW
+    defaultName: "New Warnings"

--- a/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/IssuesColumnUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/analysis/warnings/IssuesColumnUiTest.java
@@ -19,10 +19,6 @@ import static io.jenkins.plugins.analysis.warnings.IssuesColumnConfiguration.*;
 @WithPlugins("warnings-ng")
 public class IssuesColumnUiTest extends UiTest {
     private static final String CUSTOM_ISSUES_COLUMN_NAME = "Hello World";
-    private static final String CHECK_STYLE_LINK = CHECK_STYLE_NAME + " Warnings";
-    private static final String FIND_BUGS_LINK = FINDBUGS_TOOL + " Warnings";
-    private static final String PMD_LINK = PMD_TOOL + " Warnings";
-    private static final String CPD_LINK = "CPD Duplications";
 
     /**
      * Configure a job with multiple recorders: Should display a table when hovering over the issue column.
@@ -39,11 +35,6 @@ public class IssuesColumnUiTest extends UiTest {
 
         IssuesColumn column = new IssuesColumn(jenkins, DEFAULT_ISSUES_COLUMN_NAME);
         assertThat(column).hasTotalCount("25");
-
-        assertHoverValues(column, 1, CHECK_STYLE_LINK, "3");
-        assertHoverValues(column, 2, FIND_BUGS_LINK, "0");
-        assertHoverValues(column, 3, PMD_LINK, "2");
-        assertHoverValues(column, 4, CPD_LINK, "20");
 
         ListView view = createListView();
 
@@ -66,11 +57,6 @@ public class IssuesColumnUiTest extends UiTest {
         IssuesColumn highColumn = new IssuesColumn(build, CUSTOM_ISSUES_COLUMN_NAME);
         assertThat(highColumn).hasTotalCount("5");
         assertThat(highColumn).doesNotHaveLinkToResults();
-
-        assertHoverValues(highColumn, 1, CHECK_STYLE_LINK, "0");
-        assertHoverValues(highColumn, 2, FIND_BUGS_LINK, "0");
-        assertHoverValues(highColumn, 3, PMD_LINK, "0");
-        assertHoverValues(highColumn, 4, CPD_LINK, "5");
     }
 
     /**
@@ -104,11 +90,6 @@ public class IssuesColumnUiTest extends UiTest {
             recorder.setTool(CHECKSTYLE_TOOL).setPattern("**/checkstyle-report.xml");
             recorder.setEnabledForFailure(true);
         });
-    }
-
-    private void assertHoverValues(final IssuesColumn column, final int rowNumber, final String toolName, final String issueCount) {
-        assertThat(column.getToolFromTooltip(rowNumber)).isEqualTo(toolName);
-        assertThat(column.getTotalFromTooltip(rowNumber)).isEqualTo(issueCount);
     }
 
     private ListView createListView() {


### PR DESCRIPTION
The new appearance configuration for the warnings column should also provide a way to specify the default warnings type and column name.

<img width="1105" height="344" alt="Bildschirmfoto 2025-08-06 um 19 29 01" src="https://github.com/user-attachments/assets/2dd2f727-7eb1-456a-a904-0ff2407acf5d" />

