### PR TITLE
Use properties of `ChecksInfo` context when available

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -109,6 +109,9 @@ class WarningChecksPublisher {
         var checksName = Optional.ofNullable(checksInfo).map(ChecksInfo::getName)
                 .filter(StringUtils::isNotEmpty)
                 .orElse(labelProvider.getName());
+        var detailsUrl = Optional.ofNullable(checksInfo).map(ChecksInfo::getDetailsURL)
+                .filter(StringUtils::isNotEmpty)
+                .orElse(action.getAbsoluteUrl());
 
         var summary = extractChecksSummary(totals) + "\n" + extractReferenceBuild(result);
         return new ChecksDetailsBuilder()
@@ -121,7 +124,7 @@ class WarningChecksPublisher {
                         .withText(extractChecksText(totals))
                         .withAnnotations(extractChecksAnnotations(filterIssuesForAnnotations(annotationScope, result), labelProvider))
                         .build())
-                .withDetailsURL(action.getAbsoluteUrl())
+                .withDetailsURL(detailsUrl)
                 .build();
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisherITest.java
@@ -50,6 +50,27 @@ class WarningChecksPublisherITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String NEW_CHECKSTYLE_REPORT = "checkstyle1.xml";
 
     /**
+     * Verifies that publishIssues uses the detailsURL from withChecks context when no direct override is provided.
+     */
+    @Test
+    void shouldUseContextDetailsURLWhenPublishIssuesHasNoOverride() {
+        var project = createPipelineWithWorkspaceFilesWithSuffix(NEW_CHECKSTYLE_REPORT);
+        var contextUrl = "http://context-publish-url";
+        var contextName = "Checks Name";
+        project.setDefinition(asStage("withChecks(name: '" + contextName
+                        + "', detailsURL: '" + contextUrl + "') {",
+                createScanForIssuesStep(new CheckStyle()),
+                "publishIssues(issues: [issues])", "}"));
+        buildSuccessfully(project);
+
+        List<ChecksDetails> publishedChecks = getPublishedChecks();
+        // index 0 is 'In progress' from withChecks, index 1 is publishIssues
+        assertThat(publishedChecks).hasSize(2);
+        assertThat(publishedChecks.get(1).getDetailsURL()).contains(contextUrl);
+        assertThat(publishedChecks.get(1).getName()).contains(contextName);
+    }
+
+    /**
      * Verifies that {@link WarningChecksPublisher} constructs the {@link ChecksDetails} correctly with only new
      * issues.
      */


### PR DESCRIPTION
GitHub checks can be wrapped into an optional `withChecks` block that contains a custom name and URL. In those cases the default values should be overwritten with the context object values.

Followup to https://github.com/jenkinsci/checks-api-plugin/pull/329

Supersedes #3354 