### PR TITLE
Add parser for anchorectl image one-time-scan output

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -40,7 +40,7 @@
     <maven.deploy.skip>false</maven.deploy.skip>
 
     <!-- Library Dependencies Versions -->
-    <analysis-model-tests.version>14.2.0</analysis-model-tests.version>
+    <analysis-model-tests.version>14.8.0</analysis-model-tests.version>
     <pull-request-monitoring.version>335.v525cd64ec76b_</pull-request-monitoring.version>
 
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>analysis-model-api</artifactId>
-      <version>14.2.0-964.v3eb_80540a_92f</version>
+      <version>14.8.0-976.v5097f60f61a_4</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/AnchoreCtl.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/warnings/AnchoreCtl.java
@@ -1,0 +1,35 @@
+package io.jenkins.plugins.analysis.warnings;
+
+import java.io.Serial;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.jenkinsci.Symbol;
+import hudson.Extension;
+
+import io.jenkins.plugins.analysis.core.model.AnalysisModelParser;
+
+/**
+ * Provides parser for anchorectl image one-time-scan vulnerability reports.
+ */
+public class AnchoreCtl extends AnalysisModelParser {
+    @Serial
+    private static final long serialVersionUID = 3481658723094562871L;
+    private static final String ID = "anchore-ctl";
+
+    /** Create instance. */
+    @DataBoundConstructor
+    public AnchoreCtl() {
+        super();
+        // empty constructor required for stapler
+    }
+
+    /** Descriptor for this static analysis tool. */
+    @Symbol("anchoreCtl")
+    @Extension
+    public static class Descriptor extends AnalysisModelParserDescriptor {
+        /** Create instance. **/
+        public Descriptor() {
+            super(ID);
+        }
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/warnings/steps/ParsersITest.java
@@ -1061,6 +1061,12 @@ class ParsersITest extends IntegrationTestWithJenkinsPerSuite {
         shouldFindIssuesOfTool(3, new Grype(), "grype-report.json");
     }
 
+    /** Runs the AnchoreCtl parser on an output file that contains 3 issues. */
+    @Test
+    void shouldFindAllAnchoreCtlIssues() {
+        shouldFindIssuesOfTool(3, new AnchoreCtl(), "anchorectl-report.json");
+    }
+
     /** Runs the Vale analysis parser on an output file that contains 3 issues. */
     @Test
     void shouldFindAllValeIssues() {

--- a/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/anchorectl-report.json
+++ b/plugin/src/test/resources/io/jenkins/plugins/analysis/warnings/steps/anchorectl-report.json
@@ -1,0 +1,68 @@
+{
+  "extendedSupport": false,
+  "sbomId": "sha256:abc123def456",
+  "vulnerabilities": [
+    {
+      "detectedAt": "2026-04-01T00:00:00Z",
+      "feed": "vulnerabilities",
+      "feedGroup": "nvd",
+      "fix": "1.1.1l",
+      "nvdData": [
+        {
+          "cvssV3": { "baseScore": 7.5 },
+          "id": "CVE-2021-1234",
+          "isKev": false,
+          "source": "nvd@nist.gov"
+        }
+      ],
+      "packageName": "openssl",
+      "packagePath": "/usr/lib64/libssl.so.1.1",
+      "packageType": "rpm",
+      "packageVersion": "1.1.1k",
+      "purl": "pkg:rpm/rhel/openssl@1.1.1k",
+      "severity": "High",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-1234",
+      "vuln": "CVE-2021-1234",
+      "willNotFix": false
+    },
+    {
+      "detectedAt": "2026-04-01T00:00:00Z",
+      "feed": "vulnerabilities",
+      "feedGroup": "nvd",
+      "fix": "None",
+      "nvdData": [
+        {
+          "cvssV3": { "baseScore": 9.8 },
+          "id": "CVE-2021-5678",
+          "isKev": true,
+          "source": "nvd@nist.gov"
+        }
+      ],
+      "packageName": "busybox",
+      "packagePath": "/lib/apk/db/installed",
+      "packageType": "APKG",
+      "packageVersion": "1.34.0-r0",
+      "purl": "pkg:apk/alpine/busybox@1.34.0-r0",
+      "severity": "Critical",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-5678",
+      "vuln": "CVE-2021-5678",
+      "willNotFix": false
+    },
+    {
+      "detectedAt": "2026-04-01T00:00:00Z",
+      "feed": "vulnerabilities",
+      "feedGroup": "nvd",
+      "fix": "None",
+      "nvdData": [],
+      "packageName": "zlib",
+      "packagePath": "/lib64/libz.so.1",
+      "packageType": "rpm",
+      "packageVersion": "1.2.11",
+      "purl": "pkg:rpm/rhel/zlib@1.2.11",
+      "severity": "Medium",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-9999",
+      "vuln": "CVE-2022-9999",
+      "willNotFix": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Exposes the `AnchoreCTL` parser in the warnings-ng plugin, backed by the `anchore-ctl` entry added to the analysis-model registry in [jenkinsci/analysis-model#1511](https://github.com/jenkinsci/analysis-model/pull/1511) (released in analysis-model v14.6.0).

The parser handles all three output variants of `anchorectl image one-time-scan` transparently:

| Command | Format |
|---|---|
| `anchorectl image one-time-scan -o json IMAGE` | Unified envelope (`sbom` + `policyEvaluation` + `vulnerabilities`) |
| `anchorectl image one-time-scan -o json --output-directory DIR IMAGE` | Standalone `*_vulnerabilities.json` (camelCase) |
| `anchorectl image one-time-scan -o json-raw --output-directory DIR IMAGE` | Standalone `*_vulnerabilities.json` (snake_case) |

Severity mapping: `Critical → ERROR`, `High → WARNING_HIGH`, `Medium → WARNING_NORMAL`, `Low / Negligible / other → WARNING_LOW`.

Default file pattern (`**/*vulnerabilities*.json`), help text, and Anchore documentation URL are all defined in `AnchoreCtlDescriptor` in analysis-model and surfaced automatically.


## Test plan

- [ ] Build plugin locally against analysis-model-api `14.6.0-*` once released
- [ ] Verify `anchorectl` appears in the tool dropdown in a Jenkins job configuration
- [ ] Run a scan with `anchorectl image one-time-scan -o json` and confirm issues are parsed and trend graphs work