### PR TITLE
Allow for custom details url via recordIssues and publishIssues

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -128,6 +128,8 @@ public class IssuesRecorder extends Recorder {
     @CheckForNull
     private ChecksInfo checksInfo;
 
+    private String detailsURL = StringUtils.EMPTY; // @since 13.0.0: custom details URL for checks
+
     private String id = StringUtils.EMPTY;
     private String name = StringUtils.EMPTY;
     private String icon = StringUtils.EMPTY; // @since 12.0.0: by default no custom icon is set
@@ -188,6 +190,9 @@ public class IssuesRecorder extends Recorder {
         }
         if (targetPathPrefix == null) {
             targetPathPrefix = StringUtils.EMPTY;
+        }
+        if (detailsURL == null) {
+            detailsURL = StringUtils.EMPTY;
         }
         return this;
     }
@@ -516,6 +521,22 @@ public class IssuesRecorder extends Recorder {
 
     public ChecksAnnotationScope getChecksAnnotationScope() {
         return checksAnnotationScope;
+    }
+
+    /**
+     * Sets the custom details URL for checks. If set, this URL will be used instead of the default
+     * Jenkins job URL in the checks published to SCM platforms.
+     *
+     * @param detailsURL
+     *         the custom details URL
+     */
+    @DataBoundSetter
+    public void setDetailsURL(final String detailsURL) {
+        this.detailsURL = detailsURL;
+    }
+
+    public String getDetailsURL() {
+        return detailsURL;
     }
 
     /**
@@ -891,7 +912,7 @@ public class IssuesRecorder extends Recorder {
         var action = publisher.attachAction(trendChartType);
 
         if (!skipPublishingChecks) {
-            var checksPublisher = new WarningChecksPublisher(action, listener, checksInfo);
+            var checksPublisher = new WarningChecksPublisher(action, listener, checksInfo, detailsURL);
             checksPublisher.publishChecks(getChecksAnnotationScope());
         }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -83,6 +83,7 @@ public class PublishIssuesStep extends Step implements Serializable {
     private String name = StringUtils.EMPTY;
     private String icon = StringUtils.EMPTY; // @since 12.0.0: by default no custom icon is set
     private String scm = StringUtils.EMPTY;
+    private String detailsURL = StringUtils.EMPTY; // @since 14.0.0: custom details URL for checks
 
     /**
      * Creates a new instance of {@link PublishIssuesStep}.
@@ -173,6 +174,21 @@ public class PublishIssuesStep extends Step implements Serializable {
 
     public String getScm() {
         return scm;
+    }
+
+    /**
+     * Sets the custom details URL for checks published to SCM platforms.
+     *
+     * @param detailsURL
+     *         the custom URL to use for the details link in checks
+     */
+    @DataBoundSetter
+    public void setDetailsURL(final String detailsURL) {
+        this.detailsURL = detailsURL;
+    }
+
+    public String getDetailsURL() {
+        return detailsURL;
     }
 
     /**
@@ -484,7 +500,8 @@ public class PublishIssuesStep extends Step implements Serializable {
             var action = publisher.attachAction(step.getTrendChartType());
 
             if (!step.isSkipPublishingChecks()) {
-                var checksPublisher = new WarningChecksPublisher(action, getTaskListener(), getContext().get(ChecksInfo.class));
+                var checksPublisher = new WarningChecksPublisher(action, getTaskListener(),
+                        getContext().get(ChecksInfo.class), step.getDetailsURL());
                 checksPublisher.publishChecks(step.getChecksAnnotationScope());
             }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
@@ -107,6 +107,7 @@ public class RecordIssuesStep extends Step implements Serializable {
     private String scm = StringUtils.EMPTY;
 
     private boolean quiet;
+    private String detailsURL = StringUtils.EMPTY; // @since 13.0.0: custom details URL for checks
 
     /**
      * Creates a new instance of {@link RecordIssuesStep}.
@@ -401,6 +402,27 @@ public class RecordIssuesStep extends Step implements Serializable {
     }
 
     /**
+     * Returns the custom details URL for checks.
+     *
+     * @return the custom details URL, or empty string if not set
+     */
+    public String getDetailsURL() {
+        return detailsURL;
+    }
+
+    /**
+     * Sets the custom details URL for checks. If set, this URL will be used instead of the default
+     * Jenkins job URL in the checks published to SCM platforms.
+     *
+     * @param detailsURL
+     *         the custom details URL
+     */
+    @DataBoundSetter
+    public void setDetailsURL(final String detailsURL) {
+        this.detailsURL = detailsURL;
+    }
+
+    /**
      * Returns whether SCM blaming should be disabled.
      *
      * @return {@code true} if SCM blaming should be disabled
@@ -687,6 +709,7 @@ public class RecordIssuesStep extends Step implements Serializable {
             recorder.setSourceDirectories(step.getAllSourceDirectories());
             recorder.setChecksInfo(getContext().get(ChecksInfo.class));
             recorder.setQuiet(step.isQuiet());
+            recorder.setDetailsURL(step.getDetailsURL());
 
             var workspace = getWorkspace();
             workspace.mkdirs();

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -80,11 +80,19 @@ class WarningChecksPublisher {
     private final TaskListener listener;
     @CheckForNull
     private final ChecksInfo checksInfo;
+    @CheckForNull
+    private final String customDetailsURL;
 
     WarningChecksPublisher(final ResultAction action, final TaskListener listener, @CheckForNull final ChecksInfo checksInfo) {
+        this(action, listener, checksInfo, null);
+    }
+
+    WarningChecksPublisher(final ResultAction action, final TaskListener listener, @CheckForNull final ChecksInfo checksInfo,
+            @CheckForNull final String customDetailsURL) {
         this.action = action;
         this.listener = listener;
         this.checksInfo = checksInfo;
+        this.customDetailsURL = customDetailsURL;
     }
 
     /**
@@ -111,6 +119,7 @@ class WarningChecksPublisher {
                 .orElse(labelProvider.getName());
 
         var summary = extractChecksSummary(totals) + "\n" + extractReferenceBuild(result);
+        var detailsUrl = StringUtils.isNotEmpty(customDetailsURL) ? customDetailsURL : action.getAbsoluteUrl();
         return new ChecksDetailsBuilder()
                 .withName(checksName)
                 .withStatus(ChecksStatus.COMPLETED)
@@ -121,7 +130,7 @@ class WarningChecksPublisher {
                         .withText(extractChecksText(totals))
                         .withAnnotations(extractChecksAnnotations(filterIssuesForAnnotations(annotationScope, result), labelProvider))
                         .build())
-                .withDetailsURL(action.getAbsoluteUrl())
+                .withDetailsURL(detailsUrl)
                 .build();
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -469,6 +469,28 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasValue(customUrl);
     }
 
+    /**
+     * Verifies that {@code publishIssues} with custom details URL publishes the URL to the checks API.
+     */
+    @Test
+    void shouldPublishCustomDetailsUrlToChecksApiWithPublishIssues() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var customUrl = "https://my.custom.url.com/build-status";
+
+        project.setDefinition(asStage(
+                createScanForIssuesStep(new CheckStyle()),
+                "publishIssues(issues: [issues], detailsURL: '" + customUrl + "')"));
+
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+
+        assertThat(publishedChecks).hasSize(1);
+        assertThat(publishedChecks.get(0).getDetailsURL())
+                .isPresent()
+                .hasValue(customUrl);
+    }
+
     private FreeStyleProject getFreeStyleJob() {
         var project = createFreeStyleProject();
         project.getPublishersList().add(new SimpleReferenceRecorder());

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -393,6 +393,82 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasFieldOrPropertyWithValue("title", Optional.of("C4101"));
     }
 
+    /**
+     * Verifies that {@link WarningChecksPublisher} uses the default details URL when no custom URL is provided.
+     */
+    @Test
+    void shouldUseDefaultDetailsUrl() {
+        var project = createFreeStyleProjectWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        enableCheckStyleWarnings(project);
+
+        Run<?, ?> run = buildSuccessfully(project);
+        var resultAction = getResultAction(run);
+        var publisher = new WarningChecksPublisher(resultAction, TaskListener.NULL, null);
+
+        var details = publisher.extractChecksDetails(ChecksAnnotationScope.NEW);
+        assertThat(details.getDetailsURL())
+                .isPresent()
+                .hasValue(resultAction.getAbsoluteUrl());
+    }
+
+    /**
+     * Verifies that {@link WarningChecksPublisher} uses the custom details URL when provided.
+     */
+    @Test
+    void shouldUseCustomDetailsUrl() {
+        var project = createFreeStyleProjectWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        enableCheckStyleWarnings(project);
+
+        Run<?, ?> run = buildSuccessfully(project);
+        var resultAction = getResultAction(run);
+        var customUrl = "https://my.public.help.com/failing-jobs";
+        var publisher = new WarningChecksPublisher(resultAction, TaskListener.NULL, null, customUrl);
+
+        var details = publisher.extractChecksDetails(ChecksAnnotationScope.NEW);
+        assertThat(details.getDetailsURL())
+                .isPresent()
+                .hasValue(customUrl);
+    }
+
+    /**
+     * Verifies that {@link WarningChecksPublisher} uses the default details URL when empty string is provided.
+     */
+    @Test
+    void shouldUseDefaultDetailsUrlWhenEmptyStringProvided() {
+        var project = createFreeStyleProjectWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        enableCheckStyleWarnings(project);
+
+        Run<?, ?> run = buildSuccessfully(project);
+        var resultAction = getResultAction(run);
+        var publisher = new WarningChecksPublisher(resultAction, TaskListener.NULL, null, "");
+
+        var details = publisher.extractChecksDetails(ChecksAnnotationScope.NEW);
+        assertThat(details.getDetailsURL())
+                .isPresent()
+                .hasValue(resultAction.getAbsoluteUrl());
+    }
+
+    /**
+     * Verifies that {@code recordIssues} with custom details URL publishes the URL to the checks API.
+     */
+    @Test
+    void shouldPublishCustomDetailsUrlToChecksApi() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var customUrl = "https://my.public.help.com/failing-jobs";
+
+        project.setDefinition(asStage(
+                "recordIssues(tools: [checkStyle(pattern: '**/*issues.txt')], detailsURL: '" + customUrl + "')"));
+
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+
+        assertThat(publishedChecks).hasSize(1);
+        assertThat(publishedChecks.get(0).getDetailsURL())
+                .isPresent()
+                .hasValue(customUrl);
+    }
+
     private FreeStyleProject getFreeStyleJob() {
         var project = createFreeStyleProject();
         project.getPublishersList().add(new SimpleReferenceRecorder());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This should make it possible to specify a detailsURL property to the recordIssues and publishIssues step functions.
When issues are published via the checks api - this details url is hard coded to point to the jenkins ui for the build in question.
in cases when jenkins isn't exposed to the public, this link causes a lot of confusion.

In particular if running jenkins against github repos, and jenkins isn't accessible to the public, these links are also not accessible. This aims to provide a way to provide a custom url that to change the link so the link points to to something that is publically available. 

I tried to include applicable tests to validate that the changes were in doing what I think / expect them to. making sure the defaults case still produces the expected url, and that providing an override is honored.

Resolves: #3352

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
