### PR TITLE
Enable UI tests with profile CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
 
   <modules>
     <module>plugin</module>
-    <module>ui-tests</module>
   </modules>
 
   <properties>
@@ -52,9 +51,10 @@
   </build>
   <profiles>
     <profile>
-      <id>quick-build</id>
+      <id>ci</id>
       <modules>
         <module>plugin</module>
+        <module>ui-tests</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
By default, UI tests are disabled. UI tests need to be manually activated with profile `ci`. 