### PR TITLE
Fix environment variable handling of BROWSER for acceptance tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -33,7 +33,4 @@ jobs:
       - name: Build warnings plugin and download dependencies
         run: mvn -V --color always -ntp verify -Pskip --file plugin/pom.xml
       - name: Run UI tests ${{ matrix.test }} on ${{ matrix.browser }}
-        env:
-          BROWSER: ${{ matrix.browser }}
-          SKIP_UPDATES: 'true'
-        run: mvn -V --color always -ntp test --file ui-tests/pom.xml -Dtest=${{ matrix.test }} -Dquite -Dgpg.skip -Dsurefire.rerunFailingTestsCount=1
+        run: mvn -V --color always -ntp test --file ui-tests/pom.xml -Dbrowser=${{ matrix.browser }} -Dtest=${{ matrix.test }} -Dquite -Dgpg.skip -Dsurefire.rerunFailingTestsCount=1

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -21,7 +21,7 @@
     <json-smart.version>2.3</json-smart.version>
     <json-unit-assertj.version>6.2.0</json-unit-assertj.version>
     <module.name>${project.groupId}.warnings.ui.tests</module.name>
-    <browser>firefox-container</browser>
+    <browser>chrome</browser>
 
     <!-- Maven Surefire ArgLine -->
     <argLine>-Djava.awt.headless=true -Xmx1024m -Djenkins.test.timeout=1000 --add-opens java.base/sun.reflect.annotation=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED</argLine>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>acceptance-test-harness</artifactId>
-      <version>6717.v4d75df63dd10</version>
+      <version>6724.va_7c5c4b_fcf9c</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -266,7 +266,7 @@
                 <SKIP_UPDATES>true</SKIP_UPDATES>
               </environmentVariables>
               <properties>
-                <browser>firefox</browser>
+                <browser>chrome</browser>
               </properties>
               <rerunFailingTestsCount>1</rerunFailingTestsCount>
               <includes>

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -21,7 +21,7 @@
     <json-smart.version>2.3</json-smart.version>
     <json-unit-assertj.version>6.2.0</json-unit-assertj.version>
     <module.name>${project.groupId}.warnings.ui.tests</module.name>
-    <browser>chrome</browser>
+    <browser>chrome-container</browser>
 
     <!-- Maven Surefire ArgLine -->
     <argLine>-Djava.awt.headless=true -Xmx1024m -Djenkins.test.timeout=1000 --add-opens java.base/sun.reflect.annotation=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED</argLine>


### PR DESCRIPTION
Since the browser is configured via a property, the pipeline needs to pass the browser as Maven `-D` flag.