### PR TITLE
Add server-side validation for `linesLookAhead` fingerprinting parameter

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
@@ -319,9 +319,14 @@ public abstract class ReportScanningTool extends Tool {
          */
         @POST
         public FormValidation doCheckLinesLookAhead(@QueryParameter final int linesLookAhead) {
+            if (!JENKINS.hasPermission(Jenkins.READ)) {
+                return FormValidation.ok();
+            }
+
             if (linesLookAhead < 0) {
                 return FormValidation.error(Messages.ReportScanningTool_LinesLookAheadMustBeNonNegative());
             }
+
             return FormValidation.ok();
         }
 

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/model/ReportScanningTool.java
@@ -136,14 +136,15 @@ public abstract class ReportScanningTool extends Tool {
     }
 
     /**
-     * Sets the context lines which is used in the fingerprinting process.
+     * Sets the context lines which is used in the fingerprinting process. The value must be a non-negative integer.
+     * If a negative value is provided, it will be clamped to 0.
      *
      * @param linesLookAhead
-     *         the actual number of lines.
+     *         the actual number of lines (must be &gt;= 0)
      */
     @DataBoundSetter
     public void setLinesLookAhead(final int linesLookAhead) {
-        this.linesLookAhead = linesLookAhead;
+        this.linesLookAhead = Math.max(0, linesLookAhead);
     }
 
     public int getLinesLookAhead() {
@@ -305,6 +306,23 @@ public abstract class ReportScanningTool extends Tool {
             }
 
             return VALIDATION_UTILITIES.validateCharset(reportEncoding);
+        }
+
+        /**
+         * Performs on-the-fly validation of the context lines (linesLookAhead) used for fingerprinting.
+         * The value must be a non-negative integer.
+         *
+         * @param linesLookAhead
+         *         the number of context lines to validate
+         *
+         * @return the validation result
+         */
+        @POST
+        public FormValidation doCheckLinesLookAhead(@QueryParameter final int linesLookAhead) {
+            if (linesLookAhead < 0) {
+                return FormValidation.error(Messages.ReportScanningTool_LinesLookAheadMustBeNonNegative());
+            }
+            return FormValidation.ok();
         }
 
         /**

--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/Messages.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/core/model/Messages.properties
@@ -45,6 +45,7 @@ Summary.ShowDetails=Show info and error messages
 
 ConsoleLog.Name=Console Output
 ReportScanningTool.PatternIsEmptyAndConsoleParsingDisabled=A pattern must be specified. This parser is unable to parse the console output.
+ReportScanningTool.LinesLookAheadMustBeNonNegative=The number of context lines must be a non-negative integer (>= 0).
 
 Modified.Warnings.Header=Warnings in Modified Code
 Fixed.Warnings.Header=Fixed Warnings

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ReportScanningToolITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/model/ReportScanningToolITest.java
@@ -55,6 +55,54 @@ class ReportScanningToolITest extends IntegrationTestWithJenkinsPerSuite {
         assertThat(descriptor.doCheckPattern(null, givenPattern)).isOk();
     }
 
+    /** Tests that a negative linesLookAhead value is rejected with an error. */
+    @Test
+    void descriptorMethodDoCheckLinesLookAheadWhenCalledWithNegativeValueReturnsError() {
+        final var descriptor = new ReportScanningTool.ReportScanningToolDescriptor("someId");
+
+        assertThat(descriptor.doCheckLinesLookAhead(-1)).isError();
+    }
+
+    /** Tests that linesLookAhead value of zero is valid. */
+    @Test
+    void descriptorMethodDoCheckLinesLookAheadWhenCalledWithZeroReturnsOk() {
+        final var descriptor = new ReportScanningTool.ReportScanningToolDescriptor("someId");
+
+        assertThat(descriptor.doCheckLinesLookAhead(0)).isOk();
+    }
+
+    /** Tests that a positive linesLookAhead value is valid. */
+    @Test
+    void descriptorMethodDoCheckLinesLookAheadWhenCalledWithPositiveValueReturnsOk() {
+        final var descriptor = new ReportScanningTool.ReportScanningToolDescriptor("someId");
+
+        assertThat(descriptor.doCheckLinesLookAhead(3)).isOk();
+    }
+
+    /** Tests that setting a negative linesLookAhead on a tool clamps it to zero. */
+    @Test
+    void setLinesLookAheadClampsNegativeValueToZero() {
+        var tool = new ReportScanningToolStubForTesting(null);
+        tool.setLinesLookAhead(-5);
+        assertThat(tool.getLinesLookAhead()).isEqualTo(0);
+    }
+
+    /** Tests that setting a zero linesLookAhead is stored as-is. */
+    @Test
+    void setLinesLookAheadStoresZeroValue() {
+        var tool = new ReportScanningToolStubForTesting(null);
+        tool.setLinesLookAhead(0);
+        assertThat(tool.getLinesLookAhead()).isEqualTo(0);
+    }
+
+    /** Tests that setting a positive linesLookAhead is stored as-is. */
+    @Test
+    void setLinesLookAheadStoresPositiveValue() {
+        var tool = new ReportScanningToolStubForTesting(null);
+        tool.setLinesLookAhead(5);
+        assertThat(tool.getLinesLookAhead()).isEqualTo(5);
+    }
+
     private ReportScanningTool.ReportScanningToolDescriptor makeDescriptor(final boolean canScanConsoleLog, final String getPattern) {
         return new ReportScanningToolStubForTesting.ReportScanningToolDescriptorStubForTesting("someId",
                 canScanConsoleLog, getPattern);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Add server-side validation for `linesLookAhead` fingerprinting parameter

Originally this PR was opened to fix #2957 .

What this PR does:

- Adds server-side form validation (`doCheckLinesLookAhead`) to reject negative `linesLookAhead` values in the Jenkins UI
- Defensively clamps negative values to `0` in the setter to prevent silent misconfiguration from Pipeline/JCasC
- Adds tests for both the validation and the clamping behaviour
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
