### PR TITLE
Fix: trend chart Y-axis starts at dataMin instead of 0

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/HealthTrendChart.java
@@ -37,6 +37,7 @@ public class HealthTrendChart implements TrendChart {
         var dataSet = builder.createDataSet(configuration, results);
 
         var model = new LinesChartModel(dataSet);
+        model.setRangeMin(0);
 
         if (healthDescriptor.isEnabled()) {
             var healthy = createSeries(Messages.Healthy_Name(), JenkinsPalette.GREEN);

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/NewVersusFixedTrendChart.java
@@ -23,6 +23,7 @@ public class NewVersusFixedTrendChart implements TrendChart {
         var builder = new NewVersusFixedSeriesBuilder();
         var dataSet = builder.createDataSet(configuration, results);
         var model = new LinesChartModel(dataSet);
+        model.setRangeMin(0);
 
         var newSeries = getSeries(dataSet, Messages.New_Warnings_Short(), JenkinsPalette.RED,
                 NewVersusFixedSeriesBuilder.NEW);

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/SeverityTrendChart.java
@@ -49,6 +49,7 @@ public class SeverityTrendChart implements TrendChart {
 
     private LinesChartModel createChartFromDataSet(final LinesDataSet dataSet) {
         var model = new LinesChartModel(dataSet);
+        model.setRangeMin(0);
 
         Severity[] visibleSeverities
                 = {Severity.WARNING_LOW, Severity.WARNING_NORMAL, Severity.WARNING_HIGH, Severity.ERROR};

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/ToolsTrendChart.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/charts/ToolsTrendChart.java
@@ -45,6 +45,7 @@ public class ToolsTrendChart implements TrendChart {
         var lineModel = builder.createDataSet(configuration, results);
 
         var model = new LinesChartModel(lineModel);
+        model.setRangeMin(0);
 
         int index = 0;
         for (String toolId : lineModel.getDataSetIds()) {


### PR DESCRIPTION
Split from #3295

### Problem

All four trend chart models (SeverityTrendChart, HealthTrendChart, NewVersusFixedTrendChart, ToolsTrendChart) did not set an explicit rangeMin, so the echarts-api JS fell back to dataMin. This caused the Y-axis to start at the minimum data value rather than 0, visually exaggerating differences between builds.

Note: as mentioned in [#3295 (comment)](https://github.com/jenkinsci/warnings-ng-plugin/pull/3295#issuecomment-4225855741), this change also affects the trend charts displayed on build pages — please verify the rendering there before merging.

### Fix

Explicitly call rangeMin(0) on every LinesChartModel in the four affected chart classes.

### Testing

All existing trend chart unit tests pass.