### PR TITLE
[JENKINS-76020] Resolve missing architecture rules

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>6.1165.v322e76215b_a_4</version>
+      <version>6.1167.v022176c7e0ca_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -294,7 +294,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>6.1165.v322e76215b_a_4</version>
+      <version>6.1167.v022176c7e0ca_</version>
       <classifier>tests</classifier>
       <scope>test</scope>
       <exclusions>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -89,6 +89,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1165.v322e76215b_a_4</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -293,6 +294,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1165.v322e76215b_a_4</version>
       <classifier>tests</classifier>
       <scope>test</scope>
       <exclusions>

--- a/plugin/src/test/java/io/jenkins/plugins/archunit/PluginArchitectureTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/archunit/PluginArchitectureTest.java
@@ -8,7 +8,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
 import edu.hm.hafner.analysis.ParsingCanceledException;
-import edu.hm.hafner.util.ArchitectureRules;
+import edu.hm.hafner.archunit.ArchitectureRules;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
Bump the version of plugin-util to 6.1165.v322e76215b_a_4. This version contains the missing class again.