### PR TITLE
Support image icons in Widget

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/RunTab/styles.css
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/RunTab/styles.css
@@ -37,7 +37,7 @@
     text-decoration: none !important;
     z-index: 2;
 
-    svg {
+    svg, img {
         width: 0.875rem;
         height: 0.875rem;
         margin-bottom: 0;


### PR DESCRIPTION
Spotted on ci.jenkins.io - images in the widget scale unexpectedly.

### Testing done

#### Before
<img width="426" height="371" alt="Screenshot 2026-04-26 at 10 25 37" src="https://github.com/user-attachments/assets/e2ee9173-8511-4acb-808e-0fdeac39e2f8" />

#### After
<img width="420" height="359" alt="image" src="https://github.com/user-attachments/assets/328e0e48-3965-4b2f-9846-69c9d37fb2d7" />

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
