### PR TITLE
Do not report column start/end for whole line annotations

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -253,8 +253,11 @@ class WarningChecksPublisher {
                     .withRawDetails(StringUtils.normalizeSpace(labelProvider.getDescription(issue)));
 
             if (issue.getLineStart() == issue.getLineEnd()) {
-                builder.withStartColumn(issue.getColumnStart())
-                        .withEndColumn(issue.getColumnEnd());
+                // columns are 1-based and zero is for the whole line so skip start/end for whole line reports
+                if (issue.getColumnStart() != 0) {
+                    builder.withStartColumn(issue.getColumnStart())
+                           .withEndColumn(issue.getColumnEnd());
+                }
             }
 
             annotations.add(builder.build());

--- a/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/analysis/core/steps/WarningChecksPublisher.java
@@ -256,7 +256,7 @@ class WarningChecksPublisher {
                 // columns are 1-based and zero is for the whole line so skip start/end for whole line reports
                 if (issue.getColumnStart() != 0) {
                     builder.withStartColumn(issue.getColumnStart())
-                           .withEndColumn(issue.getColumnEnd());
+                            .withEndColumn(issue.getColumnEnd());
                 }
             }
 


### PR DESCRIPTION
When the start coulmn is 0 then the report is for the whole line. If we add zero here then a check reporter will take that value and add it and try and publish it.  This ultimately gets rejected and causes annotations to not be published

Fixes: #3424

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
