### PR TITLE
Fix rendering of multiple instances of the `IssuesChartPortlet`

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/portlet.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/portlet.jelly
@@ -8,17 +8,18 @@
       <td>
         <div id="${it.id}-issues-chart" class="graph-cursor-pointer"
              style="width: 100%; min-height: ${it.height}px; min-width: 500px; height: ${it.height}px;"/>
-
       </td>
     </tr>
   </dp:decorate>
 
   <st:adjunct includes="io.jenkins.plugins.echarts"/>
 
-  <st:bind value="${it}" var="trendProxy"/>
-  <f:invisibleEntry>
-    <span class="issues-chart-portlet-data-holder" data-id="${it.id}" />
-  </f:invisibleEntry>
-  <st:adjunct includes="io.jenkins.plugins.analysis.core.portlets.IssuesChartPortlet.render-trend-chart" />
+  <j:set var="proxyId" value="${h.generateId()}" />
+  <st:bind value="${it}" var="trendProxy${proxyId}"/>
+  <span class="issues-chart-portlet-data-holder"
+        data-id="${it.id}"
+        data-proxy-name="trendProxy${proxyId}"
+        style="display:none"/>
 
+  <st:adjunct includes="io.jenkins.plugins.analysis.core.portlets.IssuesChartPortlet.render-trend-chart" />
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/render-trend-chart.js
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/render-trend-chart.js
@@ -1,2 +1,10 @@
-const issuesChartPortletId = document.querySelector(".issues-chart-portlet-data-holder").getAttribute("data-id");
-echartsJenkinsApi.renderTrendChart(`${issuesChartPortletId}-issues-chart`, `false`, trendProxy);
+window.addEventListener("DOMContentLoaded", () => {
+    const dataHolders = document.querySelectorAll(".issues-chart-portlet-data-holder");
+
+    dataHolders.forEach(dataHolder => {
+        const id = dataHolder.getAttribute("data-id");
+        const proxyName = dataHolder.getAttribute("data-proxy-name");
+
+        echartsJenkinsApi.renderTrendChart(id + '-issues-chart', 'false', window[proxyName]);
+    });
+});


### PR DESCRIPTION
Supersedes the rendering fix from #3295.

### Problem

When multiple IssuesChartPortlet are placed on the same Jenkins dashboard, only the first one ever renders. Each portlet was writing its Stapler proxy to the same hardcoded global JS variable name, so every subsequent portlet overwrote the first binding and then rendered into the wrong container.

### Fix

Generate a unique proxy variable name per portlet using h.generateId()
Store that name in a data- attribute on a hidden element in the portlet markup
Load the JS file once per page via st:adjunct (Jenkins CSP compliant — no inline scripts)
In the JS, iterate all data holders via querySelectorAll and resolve each portlet's proxy via window[proxyName]