### PR TITLE
Use custom detailsURL in checks when configured

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -144,6 +144,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>checks-api</artifactId>
+      <version>415.vf022234a_931d</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesRecorder.java
@@ -128,6 +128,9 @@ public class IssuesRecorder extends Recorder {
     @CheckForNull
     private ChecksInfo checksInfo;
 
+    @CheckForNull
+    private String detailsURL = StringUtils.EMPTY;
+
     private String id = StringUtils.EMPTY;
     private String name = StringUtils.EMPTY;
     private String icon = StringUtils.EMPTY; // @since 12.0.0: by default no custom icon is set
@@ -206,6 +209,22 @@ public class IssuesRecorder extends Recorder {
 
     public String getScm() {
         return scm;
+    }
+
+    /**
+     * Sets the custom details URL for checks. If set, this URL will be used instead of the default
+     * Jenkins job URL in the checks published to SCM platforms.
+     *
+     * @param detailsURL
+     *         the custom details URL
+     */
+    @DataBoundSetter
+    public void setDetailsURL(final String detailsURL) {
+        this.detailsURL = detailsURL;
+    }
+
+    public String getDetailsURL() {
+        return detailsURL;
     }
 
     /**
@@ -891,7 +910,7 @@ public class IssuesRecorder extends Recorder {
         var action = publisher.attachAction(trendChartType);
 
         if (!skipPublishingChecks) {
-            var checksPublisher = new WarningChecksPublisher(action, listener, checksInfo);
+            var checksPublisher = new WarningChecksPublisher(action, listener, checksInfo, detailsURL);
             checksPublisher.publishChecks(getChecksAnnotationScope());
         }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/PublishIssuesStep.java
@@ -84,6 +84,9 @@ public class PublishIssuesStep extends Step implements Serializable {
     private String icon = StringUtils.EMPTY; // @since 12.0.0: by default no custom icon is set
     private String scm = StringUtils.EMPTY;
 
+    @CheckForNull
+    private String detailsURL = StringUtils.EMPTY;
+
     /**
      * Creates a new instance of {@link PublishIssuesStep}.
      *
@@ -173,6 +176,15 @@ public class PublishIssuesStep extends Step implements Serializable {
 
     public String getScm() {
         return scm;
+    }
+
+    @DataBoundSetter
+    public void setDetailsURL(final String detailsURL) {
+        this.detailsURL = detailsURL;
+    }
+
+    public String getDetailsURL() {
+        return detailsURL;
     }
 
     /**
@@ -484,7 +496,7 @@ public class PublishIssuesStep extends Step implements Serializable {
             var action = publisher.attachAction(step.getTrendChartType());
 
             if (!step.isSkipPublishingChecks()) {
-                var checksPublisher = new WarningChecksPublisher(action, getTaskListener(), getContext().get(ChecksInfo.class));
+                var checksPublisher = new WarningChecksPublisher(action, getTaskListener(), getContext().get(ChecksInfo.class), step.getDetailsURL());
                 checksPublisher.publishChecks(step.getChecksAnnotationScope());
             }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/RecordIssuesStep.java
@@ -106,6 +106,9 @@ public class RecordIssuesStep extends Step implements Serializable {
     private boolean stopBuild; // @since 12.10010: by default, pipeline execution will not be stopped
     private String scm = StringUtils.EMPTY;
 
+    @CheckForNull
+    private String detailsURL = StringUtils.EMPTY;
+
     private boolean quiet;
 
     /**
@@ -314,6 +317,15 @@ public class RecordIssuesStep extends Step implements Serializable {
     @CheckForNull
     public Tool getTool() {
         return null;
+    }
+
+    @DataBoundSetter
+    public void setDetailsURL(final String detailsURL) {
+        this.detailsURL = detailsURL;
+    }
+
+    public String getDetailsURL() {
+        return detailsURL;
     }
 
     @CheckForNull
@@ -685,6 +697,7 @@ public class RecordIssuesStep extends Step implements Serializable {
             recorder.setStopBuild(step.getStopBuild());
             recorder.setTrendChartType(step.getTrendChartType());
             recorder.setSourceDirectories(step.getAllSourceDirectories());
+            recorder.setDetailsURL(step.getDetailsURL());
             recorder.setChecksInfo(getContext().get(ChecksInfo.class));
             recorder.setQuiet(step.isQuiet());
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -81,10 +81,14 @@ class WarningChecksPublisher {
     @CheckForNull
     private final ChecksInfo checksInfo;
 
-    WarningChecksPublisher(final ResultAction action, final TaskListener listener, @CheckForNull final ChecksInfo checksInfo) {
+    @CheckForNull
+    private final String detailsURLOverride;
+
+    WarningChecksPublisher(final ResultAction action, final TaskListener listener, @CheckForNull final ChecksInfo checksInfo, @CheckForNull final String detailsURLOverride) {
         this.action = action;
         this.listener = listener;
         this.checksInfo = checksInfo;
+        this.detailsURLOverride = detailsURLOverride;
     }
 
     /**
@@ -109,6 +113,11 @@ class WarningChecksPublisher {
         var checksName = Optional.ofNullable(checksInfo).map(ChecksInfo::getName)
                 .filter(StringUtils::isNotEmpty)
                 .orElse(labelProvider.getName());
+        var detailsURL = Optional.ofNullable(detailsURLOverride)
+                .filter(StringUtils::isNotEmpty)
+                .orElseGet(() -> Optional.ofNullable(checksInfo).map(ChecksInfo::getDetailsURL)
+                        .filter(StringUtils::isNotEmpty)
+                        .orElse(action.getAbsoluteUrl()));
 
         var summary = extractChecksSummary(totals) + "\n" + extractReferenceBuild(result);
         return new ChecksDetailsBuilder()
@@ -121,7 +130,7 @@ class WarningChecksPublisher {
                         .withText(extractChecksText(totals))
                         .withAnnotations(extractChecksAnnotations(filterIssuesForAnnotations(annotationScope, result), labelProvider))
                         .build())
-                .withDetailsURL(action.getAbsoluteUrl())
+                .withDetailsURL(detailsURL)
                 .build();
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -34,6 +34,7 @@ import io.jenkins.plugins.checks.api.ChecksOutput.ChecksOutputBuilder;
 import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
 import io.jenkins.plugins.checks.api.ChecksStatus;
 import io.jenkins.plugins.checks.util.CapturingChecksPublisher;
+import io.jenkins.plugins.checks.steps.ChecksInfo;
 import io.jenkins.plugins.forensics.reference.SimpleReferenceRecorder;
 import io.jenkins.plugins.util.QualityGate.QualityGateCriticality;
 
@@ -71,7 +72,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasTotalSize(6)
                 .hasNewSize(2);
 
-        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
+        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null, null);
         assertThat(publisher.extractChecksDetails(ChecksAnnotationScope.NEW))
                 .hasFieldOrPropertyWithValue("detailsURL", Optional.of(getResultAction(run).getAbsoluteUrl()))
                 .usingRecursiveComparison()
@@ -114,14 +115,14 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
      * Verifies that {@link WarningChecksPublisher} correctly reports a successful quality gate.
      */
     @Test
-    void shouldConcludeChecksAsSuccessWhenQualityGateIsPassed() {
+    void shouldConcludeChecksAsSuccessWhenQualityGateHased() {
         var project = createFreeStyleProjectWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
         enableAndConfigureCheckstyle(project,
                 recorder -> recorder.setQualityGates(List.of(
                         new WarningsQualityGate(10, QualityGateType.TOTAL, QualityGateCriticality.UNSTABLE))));
 
         Run<?, ?> build = buildSuccessfully(project);
-        var publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL, null);
+        var publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL, null, null);
 
         assertThat(publisher.extractChecksDetails(ChecksAnnotationScope.NEW).getConclusion())
                 .isEqualTo(ChecksConclusion.SUCCESS);
@@ -156,7 +157,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
         copySingleFileToWorkspace(project, "PVSReport.xml", "PVSReport.plog");
         Run<?, ?> run = buildSuccessfully(project);
 
-        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
+        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null, null);
         var details = publisher.extractChecksDetails(ChecksAnnotationScope.NEW);
 
         assertThat(details.getOutput().get().getChecksAnnotations())
@@ -182,7 +183,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasTotalSize(0)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null)
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null, null)
                 .extractChecksDetails(ChecksAnnotationScope.NEW).getOutput())
                 .isPresent()
                 .get()
@@ -203,7 +204,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasTotalSize(4)
                 .hasNewSize(0);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null)
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null, null)
                 .extractChecksDetails(ChecksAnnotationScope.NEW).getOutput())
                 .isPresent()
                 .get()
@@ -229,7 +230,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasTotalSize(6)
                 .hasNewSize(6);
 
-        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null)
+        assertThat(new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null, null)
                 .extractChecksDetails(ChecksAnnotationScope.NEW).getOutput())
                 .isPresent()
                 .get()
@@ -251,7 +252,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
         copySingleFileToWorkspace(project, "pmd-report.xml");
         Run<?, ?> run = buildSuccessfully(project);
 
-        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
+        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null, null);
         var details = publisher.extractChecksDetails(ChecksAnnotationScope.NEW);
 
         assertThat(details.getOutput().get().getChecksAnnotations().get(0))
@@ -278,6 +279,59 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
 
         assertThat(publishedChecks.get(0).getOutput()).isPresent().hasValueSatisfying(
                 output -> assertThat(output.getTitle()).contains("No new issues, 6 total"));
+    }
+
+    /**
+     * Verifies that publishIssues propagates a direct detailsURL override to the publisher.
+     */
+    @Test
+    void shouldPropagateDirectDetailsURLFromPublishIssues() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var customUrl = "http://direct-publish-url";
+        // We need to run a scan first so that there are results to publish
+        project.setDefinition(asStage(createScanForIssuesStep(new CheckStyle()), 
+                "publishIssues(issues: [issues], detailsURL: '" + customUrl + "')"));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+        assertThat(publishedChecks).hasSize(1);
+        assertThat(publishedChecks.get(0).getDetailsURL()).isEqualTo(Optional.of(customUrl));
+    }
+
+    /**
+     * Verifies that publishIssues uses the detailsURL from withChecks context when no direct override is provided.
+     */
+    @Test
+    void shouldUseContextDetailsURLWhenPublishIssuesHasNoOverride() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var contextUrl = "http://context-publish-url";
+        project.setDefinition(asStage("withChecks(name: 'Custom Name', detailsURL: '" + contextUrl + "') {",
+                createScanForIssuesStep(new CheckStyle()), 
+                "publishIssues(issues: [issues])", "}"));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+        // index 0 is 'In progress' from withChecks, index 1 is publishIssues
+        assertThat(publishedChecks).hasSize(2);
+        assertThat(publishedChecks.get(1).getDetailsURL()).isEqualTo(Optional.of(contextUrl));
+    }
+
+    /**
+     * Verifies that a direct override in publishIssues takes precedence over the withChecks context URL.
+     */
+    @Test
+    void shouldPreferDirectOverrideOverContextURLForPublishIssues() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var contextUrl = "http://context-publish-url";
+        var directUrl = "http://direct-publish-url";
+        project.setDefinition(asStage("withChecks(name: 'Custom Name', detailsURL: '" + contextUrl + "') {",
+                createScanForIssuesStep(new CheckStyle()), 
+                "publishIssues(issues: [issues], detailsURL: '" + directUrl + "')", "}"));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+        assertThat(publishedChecks).hasSize(2);
+        assertThat(publishedChecks.get(1).getDetailsURL()).isEqualTo(Optional.of(directUrl));
     }
 
     /**
@@ -374,6 +428,83 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
     }
 
     /**
+     * Verifies the priority chain for detailsURL resolution: Direct Override > Context (ChecksInfo) > System Default.
+     */
+    @Test
+    void shouldResolveDetailsURLWithCorrectPriority() {
+        var project = createFreeStyleProjectWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        enableCheckStyleWarnings(project);
+        Run<?, ?> run = buildSuccessfully(project);
+        var action = getResultAction(run);
+        var defaultUrl = action.getAbsoluteUrl();
+
+        // Case 1: System Default (No override, no context)
+        var publisherDefault = new WarningChecksPublisher(action, TaskListener.NULL, null, null);
+        assertThat(publisherDefault.extractChecksDetails(ChecksAnnotationScope.NEW).getDetailsURL())
+                .isEqualTo(Optional.of(defaultUrl));
+
+        // Case 2: Contextual Override (No direct override, context provided)
+        var checksInfo = new ChecksInfo("Custom Name", "http://context-url");
+        var publisherContext = new WarningChecksPublisher(action, TaskListener.NULL, checksInfo, null);
+        assertThat(publisherContext.extractChecksDetails(ChecksAnnotationScope.NEW).getDetailsURL())
+                .isEqualTo(Optional.of("http://context-url"));
+
+        // Case 3: Direct Override (Wins over context and default)
+        var publisherDirect = new WarningChecksPublisher(action, TaskListener.NULL, checksInfo, "http://direct-url");
+        assertThat(publisherDirect.extractChecksDetails(ChecksAnnotationScope.NEW).getDetailsURL())
+                .isEqualTo(Optional.of("http://direct-url"));
+    }
+
+    /**
+     * Verifies that recordIssues propagates a direct detailsURL override to the publisher.
+     */
+    @Test
+    void shouldPropagateDirectDetailsURLFromRecordIssues() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var customUrl = "http://direct-override-url";
+        project.setDefinition(asStage("recordIssues(tools: [checkStyle()], detailsURL: '" + customUrl + "')"));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+        assertThat(publishedChecks).hasSize(1);
+        assertThat(publishedChecks.get(0).getDetailsURL()).isEqualTo(Optional.of(customUrl));
+    }
+
+    /**
+     * Verifies that recordIssues uses the detailsURL from withChecks context when no direct override is provided.
+     */
+    @Test
+    void shouldUseContextDetailsURLWhenRecordIssuesHasNoOverride() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var customUrl = "http://context-override-url";
+        project.setDefinition(asStage("withChecks(name: 'Custom Name', detailsURL: '" + customUrl + "') {",
+                createRecordIssuesStep(new CheckStyle()), "}"));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+        // index 0 is 'In progress' from withChecks, index 1 is recordIssues
+        assertThat(publishedChecks).hasSize(2);
+        assertThat(publishedChecks.get(1).getDetailsURL()).isEqualTo(Optional.of(customUrl));
+    }
+
+    /**
+     * Verifies that a direct override in recordIssues takes precedence over the withChecks context URL.
+     */
+    @Test
+    void shouldPreferDirectOverrideOverContextURL() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var customUrl = "http://context-override-url";
+        var directUrl = "http://direct-override-url";
+        project.setDefinition(asStage("withChecks(name: 'Custom Name', detailsURL: '" + customUrl + "') {",
+                "recordIssues(tools: [checkStyle()], detailsURL: '" + directUrl + "')", "}"));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+        assertThat(publishedChecks).hasSize(2);
+        assertThat(publishedChecks.get(1).getDetailsURL()).isEqualTo(Optional.of(directUrl));
+    }
+
+    /**
      * Verifies that {@link WarningChecksPublisher} uses issue category when the type is not provided.
      */
     @Test
@@ -386,7 +517,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
         copySingleFileToWorkspace(project, "msbuild.log");
         Run<?, ?> run = buildSuccessfully(project);
 
-        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null);
+        var publisher = new WarningChecksPublisher(getResultAction(run), TaskListener.NULL, null, null);
         var details = publisher.extractChecksDetails(ChecksAnnotationScope.NEW);
 
         assertThat(details.getOutput().get().getChecksAnnotations().get(0))
@@ -481,7 +612,7 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
                 .hasTotalSize(6)
                 .hasQualityGateStatus(criticality.getStatus());
 
-        var publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL, null);
+        var publisher = new WarningChecksPublisher(getResultAction(build), TaskListener.NULL, null, null);
         assertThat(publisher.extractChecksDetails(ChecksAnnotationScope.NEW).getConclusion())
                 .isEqualTo(ChecksConclusion.FAILURE);
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This should make it possible to specify a detailsURL property to the recordIssues and publishIssues step functions.
When issues are published via the checks api - this details url is hard coded to point to the jenkins ui for the build in question.
in cases when jenkins isn't exposed to the public, this link causes a lot of confusion.

In particular if running jenkins against github repos, and jenkins isn't accessible to the public, these links are also not accessible. This aims to provide a way to provide a custom url that to change the link so the link points to to something that is publically available. 

I tried to include applicable tests to validate that the changes were in doing what I think / expect them to. making sure the defaults case still produces the expected url, and that providing an override is honored.

Resolves: #3352

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
