### PR TITLE
Fix infinite loading of portlet

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
@@ -53,6 +53,9 @@ public class SeverityTrendChart implements TrendChart {
         Severity[] visibleSeverities
                 = {Severity.WARNING_LOW, Severity.WARNING_NORMAL, Severity.WARNING_HIGH, Severity.ERROR};
         for (Severity severity : visibleSeverities) {
+            if (!dataSet.getDataSetIds().contains(severity.getName())) {
+                continue;
+            }
             List<Integer> values = dataSet.getSeries(severity.getName());
             if (values.stream().anyMatch(integer -> integer > 0)) {
                 var series = createSeries(severity);

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet.java
@@ -7,6 +7,7 @@ import edu.hm.hafner.echarts.JacksonFacade;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,6 +17,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
 import org.jenkinsci.plugins.variant.OptionalExtension;
 import hudson.model.Descriptor;
 import hudson.model.Job;
+import hudson.model.Run;
 import hudson.plugins.view.dashboard.DashboardPortlet;
 
 import io.jenkins.plugins.analysis.core.charts.SeverityTrendChart;
@@ -128,15 +130,32 @@ public class IssuesChartPortlet extends DashboardPortlet {
         var severityChart = new SeverityTrendChart();
 
         List<Iterable<? extends BuildResult<AnalysisBuildResult>>> histories = jobs.stream()
-                .filter(job -> job.getLastCompletedBuild() != null)
-                .map(Job::getLastCompletedBuild)
-                .flatMap(build -> build.getActions(ResultAction.class)
-                        .stream()
+                .filter(job -> job.getLastBuild() != null)
+                .flatMap(job -> findLastBuildWithResults(job).stream()
                         .filter(createToolFilter(selectTools, tools)))
                 .map(ResultAction::createBuildHistory).collect(Collectors.toList());
 
         return new JacksonFacade().toJson(
                 severityChart.aggregate(histories, new ChartModelConfiguration(AxisType.DATE)));
+    }
+
+    /**
+     * Returns the {@link ResultAction}s from the most recent build of the given job that has analysis results.
+     * Walks backwards from the last build, skipping builds that failed without producing analysis data.
+     *
+     * @param job
+     *         the job to search
+     *
+     * @return list of {@link ResultAction}s from the most recent build with results, or empty if none found
+     */
+    private List<ResultAction> findLastBuildWithResults(final Job<?, ?> job) {
+        for (Run<?, ?> run = job.getLastBuild(); run != null; run = run.getPreviousBuild()) {
+            List<ResultAction> actions = run.getActions(ResultAction.class);
+            if (!actions.isEmpty()) {
+                return actions;
+            }
+        }
+        return Collections.emptyList();
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChartTest.java
@@ -157,6 +157,17 @@ class SeverityTrendChartTest {
                 .isArray().hasSize(4);
     }
 
+    @Test
+    void shouldReturnEmptyModelWhenAggregatingNoHistories() {
+        var chart = new SeverityTrendChart();
+
+        var model = chart.aggregate(List.of(), new ChartModelConfiguration(AxisType.DATE));
+
+        assertThatJson(model).node("series").isArray().isEmpty();
+        assertThatJson(model).node("domainAxisLabels").isArray().isEmpty();
+        assertThatJson(model).node("buildNumbers").isArray().isEmpty();
+    }
+
     private void verifySeries(final LineSeries series, final Severity severity, final int... values) {
         assertThatJson(series).node("name").isEqualTo(LocalizedSeverity.getLocalizedString(severity));
         for (int value : values) {


### PR DESCRIPTION
Split from #3295 

### Problem

When a job's most recent builds fail or are aborted without producing analysis data, the portlet chart enters a permanent loading state. Two root causes combine:

getBuildTrendModel() called getLastCompletedBuild(), which returns the latest build regardless of whether it produced a ResultAction. This yields an empty histories list.
SeverityTrendChart.createChartFromDataSet() then called LinesDataSet.getSeries() on severity keys that were never registered, throwing NoSuchElementException. The exception propagated to the JS layer, leaving the chart spinning forever.

### Fix

IssuesChartPortlet: replace getLastCompletedBuild() with findLastBuildWithResults(), which walks backwards through getPreviousBuild() until it finds a build that actually produced analysis data. Historical data is still shown even when recent builds failed.
SeverityTrendChart: guard each getSeries() call with getDataSetIds().contains(), so an empty history produces a valid empty chart model instead of a crash.

### Testing

Unit test added in SeverityTrendChartTest.shouldReturnEmptyModelWhenAggregatingNoHistories — covers the exact crash path: empty history → valid empty JSON, no exception.
All existing trend chart unit tests pass (13 tests, 0 failures).