### PR TITLE
Remove  broken `equals` in `AxivionSuite`

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/axivion/AxivionSuite.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/axivion/AxivionSuite.java
@@ -27,7 +27,6 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -85,25 +84,6 @@ public final class AxivionSuite extends Tool {
     public AxivionSuite() {
         super();
         // empty constructor required for stapler
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        var that = (AxivionSuite) o;
-        return projectUrl.equals(that.projectUrl) && credentialsId.equals(that.credentialsId) && basedir.equals(
-                that.basedir) && namedFilter.equals(that.namedFilter)
-                && ignoreSuppressedOrJustified == that.ignoreSuppressedOrJustified;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(projectUrl, credentialsId, basedir, namedFilter, ignoreSuppressedOrJustified);
     }
 
     public String getBasedir() {

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/axivion/AxivionSuiteTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/axivion/AxivionSuiteTest.java
@@ -2,9 +2,6 @@ package io.jenkins.plugins.analysis.warnings.axivion;
 
 import org.junit.jupiter.api.Test;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import static org.assertj.core.api.Assertions.*;
 
 class AxivionSuiteTest {
@@ -19,12 +16,5 @@ class AxivionSuiteTest {
 
         assertThat(newTool("https://axivion.com/projects/vscode plugin").getProjectUrl())
                 .isEqualTo("https://axivion.com/projects/vscode%20plugin");
-    }
-
-    @Test
-    void shouldAdhereToEquals() {
-        EqualsVerifier.forClass(AxivionSuite.class)
-                .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
-                .verify();
     }
 }


### PR DESCRIPTION
Subclasses of `Tool` do not need `equals`.