### PR TITLE
Ignore UI tests during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,14 @@
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <profile>
+      <id>quick-build</id>
+      <modules>
+        <module>plugin</module>
+      </modules>
+    </profile>
+  </profiles>
 
   <repositories>
     <repository>


### PR DESCRIPTION
During a release, the quick-build profile is active. So no tests and analysis is started.
