### PR TITLE
Add description in configuration preview of Groovy Based Warnings Parsers

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParser.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParser.java
@@ -461,6 +461,7 @@ public class GroovyParser extends AbstractDescribableImpl<GroovyParser> implemen
             message(okMessage, Messages.GroovyParser_Error_Example_ok_category(issue.getCategory()));
             message(okMessage, Messages.GroovyParser_Error_Example_ok_type(issue.getType()));
             message(okMessage, Messages.GroovyParser_Error_Example_ok_message(issue.getMessage()));
+            message(okMessage, Messages.GroovyParser_Error_Example_ok_description(issue.getDescription()));
             return FormValidation.ok(okMessage.toString());
         }
 

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/groovy/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/groovy/Messages.properties
@@ -21,6 +21,7 @@ GroovyParser.Error.Example.ok.priority=severity: {0}
 GroovyParser.Error.Example.ok.category=category:  {0}
 GroovyParser.Error.Example.ok.type=type: {0}
 GroovyParser.Error.Example.ok.message=message: {0}
+GroovyParser.Error.Example.ok.description=description: {0}
 
 GroovyParser.Error.Example.wrongReturnType=Result of the script is not of type ''Issue'': {0}
 GroovyParser.Error.Example.regexpDoesNotMatch=The regular expression does not match the example text.

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParserTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/groovy/GroovyParserTest.java
@@ -207,6 +207,18 @@ class GroovyParserTest extends SerializableTest<GroovyParser> {
     }
 
     @Test
+    @Issue("JENKINS-3259")
+    void shouldShowDescriptionInPreview() {
+        var descriptor = createDescriptor();
+        var result = descriptor.checkExample(SINGLE_LINE_EXAMPLE, SINGLE_LINE_REGEXP,
+                toString("parser-with-description.groovy"));
+
+        assertThat(result).isOk();
+        assertThat(result.getMessage()).contains("description:");
+        assertThat(result.getMessage()).contains("Link to details");
+    }
+
+    @Test
     void shouldAcceptMultiLineRegularExpression() {
         var descriptor = createDescriptor();
 

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/groovy/parser-with-description.groovy
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/groovy/parser-with-description.groovy
@@ -1,0 +1,8 @@
+package io.jenkins.plugins.analysis.warnings.groovy
+
+return builder.setFileName(matcher.group(1))
+        .setLineStart(Integer.parseInt(matcher.group(2)))
+        .setCategory(matcher.group(3))
+        .setMessage(matcher.group(4))
+        .setDescription("<a href='http://example.com'>Link to details</a>")
+        .buildOptional()


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Description not shown in configuration preview of Groovy Based Warnings Parsers

Fixes #3259 

For more details, see https://github.com/jenkinsci/warnings-ng-plugin/pull/3231
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
