### PR TITLE
Add configuration action for trends in dashboard portlet

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet.java
@@ -140,6 +140,30 @@ public class IssuesChartPortlet extends DashboardPortlet {
     }
 
     /**
+     * Returns the UI model for an ECharts line chart that shows the issues stacked by severity, using the specified
+     * configuration.
+     *
+     * @param configuration
+     *         JSON configuration of the chart (number of builds, axis type, etc.)
+     *
+     * @return the UI model as JSON
+     */
+    @JavaScriptMethod
+    @SuppressWarnings("unused") // Called by jelly view
+    public String getConfigurableBuildTrendModel(final String configuration) {
+        var severityChart = new SeverityTrendChart();
+
+        List<Iterable<? extends BuildResult<AnalysisBuildResult>>> histories = jobs.stream()
+                .filter(job -> job.getLastBuild() != null)
+                .flatMap(job -> findLastBuildWithResults(job).stream()
+                        .filter(createToolFilter(selectTools, tools)))
+                .map(ResultAction::createBuildHistory).collect(Collectors.toList());
+
+        return new JacksonFacade().toJson(
+                severityChart.aggregate(histories, ChartModelConfiguration.fromJson(configuration)));
+    }
+
+    /**
      * Returns the {@link ResultAction}s from the most recent build of the given job that has analysis results.
      * Walks backwards from the last build, skipping builds that failed without producing analysis data.
      *

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.analysis.core.portlets;
 
 import edu.hm.hafner.echarts.BuildResult;
 import edu.hm.hafner.echarts.ChartModelConfiguration;
-import edu.hm.hafner.echarts.ChartModelConfiguration.AxisType;
 import edu.hm.hafner.echarts.JacksonFacade;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -117,26 +116,6 @@ public class IssuesChartPortlet extends DashboardPortlet {
     @DataBoundSetter
     public void setHeight(final int height) {
         this.height = height;
-    }
-
-    /**
-     * Returns the UI model for an ECharts line chart that shows the issues stacked by severity.
-     *
-     * @return the UI model as JSON
-     */
-    @JavaScriptMethod
-    @SuppressWarnings("unused") // Called by jelly view
-    public String getBuildTrendModel() {
-        var severityChart = new SeverityTrendChart();
-
-        List<Iterable<? extends BuildResult<AnalysisBuildResult>>> histories = jobs.stream()
-                .filter(job -> job.getLastBuild() != null)
-                .flatMap(job -> findLastBuildWithResults(job).stream()
-                        .filter(createToolFilter(selectTools, tools)))
-                .map(ResultAction::createBuildHistory).collect(Collectors.toList());
-
-        return new JacksonFacade().toJson(
-                severityChart.aggregate(histories, new ChartModelConfiguration(AxisType.DATE)));
     }
 
     /**

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/portlet.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/portlet.jelly
@@ -12,7 +12,7 @@
     </tr>
   </dp:decorate>
 
-  <st:adjunct includes="io.jenkins.plugins.echarts"/>
+  <st:adjunct includes="io.jenkins.plugins.analysis.warnings.charts"/>
 
   <j:set var="proxyId" value="${h.generateId()}" />
   <st:bind value="${it}" var="trendProxy${proxyId}"/>

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/render-trend-chart.js
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/portlets/IssuesChartPortlet/render-trend-chart.js
@@ -5,6 +5,6 @@ window.addEventListener("DOMContentLoaded", () => {
         const id = dataHolder.getAttribute("data-id");
         const proxyName = dataHolder.getAttribute("data-proxy-name");
 
-        echartsJenkinsApi.renderTrendChart(id + '-issues-chart', 'false', window[proxyName]);
+        echartsJenkinsApi.renderConfigurableTrendChart(id + '-issues-chart', 'false', 'warnings', window[proxyName]);
     });
 });


### PR DESCRIPTION
The IssuesChartPortlet trend chart was rendered without a configurationId, causing the echarts-api to hide the settings gear icon. Fix by:
- Adding `getConfigurableBuildTrendModel()` to `IssuesChartPortlet` so it responds to the AJAX call made by the configurable chart renderer
- Switching `render-trend-chart.js` to use `renderConfigurableTrendChart` with `configurationId="warnings"` to enable the gear icon
- Including the warnings charts adjunct in `portlet.jelly` to inject the configuration dialog (`trend-configuration-warnings`) into the page

### Root cause

`echartsJenkinsApi.renderTrendChart()` internally passes `configurationId = null` to the chart renderer. When `configurationId` is null, `hasConfigurationDialog()` returns false and the echarts-api hides the gear icon entirely. The job view used `renderConfigurableTrendChart` with `configurationId="warnings"` (via the `c:trend-chart` Jelly tag), but the portlet did not.

### Testing done

For unkown reason, I was unable to load the plugin on our jenkins instance, i'll retry as soon as possible

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed