### PR TITLE
Add a header to the tools repeatable so one can change tool order

### DIFF
--- a/plugin/src/main/resources/issues/recorder.jelly
+++ b/plugin/src/main/resources/issues/recorder.jelly
@@ -9,7 +9,7 @@
 
   <f:entry title="${%title.tool}">
     <div id="tools">
-      <f:repeatableProperty minimum="1" field="toolProxies" add="${%Add Tool}" header="Tool"/>
+      <f:repeatableProperty minimum="1" field="toolProxies" add="${%Add Tool}" header="${%Tool}"/>
     </div>
   </f:entry>
 


### PR DESCRIPTION
In the current Web UI, you can add tools, but you cannot change the order.
I would like to be able to change the order using drag and drop.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
