### PR TITLE
Initialize `fileName` and `lineStart` in groovy parsers

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyExpressionMatcher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyExpressionMatcher.java
@@ -119,6 +119,9 @@ class GroovyExpressionMatcher implements Serializable {
      */
     public Object run(final Matcher matcher, final IssueBuilder builder, final int lineNumber, final String fileName) {
         if (compileScriptIfNotYetDone()) {
+            builder.setFileName(fileName);
+            builder.setLineStart(lineNumber);
+            
             var binding = compiled.getBinding();
             binding.setVariable("matcher", matcher);
             binding.setVariable("builder", builder);

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyExpressionMatcherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyExpressionMatcherTest.java
@@ -73,4 +73,19 @@ class GroovyExpressionMatcherTest {
         var result = matcher.run(null, new IssueBuilder(), 15, FILE_NAME);
         assertThat(result).isEqualTo(new IssueBuilder().setLineStart(15).setFileName("File.txt").buildOptional());
     }
+
+    @Test
+    void shouldAutomaticallySetFileNameAndLineStartWhenNotSetByScript() {
+        // JENKINS-74818: Test that fileName and lineStart are automatically set when not explicitly set by the script
+        var matcher = new GroovyExpressionMatcher(
+                "return builder.setMessage('test message').buildOptional()");
+
+        var result = matcher.run(null, new IssueBuilder(), 42, "test.txt");
+        var expected = new IssueBuilder()
+                .setFileName("test.txt")
+                .setLineStart(42)
+                .setMessage("test message")
+                .buildOptional();
+        assertThat(result).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
Automatically set fileName and lineStart in groovy parsers.

Fixes #3158 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
