### PR TITLE
Override job-dsl version not depending on commons-lang2

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -61,9 +61,9 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Remove once in bom;
-        job-dsl version coming from bom at this time is 1.93 - which still using commons-lang2
-        Below tests that use the job-dsl plugin are failing when running in Jenkins core that doesn't commons-lang2
+      <!-- Remove once this is updated in the BOM;
+        job-dsl version coming from the BOM at this time is 1.93, which still uses commons-lang2.
+        The tests below that use the job-dsl plugin are failing when running on Jenkins core that doesn't include commons-lang2
         io.jenkins.plugins.analysis.warnings.integrations.JobDslITest
           * shouldCreateFreestyleJobUsingJobDslAndVerifyIssueRecorderWithValuesSet
           * shouldCreateFreestyleJobUsingJobDslAndVerifyIssueRecorderWithDefaultConfiguration

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -59,6 +59,25 @@
     </argLine>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- Remove once in bom;
+        job-dsl version coming from bom at this time is 1.93 - which still using commons-lang2
+        Below tests that use the job-dsl plugin are failing when running in Jenkins core that doesn't commons-lang2
+        io.jenkins.plugins.analysis.warnings.integrations.JobDslITest
+          * shouldCreateFreestyleJobUsingJobDslAndVerifyIssueRecorderWithValuesSet
+          * shouldCreateFreestyleJobUsingJobDslAndVerifyIssueRecorderWithDefaultConfiguration
+        io.jenkins.plugins.analysis.warnings.integrations.JobDslITest
+          * shouldCreateColumnFromYamlConfiguration
+      -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>job-dsl</artifactId>
+        <version>3654.vdf58f53e2d15</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <!-- Project Library Dependencies -->


### PR DESCRIPTION
When running this PCT with this plugin on a Jenkins core that drops the commons-lang2 - to be done in https://github.com/jenkinsci/jenkins/pull/26105; noticed the tests mentioned in the comments were failing with `java.lang.NoClassDefFoundError: org/apache/commons/lang/ClassUtils` originating from job-dsl plugin calls.

The job-dsl plugin currently in use here is `1.93` via the bom - which still the same even in the current bom master branch.
Hence pinning the version here.

https://github.com/jenkinsci/job-dsl-plugin/pull/1604 migrated job-dsl from lang2 to lang3, released in https://github.com/jenkinsci/job-dsl-plugin/releases/tag/3654.vdf58f53e2d15

### Testing done

TBU after testing incremental version produced here against jenkins core without lang2

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed