### PR TITLE
[JENKINS-75764] Skip already shown log messages in console log

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnnotatedReport.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/AnnotatedReport.java
@@ -4,6 +4,7 @@ import com.google.errorprone.annotations.FormatMethod;
 
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.util.Ensure;
+import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import java.io.Serial;
@@ -275,5 +276,19 @@ public class AnnotatedReport implements Serializable {
      */
     public void addRepositoryStatistics(final RepositoryStatistics statistics) {
         aggregatedRepositoryStatistics.addAll(statistics);
+    }
+
+    /**
+     * Returns a logger that contains all info and error messages of the aggregated report.
+     * Note that this logger will not automatically update itself when new messages that are
+     * added to the report afterward.
+     *
+     * @return the logger with all messages
+     */
+    public FilteredLog getLogger() {
+        var log = new FilteredLog();
+        aggregatedReport.getInfoMessages().forEach(log::logInfo);
+        aggregatedReport.getErrorMessages().forEach(log::logError);
+        return log;
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -802,7 +802,7 @@ public class IssuesRecorder extends Recorder {
     AnalysisResult publishResult(final Run<?, ?> run, final FilePath workspace, final TaskListener listener,
             final String loggerName, final AnnotatedReport annotatedReport, final String customName,
             final String customIcon, final ResultHandler resultHandler) {
-        var logHandler = new LogHandler(listener, loggerName);
+        var logHandler = new LogHandler(listener, loggerName, annotatedReport.getLogger());
         logHandler.setQuiet(quiet);
 
         var report = annotatedReport.getReport();

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -470,7 +470,7 @@ public class PublishIssuesStep extends Step implements Serializable {
         private LogHandler getLogger(final AnnotatedReport annotatedReport) throws InterruptedException {
             var toolName = new LabelProviderFactory().create(annotatedReport.getId(),
                     StringUtils.defaultString(step.getName())).getName();
-            var logHandler = new LogHandler(getTaskListener(), toolName);
+            var logHandler = new LogHandler(getTaskListener(), toolName, annotatedReport.getLogger());
             logHandler.setQuiet(step.isQuiet());
 
             var report = annotatedReport.getReport();

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/StepsITest.java
@@ -329,6 +329,8 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         var result = scheduleSuccessfulBuild(job);
 
         assertThat(result).hasTotalSize(1);
+
+        assertThat(getConsoleLog(result)).containsOnlyOnce("[-ERROR-] Can't create fingerprints for some files");
     }
 
     private String createShellStep(final String script) {
@@ -447,6 +449,8 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasSeverity(Severity.ERROR);
         assertThat(result.getIssues().get(3).getDescription())
                 .contains("Re-run Maven using the -X switch to enable full debug logging.");
+
+        assertThat(getConsoleLog(result)).containsOnlyOnce("-> found 4 issues (skipped 0 duplicates)");
     }
 
     /** Runs the Clang parser on an output file that contains 1 issue. */
@@ -461,6 +465,8 @@ class StepsITest extends IntegrationTestWithJenkinsPerSuite {
         var result = scheduleSuccessfulBuild(job);
 
         assertThat(result).hasTotalSize(6);
+
+        assertThat(getConsoleLog(result)).containsOnlyOnce("Parsing console log");
     }
 
     /**


### PR DESCRIPTION
When logging the messages of reports, then make sure that all messages appear only once.
