### PR TITLE
Remove prism version, the correct version is part of the BOM again

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -109,7 +109,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>prism-api</artifactId>
-      <version>1.30.0-703.v116fb_3b_5b_b_a_a_</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Specifying a version is not required anymore, as all required API changes are now part of the BOM.